### PR TITLE
Wire real Cloudflare Turnstile site key into demo.html

### DIFF
--- a/demo.html
+++ b/demo.html
@@ -149,8 +149,8 @@
           <input type="tel" id="demo-phone" placeholder="+1 (555) 000-0000" autocomplete="tel" aria-label="Your phone number" style="flex:1;min-width:200px"/>
           <button class="cta-button" id="demo-call-btn" type="button">Receive a Call from Beacon</button>
         </div>
-        <!-- data-sitekey is a placeholder pending Cloudflare Turnstile dashboard setup (one-time manual step, same pattern as agents/compass_system_prompt.md's pending agent_id) -->
-        <div class="cf-turnstile" id="demo-call-turnstile" data-sitekey="sitekey_pending_cloudflare_dashboard_creation" data-callback="nhidOnTurnstileSuccess"></div>
+        <!-- Cloudflare Turnstile site key (public). The matching secret key is never committed — it's passed only at deploy time via `make deploy CLOUDFLARE_TURNSTILE_SECRET=...` and verified server-side in handler._verify_turnstile(). -->
+        <div class="cf-turnstile" id="demo-call-turnstile" data-sitekey="0x4AAAAAADoOpjQr1DAbFwwY" data-callback="nhidOnTurnstileSuccess"></div>
         <p id="demo-call-status" hidden aria-live="polite" style="margin-top:.75rem"></p>
       </div>
 


### PR DESCRIPTION
## Summary

Second of the manual provisioning follow-ups from #265. A Cloudflare Turnstile widget was created (Managed mode, hostnames `nhid-clinical.org` + `www.nhid-clinical.org`), so this replaces the `sitekey_pending_cloudflare_dashboard_creation` placeholder in `demo.html` with the real **public site key**.

The matching **secret key is intentionally not in this diff** — it's passed only at deploy time via `make deploy CLOUDFLARE_TURNSTILE_SECRET=...` (a `NoEcho` CloudFormation parameter → Lambda env var) and verified server-side in `handler._verify_turnstile()`.

## Still pending (separate follow-ups)
- Twilio demo number + webhook
- ElevenLabs Beacon phone number ID + API key
- Pull Compass live voice/model into `compass.config.json`
- Baseline `make deploy` (unlocks `ApiBaseUrl`), then final deploy with all three secrets

## Test plan
- [x] Diff contains only the public site key; no secret committed
- [ ] Manual: load `demo.html`, confirm the Turnstile widget renders and the "Receive a Call from Beacon" form requires solving it before submit

---
_Generated by [Claude Code](https://claude.ai/code/session_01XorMR2iJBdCQ4EqjkS4jao)_