### PR TITLE
Fix mobile nav menu + control-list consistency across site and PDFs

### DIFF
--- a/faq.html
+++ b/faq.html
@@ -176,7 +176,7 @@
         <div class="faq-item">
           <h3>Why are NPIs a security risk in voice calls?</h3>
           <p>NPIs are public identifiers. Anyone can find a provider's NPI in the NPPES registry and use it when calling a payer. Without a real-time authorization check, a caller can claim to be from that practice and request operational data — claim status, eligibility, authorization details — and the payer's system has no mechanism to refuse.</p>
-          <p>NHID-Clinical v1.3 addresses the disclosure side: did the caller identify as an AI? v2 addresses the authorization side: is this AI actually delegated by the provider it claims to represent? The goal is that a payer can know not just <em>that</em> they're talking to an AI, but that the AI truly represents the provider it claims to. The reference implementation includes <strong>198 passing tests</strong> to ensure deterministic policy enforcement.</p>
+          <p>NHID-Clinical v1.3 addresses the disclosure side: did the caller identify as an AI? v2 addresses the authorization side: is this AI actually delegated by the provider it claims to represent? The goal is that a payer can know not just <em>that</em> they're talking to an AI, but that the AI truly represents the provider it claims to. The reference implementation includes <strong>270 passing tests</strong> to ensure deterministic policy enforcement.</p>
         </div>
         <div class="faq-item">
           <h3>Can I get feedback on my implementation?</h3>

--- a/index.html
+++ b/index.html
@@ -235,7 +235,7 @@
         </div>
         <div class="content-card">
           <h3>Specification (v1.3)</h3>
-          <p>The full control set: IDG-01, DBC-01, EIT-01, ATR-01, and the event schema.</p>
+          <p>The full control set: IDG-01, PDX-01, DBC-01, EIT-01, ATR-01, and the event schema.</p>
           <a class="card-link" href="/specification.html">Read the specification →</a>
         </div>
         <div class="content-card">

--- a/openapi.json
+++ b/openapi.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "NHID-Clinical Conformance API",
     "version": "1.3.0",
-    "description": "Hosted reference implementation of the NHID-Clinical v1.3 conformance check. Evaluates a voice-AI call transcript/event against the four behavioral controls (IDG-01, PDX-01, DBC-01, EIT-01) and returns a policy decision plus a Call Authorization Score (CAS).",
+    "description": "Hosted reference implementation of the NHID-Clinical v1.3 conformance check. Evaluates a voice-AI call transcript/event against the four core behavioral controls (IDG-01, PDX-01, DBC-01, EIT-01) plus the supplemental ATR-01 audit-trail control, and returns a policy decision plus a Call Authorization Score (CAS).",
     "contact": {
       "email": "contact@nhid-clinical.org"
     },

--- a/regulatory-alignment.html
+++ b/regulatory-alignment.html
@@ -69,9 +69,53 @@
         <svg class="moon-icon" viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>
       </button>
       <a class="primary-pill" href="/community.html">Get Involved</a>
+      <button class="icon-button menu-button" type="button" aria-label="Open menu" aria-expanded="false" aria-controls="mobile-nav">
+        <svg viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><path d="M4 7h16M4 12h16M4 17h16"/></svg>
+      </button>
     </div>
   </nav>
+  <div class="search-overlay" id="search-overlay" hidden>
+    <div class="container search-overlay-inner">
+      <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" style="flex-shrink:0;color:var(--body)"><circle cx="11" cy="11" r="8"/><path d="m21 21-4.35-4.35"/></svg>
+      <input type="search" id="search-input" class="search-input" placeholder="Search NHID-Clinical…" autocomplete="off" aria-label="Search site"/>
+      <button class="icon-button search-close" id="search-close" type="button" aria-label="Close search">
+        <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><path d="M18 6 6 18M6 6l12 12"/></svg>
+      </button>
+    </div>
+    <div class="container">
+      <div class="search-results" id="search-results" role="listbox" aria-label="Search results"></div>
+    </div>
+  </div>
 </header>
