### PR TITLE
Remove Beacon outbound call feature; add Plausible Analytics

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,23 +1,10 @@
 STACK_NAME ?= nhid-clinical-api
 REGION     ?= us-east-1
 PROFILE    ?=
-ELEVENLABS_API_KEY         ?=
-ELEVENLABS_PHONE_NUMBER_ID ?=
 
 AWS_ARGS := --region $(REGION)
 ifdef PROFILE
   AWS_ARGS += --profile $(PROFILE)
-endif
-
-PARAM_OVERRIDES :=
-ifneq ($(ELEVENLABS_API_KEY),)
-  PARAM_OVERRIDES += ElevenLabsApiKey=$(ELEVENLABS_API_KEY)
-endif
-ifneq ($(ELEVENLABS_PHONE_NUMBER_ID),)
-  PARAM_OVERRIDES += ElevenLabsPhoneNumberId=$(ELEVENLABS_PHONE_NUMBER_ID)
-endif
-ifneq ($(PARAM_OVERRIDES),)
-  DEPLOY_PARAMS := --parameter-overrides $(PARAM_OVERRIDES)
 endif
 
 .PHONY: build deploy destroy get-key get-url test-api logs help
@@ -32,8 +19,7 @@ help:
 	@echo "  logs        tail Lambda CloudWatch logs"
 	@echo "  destroy     delete the CloudFormation stack"
 	@echo ""
-	@echo "Overrides:  STACK_NAME, REGION, PROFILE,"
-	@echo "            ELEVENLABS_API_KEY, ELEVENLABS_PHONE_NUMBER_ID (for /v1/demo/call)"
+	@echo "Overrides:  STACK_NAME, REGION, PROFILE"
 
 build:
 	sam build $(AWS_ARGS)
@@ -43,7 +29,6 @@ deploy: build
 		--stack-name $(STACK_NAME) \
 		--capabilities CAPABILITY_IAM \
 		--resolve-s3 \
-		$(DEPLOY_PARAMS) \
 		$(AWS_ARGS)
 
 get-key:

--- a/about.html
+++ b/about.html
@@ -11,6 +11,7 @@
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=IBM+Plex+Mono:wght@400;500&display=swap" rel="stylesheet"/>
   <link rel="stylesheet" href="/nhid-clinical-ui.css"/>
   <script>try{document.documentElement.setAttribute('data-theme',localStorage.getItem('nhid-theme')||'light')}catch(e){}</script>
+  <script defer data-domain="nhid-clinical.org" src="https://plausible.io/js/script.js"></script>
 </head>
 <body>
 

--- a/community.html
+++ b/community.html
@@ -11,6 +11,7 @@
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=IBM+Plex+Mono:wght@400;500&display=swap" rel="stylesheet"/>
   <link rel="stylesheet" href="/nhid-clinical-ui.css"/>
   <script>try{document.documentElement.setAttribute('data-theme',localStorage.getItem('nhid-theme')||'light')}catch(e){}</script>
+  <script defer data-domain="nhid-clinical.org" src="https://plausible.io/js/script.js"></script>
 </head>
 <body>
 

--- a/conformance.html
+++ b/conformance.html
@@ -4,6 +4,7 @@
   <meta http-equiv="refresh" content="0; url=/specification.html">
   <link rel="canonical" href="https://nhid-clinical.org/specification.html">
   <title>Redirecting...</title>
+  <script defer data-domain="nhid-clinical.org" src="https://plausible.io/js/script.js"></script>
 </head>
 <body>
   <script>window.location.replace("/specification.html");</script>

--- a/developers.html
+++ b/developers.html
@@ -11,6 +11,7 @@
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=IBM+Plex+Mono:wght@400;500&display=swap" rel="stylesheet"/>
   <link rel="stylesheet" href="/nhid-clinical-ui.css"/>
   <script>try{document.documentElement.setAttribute('data-theme',localStorage.getItem('nhid-theme')||'light')}catch(e){}</script>
