### PR TITLE
Fix Beacon's broken consent-refusal transfer path

### DIFF
--- a/agents/beacon_system_prompt.md
+++ b/agents/beacon_system_prompt.md
@@ -45,8 +45,13 @@ Beacon MUST NOT:
 ### EIT-01 — Escalation Implementation Test
 When a counterparty requests to speak with a human, Beacon MUST:
 1. Acknowledge the request immediately
-2. Execute the `agent_transfer` tool immediately (no verbal warning before transfer)
-3. Provide an alternative contact method if no human path is available
+2. If a real human transfer path is configured, execute it immediately (no
+   verbal warning before transfer)
+3. If no human path is configured (as in this demo — no live transfer
+   destination exists), say so plainly and offer an alternative contact
+   method, then end the call. Never invoke a transfer tool that has nowhere
+   to send the call — that leaves the line dead instead of resolving the
+   request.
 
 ### ATR-01 — Audit Trail Requirements
 Every session event must carry a distinct per-event timestamp. Beacon's responses
@@ -78,7 +83,8 @@ CONSENT (SECOND STEP):
 after they confirm department, ask: "are you comfortable continuing with an AI assistant, or would you prefer to speak with a human from our office?"
 
 IF CONSENT REFUSED:
-DO NOT say anything about transferring. IMMEDIATELY execute the agent_transfer tool with NO verbal warning. The tool will handle the transfer message automatically.
+acknowledge immediately: "I understand. I'm sorry, I am unable to transfer you to a human representative at this time. Please call back during business hours or contact us at a different number."
+then use the end_call tool.
 
 IF CONSENT ACCEPTED:
 provide verification:
@@ -108,3 +114,4 @@ hi, this is Beacon, an ai assistant calling from a provider's office on behalf o
 | Date | Direction | Notes |
 |------|-----------|-------|
 | 2026-06-11 | manual | Renamed from Nadine to Beacon; populated from live ElevenLabs agent dashboard |
+| 2026-06-20 | repo → ElevenLabs (pending sync) | Fixed broken consent-refusal path: `agent_transfer` had no configured destination, leaving calls dead. Now acknowledges, explains no live transfer is available, and ends the call. |


### PR DESCRIPTION
## Why

Live-tested the Beacon outbound demo after deploying via `deploy.ps1`. When the test caller declined the AI and asked for a human, the call went dead — Beacon wouldn't speak again until the caller spoke first.

Root cause: the system prompt told Beacon to "IMMEDIATELY execute the `agent_transfer` tool" on consent refusal, but no real transfer destination exists anywhere (no phone number, extension, env var, or ElevenLabs tool config). The tool had nowhere to send the call, so it just hung.

## What

`agents/beacon_system_prompt.md`:
- `IF CONSENT REFUSED` now acknowledges the request, explains no live transfer is available in this demo, and uses `end_call` instead of invoking a transfer tool with no destination.
- Updated the EIT-01 control description to match: execute a real transfer when one is configured, otherwise acknowledge + offer an alternative contact + end the call.

Call direction (Beacon = provider's office calling an insurer with NPI ready to check claim status) was confirmed correct and unchanged.

## Follow-up required

The repo is the source of truth but ElevenLabs only reflects what's synced. After merge, run with your own `ELEVENLABS_API_KEY`:
```bash
python tests/elevenlabs_cts_runner.py --sync-prompt
```
(drop `--dry-run` to push live.) The fix has no effect on the live agent until this runs.

This branch also includes the earlier `deploy.ps1` Windows deploy script (previously opened as #268, closed without merge).

## Test plan
- [ ] Sync the prompt to the live ElevenLabs agent
- [ ] Place a Beacon test call, decline the AI when asked for a human, confirm it explains and hangs up without requiring you to speak again


---
_Generated by [Claude Code](https://claude.ai/code/session_01XorMR2iJBdCQ4EqjkS4jao)_