### PR TITLE
fix: remove duplicate Interoperability nav link and add to mobile menu

### DIFF
--- a/about.html
+++ b/about.html
@@ -38,7 +38,6 @@
       <span class="nav-sep" aria-hidden="true"></span>
       <a href="/specification.html">Spec</a>
       <a href="/developers.html">Developers</a>
-  <a href="/interoperability.html">Interoperability</a>
       <a href="/interoperability.html">Interoperability</a>
       <span class="nav-sep" aria-hidden="true"></span>
       <a href="/news.html">News</a>
@@ -80,6 +79,7 @@
   <a href="/for-payers.html">For Payers</a>
   <a href="/specification.html">Spec</a>
   <a href="/developers.html">Developers</a>
+  <a href="/interoperability.html">Interoperability</a>
   <a href="/news.html">News</a>
   <a href="/community.html">Community</a>
   <a href="/faq.html">FAQ</a>

--- a/community.html
+++ b/community.html
@@ -38,7 +38,6 @@
       <span class="nav-sep" aria-hidden="true"></span>
       <a href="/specification.html">Spec</a>
       <a href="/developers.html">Developers</a>
-  <a href="/interoperability.html">Interoperability</a>
       <a href="/interoperability.html">Interoperability</a>
       <span class="nav-sep" aria-hidden="true"></span>
       <a href="/news.html">News</a>
@@ -80,6 +79,7 @@
   <a href="/for-payers.html">For Payers</a>
   <a href="/specification.html">Spec</a>
   <a href="/developers.html">Developers</a>
+  <a href="/interoperability.html">Interoperability</a>
   <a href="/news.html">News</a>
   <a href="/community.html">Community</a>
   <a href="/faq.html">FAQ</a>

--- a/developers.html
+++ b/developers.html
@@ -38,7 +38,6 @@
       <span class="nav-sep" aria-hidden="true"></span>
       <a href="/specification.html">Spec</a>
       <a href="/developers.html">Developers</a>
-  <a href="/interoperability.html">Interoperability</a>
       <a href="/interoperability.html">Interoperability</a>
       <span class="nav-sep" aria-hidden="true"></span>
       <a href="/news.html">News</a>
@@ -80,6 +79,7 @@
   <a href="/for-payers.html">For Payers</a>
   <a href="/specification.html">Spec</a>
   <a href="/developers.html">Developers</a>
+  <a href="/interoperability.html">Interoperability</a>
   <a href="/news.html">News</a>
   <a href="/community.html">Community</a>
   <a href="/faq.html">FAQ</a>

--- a/faq.html
+++ b/faq.html
@@ -38,7 +38,6 @@
       <span class="nav-sep" aria-hidden="true"></span>
       <a href="/specification.html">Spec</a>
       <a href="/developers.html">Developers</a>
-  <a href="/interoperability.html">Interoperability</a>
       <a href="/interoperability.html">Interoperability</a>
       <span class="nav-sep" aria-hidden="true"></span>
       <a href="/news.html">News</a>
@@ -80,6 +79,7 @@
   <a href="/for-payers.html">For Payers</a>
   <a href="/specification.html">Spec</a>
   <a href="/developers.html">Developers</a>
+  <a href="/interoperability.html">Interoperability</a>
   <a href="/news.html">News</a>
   <a href="/community.html">Community</a>
   <a href="/faq.html">FAQ</a>

--- a/for-payers.html
+++ b/for-payers.html
@@ -89,7 +89,6 @@
       <span class="nav-sep" aria-hidden="true"></span>
       <a href="/specification.html">Spec</a>
       <a href="/developers.html">Developers</a>
-  <a href="/interoperability.html">Interoperability</a>
       <a href="/interoperability.html">Interoperability</a>
       <span class="nav-sep" aria-hidden="true"></span>
       <a href="/news.html">News</a>
@@ -131,6 +130,7 @@
   <a href="/for-payers.html">For Payers</a>
   <a href="/specification.html">Spec</a>
   <a href="/developers.html">Developers</a>