+  <script defer data-domain="nhid-clinical.org" src="https://plausible.io/js/script.js"></script>
 </head>
 <body>
 

--- a/docs.html
+++ b/docs.html
@@ -20,6 +20,7 @@
     .quick-btn:hover { background: #0052CC; color: white; }
     #swagger-ui { max-width: 1200px; margin: 0 auto; padding: 1rem; }
   </style>
+  <script defer data-domain="nhid-clinical.org" src="https://plausible.io/js/script.js"></script>
 </head>
 <body>
 

--- a/evidence-pack.html
+++ b/evidence-pack.html
@@ -11,6 +11,7 @@
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=IBM+Plex+Mono:wght@400;500&display=swap" rel="stylesheet"/>
   <link rel="stylesheet" href="/nhid-clinical-ui.css"/>
   <script>try{document.documentElement.setAttribute('data-theme',localStorage.getItem('nhid-theme')||'light')}catch(e){}</script>
+  <script defer data-domain="nhid-clinical.org" src="https://plausible.io/js/script.js"></script>
 </head>
 <body>
 

--- a/faq.html
+++ b/faq.html
@@ -11,6 +11,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=IBM+Plex+Mono:wght@400;500&display=swap" rel="stylesheet"/>
   <link rel="stylesheet" href="/nhid-clinical-ui.css"/>
+  <script defer data-domain="nhid-clinical.org" src="https://plausible.io/js/script.js"></script>
 </head>
 <body>
 

--- a/for-payers.html
+++ b/for-payers.html
@@ -63,6 +63,7 @@
       color: var(--body);
     }
   </style>
+  <script defer data-domain="nhid-clinical.org" src="https://plausible.io/js/script.js"></script>
 </head>
 <body>
 

--- a/functions/handler.py
+++ b/functions/handler.py
@@ -1,10 +1,7 @@
 """Lambda handler for the NHID Clinical conformance check API."""
 import json
 import os
-import re
 import sys
-import urllib.error
-import urllib.request
 
 # When SAM packages with CodeUri: ., the repo root is /var/task.
 # This insert ensures `src` and `adapters` are importable whether running locally or in Lambda.
@@ -57,10 +54,6 @@ def lambda_handler(event: dict, context) -> dict:
     if "/cts/evaluate" in path:
         return _handle_cts_evaluate(event)
 
-    # Outbound call demo route
-    if "/demo/call" in path:
-        return _handle_demo_call(event)
-
     # Turn-by-turn call-progress webhook (no DB writes, stateless)
     if "/webhooks/call-progress" in path:
         return _handle_call_progress(event)
@@ -99,62 +92,6 @@ def lambda_handler(event: dict, context) -> dict:
         return _error(500, f"Policy evaluation failed: {exc}")
 
     return _ok(_decision_to_dict(decision, policy_event))