+
+<nav class="mobile-nav" id="mobile-nav" aria-label="Mobile navigation">
+  <a href="/">Home</a>
+  <a href="/about.html">About</a>
+  <a href="/simulator.html">Simulator</a>
+  <strong class="mobile-nav-group">Specification</strong>
+  <a href="/specification.html">Specification</a>
+  <a href="/technical-stack.html">Technical Stack</a>
+  <a href="/regulatory-alignment.html">Regulatory Alignment</a>
+  <strong class="mobile-nav-group">Implement</strong>
+  <a href="/developers.html">Developers</a>
+  <a href="/interoperability.html">Interoperability</a>
+  <a href="/evidence-pack.html">Evidence Pack</a>
+  <a href="/shadow-evaluation-guide.html">Shadow Evaluation</a>
+  <strong class="mobile-nav-group">Pilot</strong>
+  <a href="/for-payers.html">For Payers</a>
+  <a href="/community.html">Community</a>
+  <a href="/roadmap.html">Roadmap</a>
+  <a href="/news.html">News</a>
+  <a href="https://ai-governance-map.vercel.app/" target="_blank" rel="noopener noreferrer">AI Map &#x2197;</a>
+  <div class="mobile-nav-footer">
+    <button class="theme-toggle mobile-theme-toggle" type="button" aria-label="Toggle dark mode">
+      <svg class="sun-icon" viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M6.34 17.66l-1.41 1.41M19.07 4.93l-1.41 1.41"/></svg>
+      <svg class="moon-icon" viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>
+      <span class="mobile-theme-label">Switch to dark mode</span>
+    </button>
+  </div>
+</nav>
+<div class="nav-backdrop" id="nav-backdrop"></div>
 
 <main>
   <section class="inner-hero">

--- a/scripts/generate_pdfs.py
+++ b/scripts/generate_pdfs.py
@@ -410,8 +410,9 @@ def make_shadow_guide():
          "escalation behavior, and audit trail presence for a sample of eligibility, "
          "claim status, and prior authorization calls."),
         ("Month 2 — Gap Analysis",
-         "Evaluate identified AI calls against the four v1.3 controls (IDG-01, DBC-01, "
-         "EIT-01, ATR-01). Quantify what passes, what fails, what is ambiguous."),
+         "Evaluate identified AI calls against the v1.3 controls (IDG-01, PDX-01, DBC-01, "
+         "EIT-01, plus the supplemental ATR-01 audit-trail control). Quantify what passes, "
+         "what fails, what is ambiguous."),
         ("Month 3 — Written Assessment",
          "Compile findings into a short written assessment. Share anonymized results "
          "with the community to help inform the next version of the proposal."),

--- a/shadow-evaluation-guide.html
+++ b/shadow-evaluation-guide.html
@@ -216,7 +216,7 @@
         </div>
         <div class="phase-card">
           <strong>Month 2 — Gap Analysis</strong>
-          <p>Evaluate identified AI calls against the four v1.3 controls (IDG-01, DBC-01, EIT-01, ATR-01). Quantify what passes, what fails, what is ambiguous.</p>
+          <p>Evaluate identified AI calls against the v1.3 controls (IDG-01, PDX-01, DBC-01, EIT-01, plus the supplemental ATR-01 audit-trail control). Quantify what passes, what fails, what is ambiguous.</p>
         </div>
         <div class="phase-card">
           <strong>Month 3 — Written Assessment</strong>

--- a/specs/NHID-Clinical-Knowledge-Archive.pdf
+++ b/specs/NHID-Clinical-Knowledge-Archive.pdf
@@ -345,7 +345,7 @@ endobj
 endobj
 23 0 obj
 <<
-/Author (\(anonymous\)) /CreationDate (D:20260617181242+00'00') /Creator (\(unspecified\)) /Keywords () /ModDate (D:20260617181242+00'00') /Producer (ReportLab PDF Library - \(opensource\)) 
+/Author (\(anonymous\)) /CreationDate (D:20260617200249+00'00') /Creator (\(unspecified\)) /Keywords () /ModDate (D:20260617200249+00'00') /Producer (ReportLab PDF Library - \(opensource\)) 
   /Subject (\(unspecified\)) /Title (\(anonymous\)) /Trapped /False
 >>
 endobj
@@ -424,7 +424,7 @@ xref
 trailer
 <<
 /ID 
-[<1c7113e50589bdb0e0a4967f1f8dea2f><1c7113e50589bdb0e0a4967f1f8dea2f>]
+[<cd27156d13f5c75404f0159bf1396a94><cd27156d13f5c75404f0159bf1396a94>]
 % ReportLab generated PDF document -- digest (opensource)
 
 /Info 23 0 R