+  <a href="/interoperability.html">Interoperability</a>
   <a href="/news.html">News</a>
   <a href="/community.html">Community</a>
   <a href="/faq.html">FAQ</a>

--- a/implementation-review.html
+++ b/implementation-review.html
@@ -38,7 +38,6 @@
       <span class="nav-sep" aria-hidden="true"></span>
       <a href="/specification.html">Spec</a>
       <a href="/developers.html">Developers</a>
-  <a href="/interoperability.html">Interoperability</a>
       <a href="/interoperability.html">Interoperability</a>
       <span class="nav-sep" aria-hidden="true"></span>
       <a href="/news.html">News</a>
@@ -80,6 +79,7 @@
   <a href="/for-payers.html">For Payers</a>
   <a href="/specification.html">Spec</a>
   <a href="/developers.html">Developers</a>
+  <a href="/interoperability.html">Interoperability</a>
   <a href="/news.html">News</a>
   <a href="/community.html">Community</a>
   <a href="/faq.html">FAQ</a>

--- a/index.html
+++ b/index.html
@@ -38,7 +38,6 @@
       <span class="nav-sep" aria-hidden="true"></span>
       <a href="/specification.html">Spec</a>
       <a href="/developers.html">Developers</a>
-  <a href="/interoperability.html">Interoperability</a>
       <a href="/interoperability.html">Interoperability</a>
       <span class="nav-sep" aria-hidden="true"></span>
       <a href="/news.html">News</a>
@@ -80,6 +79,7 @@
   <a href="/for-payers.html">For Payers</a>
   <a href="/specification.html">Spec</a>
   <a href="/developers.html">Developers</a>
+  <a href="/interoperability.html">Interoperability</a>
   <a href="/news.html">News</a>
   <a href="/community.html">Community</a>
   <a href="/faq.html">FAQ</a>

--- a/interoperability.html
+++ b/interoperability.html
@@ -37,7 +37,6 @@
       <span class="nav-sep" aria-hidden="true"></span>
       <a href="/specification.html">Spec</a>
       <a href="/developers.html">Developers</a>
-  <a href="/interoperability.html">Interoperability</a>
       <a href="/interoperability.html">Interoperability</a>
       <span class="nav-sep" aria-hidden="true"></span>
       <a href="/news.html">News</a>
@@ -79,6 +78,7 @@
   <a href="/for-payers.html">For Payers</a>
   <a href="/specification.html">Spec</a>
   <a href="/developers.html">Developers</a>
+  <a href="/interoperability.html">Interoperability</a>
   <a href="/news.html">News</a>
   <a href="/community.html">Community</a>
   <a href="/faq.html">FAQ</a>

--- a/news.html
+++ b/news.html
@@ -38,7 +38,6 @@
       <span class="nav-sep" aria-hidden="true"></span>
       <a href="/specification.html">Spec</a>
       <a href="/developers.html">Developers</a>
-  <a href="/interoperability.html">Interoperability</a>
       <a href="/interoperability.html">Interoperability</a>
       <span class="nav-sep" aria-hidden="true"></span>
       <a href="/news.html">News</a>
@@ -80,6 +79,7 @@
   <a href="/for-payers.html">For Payers</a>
   <a href="/specification.html">Spec</a>
   <a href="/developers.html">Developers</a>
+  <a href="/interoperability.html">Interoperability</a>
   <a href="/news.html">News</a>
   <a href="/community.html">Community</a>
   <a href="/faq.html">FAQ</a>

--- a/proof.html
+++ b/proof.html
@@ -38,7 +38,6 @@
       <span class="nav-sep" aria-hidden="true"></span>
       <a href="/specification.html">Spec</a>
       <a href="/developers.html">Developers</a>
-  <a href="/interoperability.html">Interoperability</a>
       <a href="/interoperability.html">Interoperability</a>
       <span class="nav-sep" aria-hidden="true"></span>
       <a href="/news.html">News</a>