-
-
-_BEACON_AGENT_ID = "agent_4001krn32nmwe5t8mqzgee0w84rj"
-
-
-def _handle_demo_call(event: dict) -> dict:
-    """Trigger an outbound ElevenLabs call to the provided phone number."""
-    raw_body = event.get("body") or ""
-    if not raw_body:
-        return _error(400, "Request body is required")
-
-    try:
-        body = json.loads(raw_body) if isinstance(raw_body, str) else raw_body
-    except json.JSONDecodeError as exc:
-        return _error(400, f"Invalid JSON: {exc}")
-
-    phone = str(body.get("phone", "")).strip()
-    if not phone:
-        return _error(400, "Missing required field: 'phone'")
-
-    digits = re.sub(r"\D", "", phone)
-    if not digits.startswith("1"):
-        digits = "1" + digits
-    if len(digits) != 11:
-        return _error(400, "Phone number must be a valid US number in E.164 format")
-    e164 = "+" + digits
-
-    api_key = os.environ.get("ELEVENLABS_API_KEY", "")
-    phone_number_id = os.environ.get("ELEVENLABS_PHONE_NUMBER_ID", "")
-    if not api_key or not phone_number_id:
-        return _error(503, "Outbound call service not configured")
-
-    url = f"https://api.elevenlabs.io/v1/convai/phone-numbers/{phone_number_id}/outbound-call"
-    payload = json.dumps({
-        "agent_id": _BEACON_AGENT_ID,
-        "to_number": e164,
-    }).encode()
-
-    req = urllib.request.Request(
-        url,
-        data=payload,
-        headers={"xi-api-key": api_key, "Content-Type": "application/json"},
-        method="POST",
-    )
-    try:
-        with urllib.request.urlopen(req, timeout=10) as resp:
-            resp_body = json.loads(resp.read())
-            return _ok({
-                "status": "dialing",
-                "call_id": resp_body.get("call_id", resp_body.get("conversation_id", "")),
-            })
-    except urllib.error.HTTPError as exc:
-        err_text = exc.read().decode("utf-8", errors="replace")
-        return _error(exc.code, f"ElevenLabs API error: {err_text}")
-    except Exception as exc:  # noqa: BLE001
-        return _error(500, f"Outbound call failed: {exc}")
 
 
 def _handle_vendor(event: dict, vendor: str) -> dict:

--- a/gov-sim.html
+++ b/gov-sim.html
@@ -307,6 +307,7 @@ body::before{
   .lg{grid-template-columns:1fr}
 }
 </style>
+  <script defer data-domain="nhid-clinical.org" src="https://plausible.io/js/script.js"></script>
 </head>
 <body>
 

--- a/governance-simulator.html
+++ b/governance-simulator.html
@@ -4,6 +4,7 @@
   <meta http-equiv="refresh" content="0; url=/simulator.html">
   <link rel="canonical" href="https://nhid-clinical.org/simulator.html">
   <title>Redirecting…</title>
+  <script defer data-domain="nhid-clinical.org" src="https://plausible.io/js/script.js"></script>
 </head>
 <body>
   <script>window.location.replace("/simulator.html");</script>

--- a/implementation-review.html
+++ b/implementation-review.html
@@ -11,6 +11,7 @@
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=IBM+Plex+Mono:wght@400;500&display=swap" rel="stylesheet"/>
   <link rel="stylesheet" href="/nhid-clinical-ui.css"/>
   <script>try{document.documentElement.setAttribute('data-theme',localStorage.getItem('nhid-theme')||'light')}catch(e){}</script>
+  <script defer data-domain="nhid-clinical.org" src="https://plausible.io/js/script.js"></script>
 </head>
 <body>
 

--- a/index.html
+++ b/index.html
@@ -11,6 +11,7 @@
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=IBM+Plex+Mono:wght@400;500&display=swap" rel="stylesheet"/>
   <link rel="stylesheet" href="/nhid-clinical-ui.css"/>
   <script>try{document.documentElement.setAttribute('data-theme',localStorage.getItem('nhid-theme')||'light')}catch(e){}</script>
+  <script defer data-domain="nhid-clinical.org" src="https://plausible.io/js/script.js"></script>
 </head>
 <body>
 
@@ -136,56 +137,8 @@
         </div>
         <p class="hero-body" style="margin-top:1rem;font-size:.9rem;color:var(--ink-soft)">CC BY 4.0 &nbsp;·&nbsp; NIST Public Comment: NIST-2025-0035-0026</p>
         <div class="hero-actions" style="flex-wrap:wrap;gap:.75rem">
-          <div class="call-demo-form">
-            <input type="tel" id="demo-phone" placeholder="+1 (555) 000-0000" autocomplete="tel" aria-label="Your phone number" />
-            <button class="cta-button" id="demo-call-btn" type="button">Receive a Call from Beacon</button>
-          </div>
           <a class="secondary-button" href="/simulator.html">Governance Simulator <span aria-hidden="true">→</span></a>
         </div>