--- a/specs/NHID-Clinical-Operational-Blueprint-v1.3.pdf
+++ b/specs/NHID-Clinical-Operational-Blueprint-v1.3.pdf
@@ -324,7 +324,7 @@ endobj
 endobj
 21 0 obj
 <<
-/Author (\(anonymous\)) /CreationDate (D:20260617181241+00'00') /Creator (\(unspecified\)) /Keywords () /ModDate (D:20260617181241+00'00') /Producer (ReportLab PDF Library - \(opensource\)) 
+/Author (\(anonymous\)) /CreationDate (D:20260617200248+00'00') /Creator (\(unspecified\)) /Keywords () /ModDate (D:20260617200248+00'00') /Producer (ReportLab PDF Library - \(opensource\)) 
   /Subject (\(unspecified\)) /Title (\(anonymous\)) /Trapped /False
 >>
 endobj
@@ -377,7 +377,7 @@ xref
 trailer
 <<
 /ID 
-[<0be23264e30ea52e3260824ea13fae5e><0be23264e30ea52e3260824ea13fae5e>]
+[<f9b8d1232165d6039c0823100c530d2e><f9b8d1232165d6039c0823100c530d2e>]
 % ReportLab generated PDF document -- digest (opensource)
 
 /Info 21 0 R

--- a/specs/NHID-Clinical-Shadow-Evaluation-Guide.pdf
+++ b/specs/NHID-Clinical-Shadow-Evaluation-Guide.pdf
@@ -360,7 +360,7 @@ endobj
 endobj
 20 0 obj
 <<
-/Author (\(anonymous\)) /CreationDate (D:20260617181240+00'00') /Creator (\(unspecified\)) /Keywords () /ModDate (D:20260617181240+00'00') /Producer (ReportLab PDF Library - \(opensource\)) 
+/Author (\(anonymous\)) /CreationDate (D:20260617200247+00'00') /Creator (\(unspecified\)) /Keywords () /ModDate (D:20260617200247+00'00') /Producer (ReportLab PDF Library - \(opensource\)) 
   /Subject (\(unspecified\)) /Title (\(anonymous\)) /Trapped /False
 >>
 endobj
