### PR TITLE
Stop FHIR validation CI from depending on tx.fhir.org

### DIFF
--- a/.github/workflows/nhid-gates.yml
+++ b/.github/workflows/nhid-gates.yml
@@ -225,7 +225,7 @@ jobs:
           FAIL=0
           for f in examples/fhir/*.json; do
             echo "=== Validating $f ==="
-            java -jar tools/validator_cli.jar -version 4.0.1 "$f" 2>&1 | tee /tmp/fhir-out.txt
+            java -jar tools/validator_cli.jar -version 4.0.1 -tx n/a "$f" 2>&1 | tee /tmp/fhir-out.txt
             if [ ${PIPESTATUS[0]} -ne 0 ]; then
               echo "FHIR VALIDATION ERROR in $f"
               FAIL=1


### PR DESCRIPTION
## Summary
- The "FHIR R4 AuditEvent validation" job calls `validator_cli.jar`, which by default connects to the public `tx.fhir.org` terminology server to validate coded values (LOINC/SNOMED/ICD-X, etc.). That connection times out intermittently in CI (seen on PR #286), failing the job for reasons unrelated to the bundle content.
- Adds `-tx n/a` to the validator invocation so it skips the external terminology-server round trip. Structural/profile validation against R4 still runs in full; only the optional external code-system lookups are skipped.

## Test plan
- [ ] Confirm the `fhir_validation` job passes on this PR without a terminology-server timeout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01XorMR2iJBdCQ4EqjkS4jao)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated validation workflow configuration to modify FHIR validator execution settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->