-        <div id="call-status" hidden aria-live="polite"></div>
-        <script>
-        (function () {
-          var btn = document.getElementById('demo-call-btn');
-          var inp = document.getElementById('demo-phone');
-          var status = document.getElementById('call-status');
-          if (!btn || !inp || !status) return;
-
-          function setStatus(msg, ok) {
-            status.textContent = msg;
-            status.hidden = false;
-            status.style.color = ok === false ? 'var(--red, #c0392b)' : 'var(--teal)';
-          }
-
-          btn.addEventListener('click', function () {
-            var raw = inp.value.replace(/\D/g, '');
-            if (!raw.startsWith('1')) raw = '1' + raw;
-            if (raw.length !== 11) {
-              setStatus('Please enter a valid US phone number.', false);
-              return;
-            }
-            var e164 = '+' + raw;
-            btn.disabled = true;
-            setStatus('Dialing…');
-            fetch('https://dc2ipcqs7k.execute-api.us-east-2.amazonaws.com/prod/v1/demo/call', {
-              method: 'POST',
-              headers: { 'Content-Type': 'application/json' },
-              body: JSON.stringify({ phone: e164 })
-            })
-            .then(function (r) { return r.json(); })
-            .then(function (d) {
-              if (d.status === 'dialing') {
-                setStatus('Beacon is calling you now. Expect disclosure within the first sentence.');
-              } else {
-                setStatus('Could not initiate call: ' + (d.error || 'unknown error'), false);
-              }
-            })
-            .catch(function () {
-              setStatus('Network error — please try again.', false);
-            })
-            .finally(function () { btn.disabled = false; });
-          });
-        })();
-        </script>
       </div>
       <div class="hero-art" aria-label="NHID-Clinical logo">
         <img class="theme-img theme-img-light" src="/assets/logo-light.jpg" alt="NHID-Clinical" />

--- a/interoperability.html
+++ b/interoperability.html
@@ -11,6 +11,7 @@
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=IBM+Plex+Mono:wght@400;500&display=swap" rel="stylesheet"/>
   <link rel="stylesheet" href="/nhid-clinical-ui.css"/>
   <script>try{document.documentElement.setAttribute('data-theme',localStorage.getItem('nhid-theme')||'light')}catch(e){}</script>
+  <script defer data-domain="nhid-clinical.org" src="https://plausible.io/js/script.js"></script>
 </head>
 <body>
 

--- a/news.html
+++ b/news.html
@@ -11,6 +11,7 @@
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=IBM+Plex+Mono:wght@400;500&display=swap" rel="stylesheet"/>
   <link rel="stylesheet" href="/nhid-clinical-ui.css"/>
   <script>try{document.documentElement.setAttribute('data-theme',localStorage.getItem('nhid-theme')||'light')}catch(e){}</script>
+  <script defer data-domain="nhid-clinical.org" src="https://plausible.io/js/script.js"></script>
 </head>
 <body>
 

--- a/pilot.html
+++ b/pilot.html
@@ -4,6 +4,7 @@
   <meta http-equiv="refresh" content="0; url=/shadow-evaluation-guide.html">
   <link rel="canonical" href="https://nhid-clinical.org/shadow-evaluation-guide.html">
   <title>Redirecting…</title>
+  <script defer data-domain="nhid-clinical.org" src="https://plausible.io/js/script.js"></script>
 </head>
 <body>
   <script>window.location.replace("/shadow-evaluation-guide.html");</script>