@@ -378,10 +378,10 @@ Gb!Sl?$G&C&UiiGR('Z0\_.L$!BaP+ii:%BPF/7^cH46B"NaA'/-UQ%R:"i5!(]s"$*-Xi/EmE_(,Hf_
 endobj
 23 0 obj
 <<
-/Filter [ /ASCII85Decode /FlateDecode ] /Length 1936
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 1986
 >>
 stream
-Gb"/'=``=U&:W67fVc_\D3jqd<Za=Ye%/,QR7q5j!gA_%KEMu%[%dKpIK6@bZE6*CV[omM`ukBaH[`SbouP*:ci21)U6>o^p<"W+Vob19cj=FW#JHXd5*)5\b@3CV-O^YIb/fEe08_Q#Ag;-_L3"!"Js[lB:@WgV.<-PQ:hEH_3.E_J4$'Ks'KN4M/m['RP,0RenmTsDc"se,H:fP,.!47p`(;2@P`/Ai;R30%9qRJ"-:bf97n9^$Qp6&tS0f=lo"sn0`EM=k:(RX(oCnQq3;HdJha-V:?n!C>#TXd_Gc;Wm4uqaa8]/?ud/s;[)^8Fg92"=,26/d83Ji>\/Z++9F?Cnk?F@^`9ZU7u/icX+f?gqg"I(F9)hmCsKCRX\,M,#QZ]e<L^)Tr8GWbd@j5k?;hK@$^];.m;oLb@#3GVjU*nj2S1/Y0F"c1`2@b.N]F`'aa,C>sWKBt5/%2-1%)$4iA+Ru5j[K:dN"3BqV<WTp7^n6^cUqdhnVtZ1tRS,\"m'S]-ZBp?frFu5&Wd69IW)q&,aB;/&C.4*8;DjmY"$^VHO$a^0CH+&JjK]P.@BP?o?):b/#RFm5Q)hLaUsMcO;'iF.CV:*9<D@<pP5L68CYlEb8Q&JK2fI2N[;c#V;?s1b)S((TrOAIYqJ_![NuZJ%`kWF'd-e&3Nr1JuKNg@&J<s?WhbI7Up-EhC%'fiDC3ak07IB1J_!7V5@j,l%MVQR8#Lp8,TkDNf(jElLNA.E(+l!/]*/#7JQS9WC`#*j%irhB"nRXlS]tc?u'qSk^oAUH;^6`9VGN(IKLR4D!;?)lW#\hiY!jt%FfsKW'\L-D1a7djTB_@$arL*Vb]@lWGa6!pf`b4_.GX%QuGj_LM9jd8)O-(oKER7<3qm%N;IIC<71<84lQhm$G^E]I!Au&]'d-n6p%87;L9'k;A)GUO0_E<cQ]9n:6Uc.,3>r8eb@GJp`Bcm5\r:",$$-1'O@nedND89L!C83JEHR@IZ;Jc[<?6_RNPBdGD5UB*B;!AXOk;kcE&EAmYUo(^jJ1l4`a9$bqm^/u[[@f%1J751so'RJ%3^L-6cJ(9f;@O@71ZDd4P0"ScmR_,A?ki3>`nHu/iX'5o@+LY[Nsr?NT(BK.f:5T\afYe0oX*]TValNq\Y=8(!eY9Ne$TfKYgf<e@Q>'E_-8XX5abY;Lb;QNOhm;>"WX;CX-n&81oK[RVlPP.>p<A<ipGRhPSn'>oQb)l%+<(6T2Og2PaR5s#7lcf3/s%UA+PmH@JO,0m]QkVN9-BX/h9Vb1A2M&99&epjA7-E*R*QTk(Nfd%OnS@PJfDUD:*5%82hrH&"4I:\`:cNp*q7$i^:\NLZYSp8#X\u\c*\KcH$7UJ@3l;,%*#o+Pp&rr$LS&X8!oLm^OcD.8Cf:g`IPJ-`fb>XOIYFk=W1ol#Mb77Z.m<iF6(/rufB^Sp*n]Us!;rpDe!d\mXp:4tRh;0EYE3]q$j^&1>B4cejB4)tqM+pRLhahi0Q#Jh<]]gl+MV$0X@pH/"d<Asu!)&?VqiNA6m97=ct?ktnU1??+FT&2I=pYn/E>#[!&=g8]'8>orK-bf#dFE3D!YPDP`3c#hPYDAkj$WPNQB-rhM+g5pXVI':J-nF)Gug*cBTl8/YMN'_]V[mhY42k?*I27M"c.HD2OP>uKTj_)\F1%ejP'iZXf;ma/2T2!(68kXD"?7L#G]2;/VjtD^Lm`4aIQOXD\BEspk&]VQ0*FTpJ5p,/S'.NftAfa\'YbQ,$1S(iNbOlYJm$kgZ;%2b%C<tY)N/o$E+79Ps+[tf7['kkBK/[ORoQm3.No(LA_Af'!Cks9L?Zad'IC9fH9)eS>4_*6)CV-X.4P,5i:<tOb<e0D\E.oZ&F&9%#<EF-L5p/j$gdWSp([bkV&+3qATped+8hF64%h"-(4Tn`m@CC7=VU7VcY[gl~>endstream
+Gb"/'968iG&AII3m&=u&$RH*CDtP=cc*V@dCF7;b0/*]h84Yuh5V(!\mfK.m=gf%mp%6VbE=<I&Yg763Yos8F06D]e(>sEE^UsmsN*n]!0IAMJItO*:dH;*u_]fP1+E<nT8HC)n_B^_+Ru_Me31Q1$5Z=&YGY7UL!#\Ap6%qJ`i9\_LFF;LB.8&.k>Qd=u+DXi6b@-R4DSBF:3J$3$&<gKbESLjI-%f^9P,t_8dq=m9kr9$EA/ka%re](d0`;:+(RFMAerh^11oC$=pQj&a6sH/<U"C=#El`hLF_"JajoI%X+SIb;@iFcK!WNt%a>b;N899YAbCO-]($c.>]OFU]$jTXLBuE^7$B?H`MJ+iN3>5:00K"WdOAI?j1nDLKMhB.9lZ!IW_V<PSgj"-mil7=KW>cXJYMD\(0,>"8nT<?`"Uck;#=m6-nP`hD--Y"`9JgMd(XEE#l^;<t"j<>P=>6kf54gKar,hlgONmJsb^7lUE^Oh.W_;qs:gJV*U)A9>*@R#.Al4`Het9D`7?*"p;d&0\p,hhI"1>Rui-cu3i=_/%HeM*&Q\Qj]:@m;MfSO>ZU>[d>Z4_2\5tIc$JZ`!c?od_o2Z++GY?Ans8L7H?pkf:D\F(<2@4>"aCSOe8D(gTG!?P84B!E-25ffAY>5+0??OU30:(&@6c.q*K;[]E621)0s3Q\DY]CSnbkH-oLKQ[XP=4%jE`W^+$="!$Ab9lbF9r?"T/(Ji_ZM)WUWeVf5qi=Cp].6k1?4IR6*a(E;&s>Qo`$??g(UsXpPRC@)2%)$%X`qeK*k6i1ZpNdSNYnuu*50nm"?B*EbB=SRPh;l<T2JR?BoXiD=Q!^Xd[WeE9+'e%58?1J`+F6[[?8[Ng?]:O)_q;rrja#NT5^,]e%Z+=gB2qAM'Ahl=g0(;#<Rj84/tfW(]3]3V92[uBJ#TufojUnHe,NT"P<5+OX'npM!0Xt.5sBa4c[.*ks8F.qmMk]VaI)nGr._O@M[cCGNil&U=B!oFX-4J5%JR,iPY4(*h.&-[F$+@q-ncNMqa'C;k_B(koTYIN<+HsbX91"<9!f['q^i0J9ZlY<l!cA%CA9qKZ[62]\u4sDcDWo/%FXW0Pn+!h44V0%ScZEH2D1TWe60H#5h+s1HFXZSr=L`X-ioBf'^`q:GCN.1LGu$1<`L=aVREOEB*)<]+X>$-T*PA4Z^g4'^-8I(u0o[Y*:=H9-)SLXMfctE@p;c;.e;gU._j$bhu+IP)hob[nIE"RPXYo_e$lVWA.KBipGRhPSk8TlLW;c8b7lD:FYm)at2O+6k;tS1f#i;VY2Ba_Xb1?lu*PuN9-BEY;a\X1A3)_8;$T/c(R`n3g_:3b:A-G4+sou9EMsUm>?&l5e',UHdLR<cTT<bm&hO1@=2b@lHh_;I#PIY].j9Fe<r^\3lG2Cd0)0o1DK:,Isr&Pr`]<BQohU?I$iV\rhH7TQtad0NLHWhV39PSI;(Bn_6V(ME4)['Ih6.j/GlTfUs!<1HOd2:>r'*m:TF^G9SulpD^S4`8@)a`TAP:Y>P@F6pPe]Yhi3t#\jc7HRh6K^-leKuf@gEcgGZ?ld'eP8`oqf.!j;a86c%JF_en^)aATFs6EJ$iTZ*;!XaJmfid`ss/hTSFpDOu2R:nl*ApSm8BhU'=>D(nJUK3r\l9adTo=Yd3K7AZpaZb8/<H!Cs?kfn*>[*>P^Y'$SBXs<BRBdj:SZHjiWMmlZMlHHFBi(XH0SSA#qHWcQB!=T4.;NM`D`9/fg\g0td/DU&#kMK`)smWp4lS;=\Kai_6@FrRD5?g_bWaaniPrreAijT'bKUgs*8/.t;&hJ;e=Cf314Jkgr,?:^N$/M9TX@e$*kY?CX4MEFjnM!$,eh[Y/VY[:qkBikpG]@?s7LQYg%F?HJ,,4n#&o.2Zh'Vc89AOmU*i)K=K[l_?ZBjI7$q`!Mb85"\<j%JhT+&BFe<9*>&*42987Y;'Mu>pg!5j%7XkM8_g$"~>endstream
 endobj
 xref
 0 24
@@ -412,7 +412,7 @@ xref
 trailer
 <<
 /ID 
-[<aa1d7fd986512c91df34556f25b6ee4e><aa1d7fd986512c91df34556f25b6ee4e>]
+[<85c47765f9a0052a9f58e8dbec4b974b><85c47765f9a0052a9f58e8dbec4b974b>]
 % ReportLab generated PDF document -- digest (opensource)
 
 /Info 20 0 R
@@ -420,5 +420,5 @@ trailer
 /Size 24
 >>
 startxref
-1139816
+1139866
 %%EOF

--- a/specs/NHID-Clinical-v1.3-Core-Specification.pdf
+++ b/specs/NHID-Clinical-v1.3-Core-Specification.pdf
@@ -324,7 +324,7 @@ endobj
 endobj
 21 0 obj
 <<
-/Author (\(anonymous\)) /CreationDate (D:20260617181241+00'00') /Creator (\(unspecified\)) /Keywords () /ModDate (D:20260617181241+00'00') /Producer (ReportLab PDF Library - \(opensource\)) 
+/Author (\(anonymous\)) /CreationDate (D:20260617200247+00'00') /Creator (\(unspecified\)) /Keywords () /ModDate (D:20260617200247+00'00') /Producer (ReportLab PDF Library - \(opensource\)) 
   /Subject (\(unspecified\)) /Title (\(anonymous\)) /Trapped /False
 >>
 endobj
@@ -377,7 +377,7 @@ xref
 trailer
 <<
 /ID 
-[<d33c09f476de267241b4eb5e101f2089><d33c09f476de267241b4eb5e101f2089>]
+[<942429d29e75916e70ff458ffd15cba6><942429d29e75916e70ff458ffd15cba6>]
 % ReportLab generated PDF document -- digest (opensource)
 
 /Info 21 0 R

--- a/specs/NHID-Clinical-v2-Technical-Playbook.pdf
+++ b/specs/NHID-Clinical-v2-Technical-Playbook.pdf
@@ -319,7 +319,7 @@ endobj
 endobj
 22 0 obj
 <<
-/Author (\(anonymous\)) /CreationDate (D:20260617181241+00'00') /Creator (\(unspecified\)) /Keywords () /ModDate (D:20260617181241+00'00') /Producer (ReportLab PDF Library - \(opensource\)) 
+/Author (\(anonymous\)) /CreationDate (D:20260617200248+00'00') /Creator (\(unspecified\)) /Keywords () /ModDate (D:20260617200248+00'00') /Producer (ReportLab PDF Library - \(opensource\)) 
   /Subject (\(unspecified\)) /Title (\(anonymous\)) /Trapped /False
 >>
 endobj
@@ -381,7 +381,7 @@ xref
 trailer
 <<
 /ID 
-[<ef691edddd8f17cb065fe8e9141c46e0><ef691edddd8f17cb065fe8e9141c46e0>]
+[<93afceaeebef0d510892d8d2e00b6320><93afceaeebef0d510892d8d2e00b6320>]
 % ReportLab generated PDF document -- digest (opensource)
 
 /Info 22 0 R

--- a/specs/index.html
+++ b/specs/index.html
@@ -109,7 +109,7 @@
 
         <article class="download-card">
           <h3>v1.3 Core Specification</h3>
-          <p>The normative reference: the four behavioral controls (IDG-01, PDX-01, DBC-01, EIT-01), the five CTS conformance tests, and the scoring rubric used to evaluate an agent's behavioral trace.</p>
+          <p>The normative reference: the four core behavioral controls (IDG-01, PDX-01, DBC-01, EIT-01) plus the supplemental ATR-01 audit-trail control, the 18-case CTS conformance suite, and the scoring rubric used to evaluate an agent's behavioral trace.</p>
           <a href="/specs/NHID-Clinical-v1.3-Core-Specification.pdf" class="download-link" download>Download PDF <span>→</span></a>
           <span class="license-badge">CC BY 4.0</span>
         </article>

--- a/technical-stack.html
+++ b/technical-stack.html
@@ -69,9 +69,53 @@
         <svg class="moon-icon" viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>
       </button>
       <a class="primary-pill" href="/community.html">Get Involved</a>
+      <button class="icon-button menu-button" type="button" aria-label="Open menu" aria-expanded="false" aria-controls="mobile-nav">
+        <svg viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><path d="M4 7h16M4 12h16M4 17h16"/></svg>
+      </button>
     </div>
   </nav>
+  <div class="search-overlay" id="search-overlay" hidden>
+    <div class="container search-overlay-inner">
+      <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" style="flex-shrink:0;color:var(--body)"><circle cx="11" cy="11" r="8"/><path d="m21 21-4.35-4.35"/></svg>
+      <input type="search" id="search-input" class="search-input" placeholder="Search NHID-Clinical…" autocomplete="off" aria-label="Search site"/>
+      <button class="icon-button search-close" id="search-close" type="button" aria-label="Close search">
+        <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><path d="M18 6 6 18M6 6l12 12"/></svg>
+      </button>
+    </div>
+    <div class="container">
+      <div class="search-results" id="search-results" role="listbox" aria-label="Search results"></div>
+    </div>
+  </div>
 </header>
+
+<nav class="mobile-nav" id="mobile-nav" aria-label="Mobile navigation">
+  <a href="/">Home</a>
+  <a href="/about.html">About</a>
+  <a href="/simulator.html">Simulator</a>
+  <strong class="mobile-nav-group">Specification</strong>
+  <a href="/specification.html">Specification</a>
+  <a href="/technical-stack.html">Technical Stack</a>
+  <a href="/regulatory-alignment.html">Regulatory Alignment</a>
+  <strong class="mobile-nav-group">Implement</strong>
+  <a href="/developers.html">Developers</a>
+  <a href="/interoperability.html">Interoperability</a>
+  <a href="/evidence-pack.html">Evidence Pack</a>
+  <a href="/shadow-evaluation-guide.html">Shadow Evaluation</a>
+  <strong class="mobile-nav-group">Pilot</strong>
+  <a href="/for-payers.html">For Payers</a>
+  <a href="/community.html">Community</a>
+  <a href="/roadmap.html">Roadmap</a>
+  <a href="/news.html">News</a>
+  <a href="https://ai-governance-map.vercel.app/" target="_blank" rel="noopener noreferrer">AI Map &#x2197;</a>
+  <div class="mobile-nav-footer">
+    <button class="theme-toggle mobile-theme-toggle" type="button" aria-label="Toggle dark mode">
+      <svg class="sun-icon" viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M6.34 17.66l-1.41 1.41M19.07 4.93l-1.41 1.41"/></svg>
+      <svg class="moon-icon" viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>
+      <span class="mobile-theme-label">Switch to dark mode</span>
+    </button>
+  </div>
+</nav>
+<div class="nav-backdrop" id="nav-backdrop"></div>
 
 <main>
   <section class="inner-hero">
@@ -115,7 +159,7 @@
             <td style="padding:.75rem">Layer 2: NHID-Clinical v1.3</td>
             <td style="padding:.75rem">Behavioral disclosure baseline</td>
             <td style="padding:.75rem">Voluntary proposal</td>
-            <td style="padding:.75rem">Core (IDG-01, DBC-01, EIT-01, ATR-01)</td>
+            <td style="padding:.75rem">Core (IDG-01, PDX-01, DBC-01, EIT-01) + ATR-01</td>
           </tr>
           <tr style="border-bottom:1px solid var(--border)">
             <td style="padding:.75rem">Layer 3: NHID-Auth v2</td>


### PR DESCRIPTION
## Summary
- Restores the missing hamburger/mobile-nav menu on `technical-stack.html` and `regulatory-alignment.html` (both pages were missing the `mobile-nav` drawer, `nav-backdrop`, search overlay, and `menu-button` markup that every other page has).
- Fixes a recurring site-wide miswording of "the four controls" that dropped the core `PDX-01` control and incorrectly substituted in the supplemental `ATR-01` control. Correct canonical set: 4 core behavioral controls (IDG-01, PDX-01, DBC-01, EIT-01) + the supplemental ATR-01 audit-trail control. Fixed in `shadow-evaluation-guide.html`, `technical-stack.html`, `index.html`, `specs/index.html`, and `scripts/generate_pdfs.py`.
- Fixes a stale "five CTS conformance tests" claim in `specs/index.html` (actual: 18-case suite) and a stale "198 passing tests" count in `faq.html` (actual: 270).
- Clarifies `openapi.json`'s top-level description to mention the supplemental ATR-01 control alongside the four core controls.
- Regenerates the 5 generator-produced PDFs in `specs/` so the downloadable documents match the corrected text.

## Test plan
- [x] `python3 -m pytest tests/ -q` — 270 passed, 18 skipped (unchanged invariant)
- [x] `python3 scripts/validate_ci.py` — CI PASS: 270 passed
- [x] Verified hamburger menu renders and opens via headless-browser (Playwright) check on both fixed pages
- [x] Repo-wide grep confirmed no other HTML page has the same missing-markup gap
- [x] `pypdf` text-extraction check on all 5 regenerated PDFs confirms corrected control-list wording is present and no stale/forbidden terms remain

---
_Generated by [Claude Code](https://claude.ai/code/session_01XorMR2iJBdCQ4EqjkS4jao)_