@@ -80,6 +79,7 @@
   <a href="/for-payers.html">For Payers</a>
   <a href="/specification.html">Spec</a>
   <a href="/developers.html">Developers</a>
+  <a href="/interoperability.html">Interoperability</a>
   <a href="/news.html">News</a>
   <a href="/community.html">Community</a>
   <a href="/faq.html">FAQ</a>

--- a/roadmap.html
+++ b/roadmap.html
@@ -37,7 +37,6 @@
       <span class="nav-sep" aria-hidden="true"></span>
       <a href="/specification.html">Spec</a>
       <a href="/developers.html">Developers</a>
-  <a href="/interoperability.html">Interoperability</a>
       <a href="/interoperability.html">Interoperability</a>
       <span class="nav-sep" aria-hidden="true"></span>
       <a href="/news.html">News</a>
@@ -79,6 +78,7 @@
   <a href="/for-payers.html">For Payers</a>
   <a href="/specification.html">Spec</a>
   <a href="/developers.html">Developers</a>
+  <a href="/interoperability.html">Interoperability</a>
   <a href="/news.html">News</a>
   <a href="/community.html">Community</a>
   <a href="/faq.html">FAQ</a>

--- a/script-examples.html
+++ b/script-examples.html
@@ -38,7 +38,6 @@
       <span class="nav-sep" aria-hidden="true"></span>
       <a href="/specification.html">Spec</a>
       <a href="/developers.html">Developers</a>
-  <a href="/interoperability.html">Interoperability</a>
       <a href="/interoperability.html">Interoperability</a>
       <span class="nav-sep" aria-hidden="true"></span>
       <a href="/news.html">News</a>
@@ -80,6 +79,7 @@
   <a href="/for-payers.html">For Payers</a>
   <a href="/specification.html">Spec</a>
   <a href="/developers.html">Developers</a>
+  <a href="/interoperability.html">Interoperability</a>
   <a href="/news.html">News</a>
   <a href="/community.html">Community</a>
   <a href="/faq.html">FAQ</a>

--- a/simulator.html
+++ b/simulator.html
@@ -149,7 +149,6 @@
       <span class="nav-sep" aria-hidden="true"></span>
       <a href="/specification.html">Spec</a>
       <a href="/developers.html">Developers</a>
-  <a href="/interoperability.html">Interoperability</a>
       <a href="/interoperability.html">Interoperability</a>
       <span class="nav-sep" aria-hidden="true"></span>
       <a href="/news.html">News</a>
@@ -191,6 +190,7 @@
   <a href="/for-payers.html">For Payers</a>
   <a href="/specification.html">Spec</a>
   <a href="/developers.html">Developers</a>
+  <a href="/interoperability.html">Interoperability</a>
   <a href="/news.html">News</a>
   <a href="/community.html">Community</a>
   <a href="/faq.html">FAQ</a>

--- a/specification.html
+++ b/specification.html
@@ -38,7 +38,6 @@
       <span class="nav-sep" aria-hidden="true"></span>
       <a href="/specification.html">Spec</a>
       <a href="/developers.html">Developers</a>
-  <a href="/interoperability.html">Interoperability</a>
       <a href="/interoperability.html">Interoperability</a>
       <span class="nav-sep" aria-hidden="true"></span>
       <a href="/news.html">News</a>
@@ -80,6 +79,7 @@
   <a href="/for-payers.html">For Payers</a>
   <a href="/specification.html">Spec</a>
   <a href="/developers.html">Developers</a>
+  <a href="/interoperability.html">Interoperability</a>
   <a href="/news.html">News</a>
   <a href="/community.html">Community</a>
   <a href="/faq.html">FAQ</a>


### PR DESCRIPTION
The previous nav injection left a mis-indented duplicate Interoperability link in the desktop nav on all 14 pages, and omitted it from the mobile hamburger menu entirely. This removes the duplicate and adds the link to both desktop (correct indent) and mobile nav across all pages.

https://claude.ai/code/session_01WoVW6Wzm6M2T5P28qJq7ay