--- a/pricing.html
+++ b/pricing.html
@@ -28,6 +28,7 @@
     .pilot-banner p { color: #444; margin-bottom: 1.5rem; }
     .pilot-banner a { background: #0052CC; color: white; padding: 0.75rem 2rem; border-radius: 6px; text-decoration: none; font-weight: 600; }
   </style>
+  <script defer data-domain="nhid-clinical.org" src="https://plausible.io/js/script.js"></script>
 </head>
 <body>
 <nav class="site-nav">

--- a/proof.html
+++ b/proof.html
@@ -11,6 +11,7 @@
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=IBM+Plex+Mono:wght@400;500&display=swap" rel="stylesheet"/>
   <link rel="stylesheet" href="/nhid-clinical-ui.css"/>
   <script>try{document.documentElement.setAttribute('data-theme',localStorage.getItem('nhid-theme')||'light')}catch(e){}</script>
+  <script defer data-domain="nhid-clinical.org" src="https://plausible.io/js/script.js"></script>
 </head>
 <body>
 

--- a/regulatory-alignment.html
+++ b/regulatory-alignment.html
@@ -11,6 +11,7 @@
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=IBM+Plex+Mono:wght@400;500&display=swap" rel="stylesheet"/>
   <link rel="stylesheet" href="/nhid-clinical-ui.css"/>
   <script>try{document.documentElement.setAttribute('data-theme',localStorage.getItem('nhid-theme')||'light')}catch(e){}</script>
+  <script defer data-domain="nhid-clinical.org" src="https://plausible.io/js/script.js"></script>
 </head>
 <body>
 

--- a/roadmap.html
+++ b/roadmap.html
@@ -11,6 +11,7 @@
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=IBM+Plex+Mono:wght@400;500&display=swap" rel="stylesheet"/>
   <link rel="stylesheet" href="/nhid-clinical-ui.css"/>
   <script>try{document.documentElement.setAttribute('data-theme',localStorage.getItem('nhid-theme')||'light')}catch(e){}</script>
+  <script defer data-domain="nhid-clinical.org" src="https://plausible.io/js/script.js"></script>
 </head>
 <body>
 

--- a/script-examples.html
+++ b/script-examples.html
@@ -11,6 +11,7 @@
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=IBM+Plex+Mono:wght@400;500&display=swap" rel="stylesheet"/>
   <link rel="stylesheet" href="/nhid-clinical-ui.css"/>
   <script>try{document.documentElement.setAttribute('data-theme',localStorage.getItem('nhid-theme')||'light')}catch(e){}</script>
+  <script defer data-domain="nhid-clinical.org" src="https://plausible.io/js/script.js"></script>
 </head>
 <body>
 

--- a/shadow-evaluation-guide.html
+++ b/shadow-evaluation-guide.html
@@ -62,6 +62,7 @@
       white-space: nowrap;
     }
   </style>
+  <script defer data-domain="nhid-clinical.org" src="https://plausible.io/js/script.js"></script>
 </head>
 <body>
 

--- a/simulator.html
+++ b/simulator.html
@@ -286,6 +286,7 @@
   .sim-lg  { grid-template-columns: 1fr; }
 }
   </style>
+  <script defer data-domain="nhid-clinical.org" src="https://plausible.io/js/script.js"></script>
 </head>
 <body>
 

--- a/specification.html
+++ b/specification.html
@@ -14,6 +14,7 @@
   <!-- Mermaid CDN -->
   <script src="https://cdn.jsdelivr.net/npm/mermaid@10/dist/mermaid.min.js"></script>
   <script>mermaid.initialize({ startOnLoad: true, theme: 'default' });</script>
+  <script defer data-domain="nhid-clinical.org" src="https://plausible.io/js/script.js"></script>
 </head>
 <body>
 

--- a/specs/index.html
+++ b/specs/index.html
@@ -11,6 +11,7 @@
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=IBM+Plex+Mono:wght@400;500&display=swap" rel="stylesheet"/>
   <link rel="stylesheet" href="/nhid-clinical-ui.css"/>
   <script>try{document.documentElement.setAttribute('data-theme',localStorage.getItem('nhid-theme')||'light')}catch(e){}</script>
+  <script defer data-domain="nhid-clinical.org" src="https://plausible.io/js/script.js"></script>
 </head>
 <body>
 

