### PR TITLE
Use devicon glyphs for README tech-stack row

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,9 +27,17 @@
 </p>
 
 <p align="center">
-  <img alt="Python" src="https://img.shields.io/badge/Python-3.11-3776AB?logo=python&logoColor=white">
-  <img alt="TypeScript" src="https://img.shields.io/badge/TypeScript-middleware-3178C6?logo=typescript&logoColor=white">
-  <img alt="AWS Lambda" src="https://img.shields.io/badge/AWS-Lambda-FF9900?logo=awslambda&logoColor=white">
+  <img alt="Python" height="40" src="https://raw.githubusercontent.com/devicons/devicon/master/icons/python/python-original.svg">
+  <img alt="TypeScript" height="40" src="https://raw.githubusercontent.com/devicons/devicon/master/icons/typescript/typescript-original.svg">
+  <img alt="Node.js" height="40" src="https://raw.githubusercontent.com/devicons/devicon/master/icons/nodejs/nodejs-original.svg">
+  <img alt="Jest" height="40" src="https://raw.githubusercontent.com/devicons/devicon/master/icons/jest/jest-plain.svg">
+  <img alt="HTML5" height="40" src="https://raw.githubusercontent.com/devicons/devicon/master/icons/html5/html5-original.svg">
+  <img alt="CSS3" height="40" src="https://raw.githubusercontent.com/devicons/devicon/master/icons/css3/css3-original.svg">
+  <img alt="AWS" height="40" src="https://raw.githubusercontent.com/devicons/devicon/master/icons/amazonwebservices/amazonwebservices-original-wordmark.svg">
+  <img alt="GitHub Actions" height="40" src="https://raw.githubusercontent.com/devicons/devicon/master/icons/githubactions/githubactions-original.svg">
+</p>
+
+<p align="center">
   <img alt="FHIR" src="https://img.shields.io/badge/FHIR-R4%20base%20spec-E0322F?logo=fhir&logoColor=white">
 </p>
 


### PR DESCRIPTION
## Summary
- Replaces the flat shields.io tech-stack badge row in `README.md` with real [devicon](https://github.com/devicons/devicon) SVG glyphs for Python, TypeScript, Node.js, Jest, HTML5, CSS3, AWS, and GitHub Actions — matching the tech actually used in the repo (verified via `middleware/package.json` and `.github/workflows/`).
- FHIR keeps its own shields.io badge since devicon has no healthcare-standard icons to represent it.
- Icon URLs verified to resolve (HTTP 200) via `raw.githubusercontent.com` before committing.

## Test plan
- [x] `python3 -m pytest tests/ -q` → 270 passed, 18 skipped
- [x] `python3 scripts/validate_ci.py` → CI PASS: 270 passed
- [x] `curl -I` on all 8 devicon SVG URLs → 200
- [ ] Visual check of rendered README on GitHub once PR is open


---
_Generated by [Claude Code](https://claude.ai/code/session_01XorMR2iJBdCQ4EqjkS4jao)_