### PR TITLE
Add caveat under NIST badge in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,10 @@
 </p>
 
 <p align="center">
+  <sub>The NIST badge links to a public comment submitted to a NIST RFI docket — it is not a NIST endorsement, adoption, or certification.</sub>
+</p>
+
+<p align="center">
   <img alt="Python" height="40" src="https://raw.githubusercontent.com/devicons/devicon/master/icons/python/python-original.svg">
   <img alt="TypeScript" height="40" src="https://raw.githubusercontent.com/devicons/devicon/master/icons/typescript/typescript-original.svg">
   <img alt="Node.js" height="40" src="https://raw.githubusercontent.com/devicons/devicon/master/icons/nodejs/nodejs-original.svg">


### PR DESCRIPTION
## Summary
- Adds a one-line caveat directly under the NIST badge in `README.md`: it's a public comment to a NIST RFI docket, not an endorsement/adoption/certification.
- The live site already disclaims this elsewhere (`faq.html`, `index.html`); the README badge had no equivalent context and could be misread in isolation.

## Test plan
- [x] `python3 -m pytest tests/ -q` → 270 passed, 18 skipped


---
_Generated by [Claude Code](https://claude.ai/code/session_01XorMR2iJBdCQ4EqjkS4jao)_