### PR TITLE
fix: add CORS headers to Lambda responses (simulator "Offline" fix)

### DIFF
--- a/functions/handler.py
+++ b/functions/handler.py
@@ -69,10 +69,17 @@ def lambda_handler(event: dict, context) -> dict:
     })
 
 
+_CORS = {
+    "Access-Control-Allow-Origin": "*",
+    "Access-Control-Allow-Headers": "Content-Type,x-api-key",
+    "Access-Control-Allow-Methods": "POST,GET,OPTIONS",
+}
+
+
 def _ok(body: dict) -> dict:
     return {
         "statusCode": 200,
-        "headers": {"Content-Type": "application/json"},
+        "headers": {"Content-Type": "application/json", **_CORS},
         "body": json.dumps(body),
     }
 
@@ -80,6 +87,6 @@ def _ok(body: dict) -> dict:
 def _error(status_code: int, message: str) -> dict:
     return {
         "statusCode": status_code,
-        "headers": {"Content-Type": "application/json"},
+        "headers": {"Content-Type": "application/json", **_CORS},
         "body": json.dumps({"error": message}),
     }


### PR DESCRIPTION
## Problem

The simulator was showing "Offline" even after the Lambda was successfully deployed. `curl` worked fine, but browser `fetch()` failed silently.

Root cause: SAM's `Cors:` setting on `AWS::Serverless::Api` only adds CORS headers to the mock OPTIONS preflight response — **not** to the actual POST/GET Lambda responses. Browsers require `Access-Control-Allow-Origin: *` on the real response too, not just the preflight. Without it, the browser blocks the response after a successful preflight, causing the fetch to reject.

## Fix

Added a `_CORS` dict to `functions/handler.py` with the three standard CORS headers, spread into every `_ok()` and `_error()` response:

```python
_CORS = {
    "Access-Control-Allow-Origin": "*",
    "Access-Control-Allow-Headers": "Content-Type,x-api-key",
    "Access-Control-Allow-Methods": "POST,GET,OPTIONS",
}
```

## After merging

Redeploy from CloudShell:
```bash
cd NHID-Clinical && git pull && make deploy REGION=us-east-2
```

Then the simulator at nhid-clinical.org/simulator.html should show **"Live API"** instead of "Offline".

## Test plan

- [ ] `curl -v ... /v1/demo/check` response headers include `Access-Control-Allow-Origin: *`
- [ ] Browser simulator shows "Live API" after redeploy
- [ ] `/v1/conformance/check` with API key still works

https://claude.ai/code/session_01XorMR2iJBdCQ4EqjkS4jao

---
_Generated by [Claude Code](https://claude.ai/code/session_01XorMR2iJBdCQ4EqjkS4jao)_