--- a/technical-stack.html
+++ b/technical-stack.html
@@ -11,6 +11,7 @@
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=IBM+Plex+Mono:wght@400;500&display=swap" rel="stylesheet"/>
   <link rel="stylesheet" href="/nhid-clinical-ui.css"/>
   <script>try{document.documentElement.setAttribute('data-theme',localStorage.getItem('nhid-theme')||'light')}catch(e){}</script>
+  <script defer data-domain="nhid-clinical.org" src="https://plausible.io/js/script.js"></script>
 </head>
 <body>
 

--- a/template.yaml
+++ b/template.yaml
@@ -2,17 +2,6 @@ AWSTemplateFormatVersion: '2010-09-09'
 Transform: AWS::Serverless-2016-10-31
 Description: NHID Clinical Policy Engine - Hosted Conformance API
 
-Parameters:
-  ElevenLabsApiKey:
-    Type: String
-    Default: ""
-    NoEcho: true
-    Description: ElevenLabs API key for Beacon outbound call triggering
-  ElevenLabsPhoneNumberId:
-    Type: String
-    Default: ""
-    Description: ElevenLabs provisioned phone number ID for Beacon outbound calls
-
 Globals:
   Function:
     Timeout: 30
@@ -32,10 +21,6 @@ Resources:
       Description: NHID Clinical policy engine conformance checker
       Policies:
         - AWSLambdaBasicExecutionRole
-      Environment:
-        Variables:
-          ELEVENLABS_API_KEY: !Ref ElevenLabsApiKey
-          ELEVENLABS_PHONE_NUMBER_ID: !Ref ElevenLabsPhoneNumberId
       Events:
         ConformancePost:
           Type: Api
@@ -80,12 +65,6 @@ Resources:
           Properties:
             RestApiId: !Ref NHIDApi
             Path: /v1/adapters/connect/check
-            Method: POST
-        DemoCallPost:
-          Type: Api
-          Properties:
-            RestApiId: !Ref NHIDApi
-            Path: /v1/demo/call
             Method: POST
         CallProgressPost:
           Type: Api

--- a/vendor/dashboard.html
+++ b/vendor/dashboard.html
@@ -29,6 +29,7 @@
   .error { background:#fff1f0; border:1px solid var(--red); color:var(--red); border-radius:8px; padding:.75rem 1rem; margin-bottom:1rem; display:none; }
   footer { color:var(--grey); font-size:.78rem; margin-top:2rem; }
 </style>
+  <script defer data-domain="nhid-clinical.org" src="https://plausible.io/js/script.js"></script>
 </head>
 <body>
 <div class="container">


### PR DESCRIPTION
## Summary
- Strips the Beacon/ElevenLabs outbound call demo feature entirely: `_handle_demo_call`, `_BEACON_AGENT_ID`, `/demo/call` routing, and unused imports from `functions/handler.py`; the `ElevenLabsApiKey`/`ElevenLabsPhoneNumberId` SAM parameters, env vars, and `DemoCallPost` event from `template.yaml`; the call-demo form/script from `index.html`; and the ElevenLabs override plumbing from `Makefile`.
- Adds Plausible Analytics (privacy-friendly, cookie-free) to all 26 live public HTML pages via a single deferred script tag pointed at `nhid-clinical.org`.

This branch had been force-pushed by a collaborator, which reset it to match `main` and wiped these two changes along with an unrelated SAM routing fix. Per owner confirmation, the routing fix was judged moot now and not reapplied; these two changes were reapplied cleanly on top of the current trunk.

## Test plan
- [x] `python3 -m pytest tests/ -q` → 270 passed, 18 skipped
- [x] `python3 scripts/validate_ci.py` → CI PASS: 270 passed
- [x] Diffed the Beacon-removal changes against the original commit to confirm exact scope match
- [ ] Visually confirm `index.html` hero renders correctly with only the Governance Simulator button

https://claude.ai/code/session_01XorMR2iJBdCQ4EqjkS4jao

---
_Generated by [Claude Code](https://claude.ai/code/session_01XorMR2iJBdCQ4EqjkS4jao)_