### PR TITLE
Platform Conformance Suite page + site premium visual layer

### DIFF
--- a/assets/css/premium.css
+++ b/assets/css/premium.css
@@ -1,0 +1,131 @@
+/* ── NHID-Clinical premium visual layer ─────────────────────────────────────
+   Additive only: loaded AFTER nhid-clinical-ui.css. Provides cinematic dark
+   bands and premium components while the site's light paper identity remains
+   the default. No external assets, no trackers. */
+
+:root {
+  --navy-deep: #0F172A;
+  --navy-deeper: #0a0f1e;
+  --teal-glow: #14B8A6;
+  --teal-soft-glow: rgba(20, 184, 166, 0.35);
+  --silver: #cbd5e1;
+  --gold-inlay: #caa652;
+  --premium-line: #1e2a44;
+}
+
+/* Dark cinematic band */
+.section-premium {
+  background:
+    radial-gradient(1200px 500px at 70% -10%, rgba(20,184,166,0.10), transparent 60%),
+    linear-gradient(180deg, var(--navy-deep) 0%, var(--navy-deeper) 100%);
+  color: #e2e8f0;
+  padding: 4.5rem 0;
+  position: relative;
+  overflow: hidden;
+}
+/* Subtle verification-lattice depth overlay */
+.section-premium::before {
+  content: "";
+  position: absolute; inset: 0;
+  background-image:
+    linear-gradient(rgba(148,163,184,0.05) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(148,163,184,0.05) 1px, transparent 1px);
+  background-size: 44px 44px;
+  mask-image: radial-gradient(80% 70% at 50% 30%, #000 40%, transparent 100%);
+  pointer-events: none;
+}
+.section-premium > .container { position: relative; }
+
+.section-premium h1, .section-premium h2, .section-premium h3 { color: #f1f5f9; }
+.section-premium a { color: var(--teal-glow); }
+.section-premium .lead { color: #b7c3d8; font-size: 1.06rem; line-height: 1.75; max-width: 52rem; }
+
+/* Hero variant */
+.hero-premium { padding: 5rem 0 4rem; }
+.hero-premium .hero-kicker {
+  display: inline-block; letter-spacing: .14em; text-transform: uppercase;
+  font-size: .72rem; color: var(--teal-glow); border: 1px solid rgba(20,184,166,.35);
+  padding: .3rem .7rem; border-radius: 999px; margin-bottom: 1rem;
+}
+.hero-premium h1 { font-size: clamp(2rem, 4.5vw, 3.1rem); letter-spacing: -0.02em; margin: 0 0 .6rem; }
+.hero-premium .tagline { color: #cbd5e1; font-size: 1.15rem; margin: 0 0 1rem; }
+.hero-premium .disclaimer { color: #93a4c0; font-size: .95rem; max-width: 46rem; line-height: 1.7; }
+.hero-premium .disclaimer strong { color: #e2e8f0; }
+
+/* Premium buttons */
+.hero-actions-premium { display: flex; flex-wrap: wrap; gap: .75rem; margin-top: 1.6rem; }
+.btn-premium, .btn-ghost {
+  display: inline-flex; align-items: center; gap: .45rem;
+  padding: .72rem 1.15rem; border-radius: 8px; font-weight: 600; font-size: .92rem;
+  text-decoration: none; transition: transform .15s ease, box-shadow .15s ease, background .15s ease;
+}
+.btn-premium {
+  color: #06222b; background: linear-gradient(135deg, #2dd4bf 0%, var(--teal-glow) 60%, #0f9c8c 100%);
+  box-shadow: 0 8px 24px -8px var(--teal-soft-glow), inset 0 1px 0 rgba(255,255,255,.35);
+}
+.btn-premium:hover { transform: translateY(-1px); box-shadow: 0 12px 30px -8px var(--teal-soft-glow); }
+.btn-ghost {
+  color: #dbe4f2; background: rgba(148,163,184,0.08);
+  border: 1px solid rgba(148,163,184,0.35);
+}
+.btn-ghost:hover { background: rgba(148,163,184,0.16); }
+.btn-premium:focus-visible, .btn-ghost:focus-visible,
+.stack-layer:focus-visible { outline: 2px solid var(--teal-glow); outline-offset: 3px; }
+
+/* Framed visual (SVG fallback or dropped-in 8K render) */
+img.premium-3d, svg.premium-3d, picture.premium-3d img {
+  width: 100%; max-width: 1100px; margin: 2rem auto 0; display: block;
+  border-radius: 12px; border: 1px solid var(--premium-line);
+  box-shadow: 0 30px 70px -20px rgba(0, 0, 0, .55), 0 0 0 1px rgba(20,184,166,.08);
+  background: var(--navy-deeper);
+}
+.visual-caption {
+  text-align: center; color: #8fa0bd; font-size: .8rem; margin-top: .7rem; font-style: italic;
+}
+
+/* Two-column contrast lists */
+.two-column { display: grid; grid-template-columns: 1fr 1fr; gap: 2.5rem; margin-top: 2.2rem; }
+.two-column h3 { margin-top: 0; font-size: 1rem; }
+.two-column ul { margin: .6rem 0 0; padding-left: 1.1rem; color: #b7c3d8; line-height: 1.85; font-size: .93rem; }
+.two-column .col-bad h3 { color: #f2a6a9; }
+.two-column .col-good h3 { color: #6ee7d5; }
+@media (max-width: 700px) { .two-column { grid-template-columns: 1fr; gap: 1.4rem; } }
+
+.disclaimer-small {
+  font-size: .85rem; color: #8fa0bd; margin-top: 2.2rem;
+  border-top: 1px solid var(--premium-line); padding-top: 1rem; line-height: 1.7;
+}
+
+/* Interactive five-layer trust stack */
+.stack-wrap { display: grid; grid-template-columns: minmax(0,1fr) minmax(0,1fr); gap: 2.5rem; align-items: start; margin-top: 2rem; }
+@media (max-width: 860px) { .stack-wrap { grid-template-columns: 1fr; } }
+.stack-layer {
+  cursor: pointer; transition: filter .18s ease, transform .18s ease;
+}
+.stack-layer:hover, .stack-layer.active { filter: brightness(1.25) drop-shadow(0 0 10px var(--teal-soft-glow)); }
+.stack-detail {
+  background: rgba(15, 23, 42, 0.6); border: 1px solid var(--premium-line);
+  border-radius: 12px; padding: 1.4rem 1.6rem; min-height: 15rem;
+}
+.stack-detail h3 { margin: 0 0 .4rem; color: #6ee7d5; font-size: 1.02rem; }
+.stack-detail .layer-tag { font-size: .72rem; letter-spacing: .12em; text-transform: uppercase; color: #8fa0bd; }
+.stack-detail p { color: #b7c3d8; line-height: 1.75; font-size: .93rem; }
+.stack-detail .stack-links { display: flex; gap: .8rem; flex-wrap: wrap; margin-top: 1rem; }
+.stack-detail .stack-links a { font-size: .85rem; font-weight: 600; }
+
+/* Premium callout panel for light subpages */
+.premium-callout {
+  background: linear-gradient(135deg, var(--navy-deep), #16233f);
+  color: #dbe4f2; border-radius: 12px; padding: 1.6rem 1.9rem;
+  border: 1px solid var(--premium-line);
+  box-shadow: 0 20px 50px -20px rgba(15, 23, 42, .5);
+  margin: 2rem 0;
+}
+.premium-callout h3 { color: #6ee7d5; margin: 0 0 .5rem; font-size: 1rem; }
+.premium-callout p { margin: 0 0 .9rem; font-size: .92rem; line-height: 1.7; color: #b7c3d8; }
+.premium-callout a { color: var(--teal-glow); font-weight: 600; }
+
+@media (prefers-reduced-motion: reduce) {
+  .btn-premium, .btn-ghost, .stack-layer { transition: none; }
+  .btn-premium:hover { transform: none; }
+}

--- a/assets/images/3d-renders/PROMPTS.md
+++ b/assets/images/3d-renders/PROMPTS.md
@@ -1,0 +1,80 @@
+# 3D Render Drop-In Slots — Generation Prompts
+
+This directory holds the optional high-resolution raster renders for the premium
+visual layer. The site works fully WITHOUT them: every `<picture>` slot falls back
+to the self-contained SVG in `assets/images/3d-svg/`. When a WebP listed below is
+added here, the corresponding page upgrades automatically — no code changes.
+
+Workflow: generate at max quality (8K if available) → downscale/optimize to WebP
+(~1600–2200px wide, <400 KB; Squoosh or ImageOptim) → save with the EXACT filename.
+Keep a PNG fallback only if a target browser matters to you (the `<picture>` tags
+already reference `.webp` first and the SVG as final fallback).
+
+House rules for every render: deep navy `#0F172A` base, teal `#14B8A6` energy
+accents, slate/metallic silver materials, subtle gold inlays; no humans, no text
+baked into the image; authoritative, grounded, premium — never salesy. Captions and
+alt text on the site always say "Illustrative 3D visualization … conceptual render
+for clarity."
+
+## Slot 1 — `nexus-trust-bridge.webp` (index.html hero · wide 16:6-ish)
+
+> Hyper-realistic insanely detailed 3D CGI cinematic render of an epic professional
+> "Governance Trust Nexus" architectural structure in a stylized digital healthcare
+> realm. A monumental modern-fortified archive or verification bridge spanning a
+> subtle digital chasm between payer and provider domains. Intricate layered
+> shields, ornate yet technical gates, and glowing teal energy pathways representing
+> identity disclosure and verification protocols. Deep navy stone and metallic
+> silver materials with subtle gold inlays. Volumetric god rays, dramatic cinematic
+> lighting, high dynamic range, intricate PBR textures, depth of field, 8K
+> resolution. Enterprise premium aesthetic like high-end Unreal Engine 5
+> architectural visualization, wide landscape composition for website hero, no
+> humans, no text, symbolic and authoritative.
+
+## Slot 2 — `trust-stack-ziggurat.webp` (index.html stack section · portrait/square)
+
+> Insanely detailed hyper-realistic 3D CGI cross-section render of a five-layer
+> monumental trust architecture ziggurat for healthcare AI voice governance. Bottom
+> foundational layer with intricate network protocol engravings. Successive layers:
+> behavioral disclosure gates, cryptographic authorization chains and NPI bindings,
+> comprehensive audit ledger textures, top observability spires. Each layer uniquely
+> textured with deep navy stone, teal energy veins, silver/gold accents. Subtle
+> control identifiers engraved. Dramatic side volumetric lighting, high resolution
+> PBR, cinematic quality, angled view for clarity, premium enterprise visualization,
+> no text overlays, authoritative mood.
+
+## Slot 3 — `impersonation-vs-verified.webp` (latency section · wide split scene)
+
+> Hyper-detailed cinematic 3D CGI split-scene render contrasting two halves of a
+> digital healthcare realm. LEFT: a shadowed, red-tinged corridor where an unmarked
+> caller orb passes a shattered gate straight into an exposed records vault — cold,
+> hazardous, unverified. RIGHT: the same corridor rebuilt in deep navy and teal —
+> an identity-disclosure gate, a verification checkpoint ring, and a sealed vault
+> with a human-escalation stair, teal energy pulse traveling the verified path.
+> Deep navy stone, metallic silver, teal light, subtle gold; volumetric lighting,
+> PBR, 8K, no humans depicted literally (symbolic orbs/gates only), no text.
+
+## Slot 4 — `idg01-gate.webp` (specification/controls · square)
+
+> Insanely detailed 3D CGI render of a single monumental "Identity Disclosure Gate"
+> — a secure glowing teal portal set in a deep navy stone frame with engraved
+> circuit-like filigree and a silver keystone, faint gold inlay seams, closed until
+> disclosure. Cinematic rim lighting, volumetric haze, PBR textures, 8K, symbolic,
+> no text.
+
+## Slot 5 — `verified-call-flow.webp` (simulator/technical-stack · wide isometric)
+
+> Hyper-detailed isometric 3D CGI visualization of a verified AI call flow across a
+> floating circuit-board landscape: caller node → disclosure gate → verification
+> ring → PHI vault → human-escalation platform → audit ledger obelisk, connected by
+> glowing teal conduits with directional pulses. Deep navy base, silver machinery,
+> teal energy, subtle gold; clean readable composition, cinematic lighting, PBR,
+> 8K, no text.
+
+## Slot 6 set — per-control artifacts (optional gallery)
+
+Same style as Slot 4, one per control. Filenames: `pdx01-checkpoint.webp`
+(verification checkpoint ring before a sealed data conduit), `dbc01-mirror.webp`
+(a truth-mirror device that reveals a machine silhouette behind a human-seeming
+waveform), `eit01-stair.webp` (an always-lit escalation stair rising from the call
+floor to a human platform), `atr01-ledger.webp` (an immutable audit obelisk with
+engraved event rows and teal seal-stamps).

--- a/assets/images/3d-svg/latency-split.svg
+++ b/assets/images/3d-svg/latency-split.svg
@@ -1,0 +1,128 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1600 560" role="img" aria-labelledby="ls-t ls-d">
+  <title id="ls-t">Impersonation latency: without a standard vs a verified trust pathway</title>
+  <desc id="ls-d">Illustrative split scene. Left: an unverified AI call reaches the receiving system with no verification pathway — trust delay effectively infinite, PHI at risk. Right: the NHID-Clinical verified pathway with disclosure gate, pre-data-exchange verification, and human escalation producing a measurable trust delay. Conceptual render for clarity.</desc>
+  <defs>
+    <linearGradient id="lsBg" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#0F172A"/><stop offset="1" stop-color="#070c18"/>
+    </linearGradient>
+    <radialGradient id="lsRed" cx=".25" cy=".35" r=".5">
+      <stop offset="0" stop-color="#e5484d" stop-opacity=".14"/><stop offset="1" stop-color="#e5484d" stop-opacity="0"/>
+    </radialGradient>
+    <radialGradient id="lsTeal" cx=".75" cy=".35" r=".5">
+      <stop offset="0" stop-color="#14B8A6" stop-opacity=".18"/><stop offset="1" stop-color="#14B8A6" stop-opacity="0"/>
+    </radialGradient>
+    <linearGradient id="lsSteel" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#3a4a63"/><stop offset="1" stop-color="#182338"/>
+    </linearGradient>
+    <filter id="lsGlow"><feGaussianBlur stdDeviation="5"/></filter>
+    <filter id="lsSoft"><feGaussianBlur stdDeviation="1.2"/></filter>
+    <marker id="lsArrT" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="7" markerHeight="7" orient="auto">
+      <path d="M0 0 L10 5 L0 10 z" fill="#2dd4bf"/>
+    </marker>
+    <marker id="lsArrR" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="7" markerHeight="7" orient="auto">
+      <path d="M0 0 L10 5 L0 10 z" fill="#e5484d"/>
+    </marker>
+  </defs>
+
+  <rect width="1600" height="560" fill="url(#lsBg)"/>
+  <rect width="800" height="560" fill="url(#lsRed)"/>
+  <rect x="800" width="800" height="560" fill="url(#lsTeal)"/>
+  <line x1="800" y1="30" x2="800" y2="530" stroke="#33415c" stroke-width="2" stroke-dasharray="6 8"/>
+
+  <g font-family="Inter,system-ui,sans-serif">
+    <!-- ══════ LEFT: without a standard ══════ -->
+    <text x="400" y="66" fill="#f2a6a9" font-size="24" font-weight="800" text-anchor="middle" letter-spacing="1.5">WITHOUT A STANDARD</text>
+    <text x="400" y="94" fill="#8fa0bd" font-size="14.5" text-anchor="middle">trust delay: effectively infinite — no verification pathway exists</text>
+
+    <!-- unknown caller -->
+    <g>
+      <circle cx="150" cy="280" r="46" fill="#182338" stroke="#5b3140" stroke-width="2.4"/>
+      <text x="150" y="292" fill="#f2a6a9" font-size="34" font-weight="800" text-anchor="middle">?</text>
+      <text x="150" y="352" fill="#8fa0bd" font-size="13.5" text-anchor="middle">unverified AI caller</text>
+    </g>
+
+    <!-- direct line straight to PHI, gate broken -->
+    <path d="M200 280 H640" stroke="#e5484d" stroke-width="3.4" marker-end="url(#lsArrR)" stroke-dasharray="12 7"/>
+    <g transform="translate(370 236)">
+      <rect width="90" height="88" rx="6" fill="#131c2e" stroke="#5b3140" stroke-width="2"/>
+      <line x1="12" y1="12" x2="78" y2="76" stroke="#e5484d" stroke-width="4"/>
+      <line x1="78" y1="12" x2="12" y2="76" stroke="#e5484d" stroke-width="4"/>
+      <text x="45" y="112" fill="#8fa0bd" font-size="12.5" text-anchor="middle">no disclosure · no check</text>
+    </g>
+
+    <!-- exposed PHI vault -->
+    <g transform="translate(600 216)">
+      <rect width="128" height="128" rx="10" fill="url(#lsSteel)" stroke="#5b3140" stroke-width="2.4"/>
+      <rect x="18" y="34" width="92" height="12" rx="3" fill="#e5484d" opacity=".75"/>
+      <rect x="18" y="58" width="70" height="12" rx="3" fill="#e5484d" opacity=".55"/>
+      <rect x="18" y="82" width="84" height="12" rx="3" fill="#e5484d" opacity=".4"/>
+      <text x="64" y="24" fill="#f2a6a9" font-size="13.5" font-weight="700" text-anchor="middle">PHI</text>
+      <text x="64" y="152" fill="#8fa0bd" font-size="12.5" text-anchor="middle">data moves before identity is known</text>
+    </g>
+
+    <!-- infinite latency dial -->
+    <g transform="translate(330 420)">
+      <circle cx="70" cy="40" r="38" fill="#131c2e" stroke="#5b3140" stroke-width="2.2"/>
+      <text x="70" y="52" fill="#f2a6a9" font-size="30" font-weight="800" text-anchor="middle">∞</text>
+      <text x="70" y="102" fill="#8fa0bd" font-size="13" text-anchor="middle">impersonation latency</text>
+    </g>
+
+    <!-- ══════ RIGHT: verified pathway ══════ -->
+    <text x="1200" y="66" fill="#6ee7d5" font-size="24" font-weight="800" text-anchor="middle" letter-spacing="1.5">WITH NHID-CLINICAL v1.3</text>
+    <text x="1200" y="94" fill="#8fa0bd" font-size="14.5" text-anchor="middle">a measurable, testable trust pathway</text>
+
+    <!-- disclosed caller -->
+    <g>
+      <circle cx="920" cy="280" r="46" fill="#0e2230" stroke="#14B8A6" stroke-width="2.4"/>
+      <text x="920" y="272" fill="#6ee7d5" font-size="15.5" font-weight="800" text-anchor="middle">AI</text>
+      <text x="920" y="294" fill="#8fa0bd" font-size="11" text-anchor="middle">disclosed</text>
+      <circle cx="953" cy="247" r="10" fill="#14B8A6"/>
+      <path d="M948 247 l4 5 7 -9" stroke="#06222b" stroke-width="2.4" fill="none"/>
+      <text x="920" y="352" fill="#8fa0bd" font-size="13.5" text-anchor="middle">identity asserted up front</text>
+    </g>
+
+    <!-- gate 1: IDG-01 -->
+    <path d="M968 280 H1030" stroke="#2dd4bf" stroke-width="3.2" marker-end="url(#lsArrT)"/>
+    <g transform="translate(1034 232)">
+      <rect width="84" height="96" rx="6" fill="#0d1626" stroke="#14B8A6" stroke-width="2"/>
+      <path d="M42 20 v34 M26 37 h32" stroke="#2dd4bf" stroke-width="3.2"/>
+      <text x="42" y="82" fill="#6ee7d5" font-size="13.5" font-weight="700" text-anchor="middle">IDG-01</text>
+      <text x="42" y="118" fill="#8fa0bd" font-size="12" text-anchor="middle">disclosure gate</text>
+    </g>
+
+    <!-- gate 2: PDX-01 -->
+    <path d="M1122 280 H1180" stroke="#2dd4bf" stroke-width="3.2" marker-end="url(#lsArrT)"/>
+    <g transform="translate(1184 232)">
+      <rect width="84" height="96" rx="6" fill="#0d1626" stroke="#14B8A6" stroke-width="2"/>
+      <circle cx="42" cy="40" r="17" fill="none" stroke="#2dd4bf" stroke-width="3"/>
+      <path d="M35 40 l5 6 11 -13" stroke="#2dd4bf" stroke-width="3" fill="none"/>
+      <text x="42" y="82" fill="#6ee7d5" font-size="13.5" font-weight="700" text-anchor="middle">PDX-01</text>
+      <text x="42" y="118" fill="#8fa0bd" font-size="12" text-anchor="middle">verify before PHI</text>
+    </g>
+
+    <!-- sealed PHI vault + human escalation -->
+    <path d="M1272 280 H1330" stroke="#2dd4bf" stroke-width="3.2" marker-end="url(#lsArrT)"/>
+    <g transform="translate(1334 216)">
+      <rect width="128" height="128" rx="10" fill="url(#lsSteel)" stroke="#14B8A6" stroke-width="2.4"/>
+      <rect x="44" y="46" width="40" height="34" rx="5" fill="#0d1626" stroke="#2dd4bf" stroke-width="2.4"/>
+      <path d="M52 46 v-9 a12 12 0 0 1 24 0 v9" stroke="#2dd4bf" stroke-width="2.6" fill="none"/>
+      <circle cx="64" cy="62" r="4" fill="#2dd4bf"/>
+      <text x="64" y="24" fill="#6ee7d5" font-size="13.5" font-weight="700" text-anchor="middle">PHI</text>
+      <text x="64" y="152" fill="#8fa0bd" font-size="12.5" text-anchor="middle">exchange after verification (EIT-01 · ATR-01)</text>
+    </g>
+
+    <!-- measurable latency dial -->
+    <g transform="translate(1130 420)">
+      <circle cx="70" cy="40" r="38" fill="#0d1626" stroke="#14B8A6" stroke-width="2.2"/>
+      <path d="M70 40 L70 14" stroke="#2dd4bf" stroke-width="3.2"/>
+      <path d="M70 40 L90 48" stroke="#6ee7d5" stroke-width="2.4"/>
+      <circle cx="70" cy="40" r="4" fill="#2dd4bf"/>
+      <text x="70" y="102" fill="#8fa0bd" font-size="13" text-anchor="middle">measurable trust delay</text>
+    </g>
+
+    <!-- verified pulse -->
+    <circle r="5.5" fill="#2dd4bf" filter="url(#lsSoft)">
+      <animateMotion dur="4.6s" repeatCount="indefinite" path="M968 280 H1330"/>
+    </circle>
+  </g>
+</svg>

--- a/assets/images/3d-svg/nexus.svg
+++ b/assets/images/3d-svg/nexus.svg
@@ -1,0 +1,124 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1600 640" role="img" aria-labelledby="nx-t nx-d">
+  <title id="nx-t">Governance Trust Nexus — conceptual visualization</title>
+  <desc id="nx-d">Illustrative visualization of a verification bridge spanning the gap between payer and provider domains, with glowing teal pathways representing identity disclosure and verification protocols. Conceptual render for clarity; not a product diagram.</desc>
+  <defs>
+    <linearGradient id="nxSky" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#0F172A"/><stop offset=".65" stop-color="#0a1122"/><stop offset="1" stop-color="#070c18"/>
+    </linearGradient>
+    <radialGradient id="nxGlow" cx=".5" cy=".38" r=".62">
+      <stop offset="0" stop-color="#14B8A6" stop-opacity=".28"/><stop offset=".5" stop-color="#14B8A6" stop-opacity=".07"/><stop offset="1" stop-color="#14B8A6" stop-opacity="0"/>
+    </radialGradient>
+    <linearGradient id="nxPylon" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0" stop-color="#1e293b"/><stop offset=".5" stop-color="#334155"/><stop offset="1" stop-color="#15202f"/>
+    </linearGradient>
+    <linearGradient id="nxDeck" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#475569"/><stop offset=".5" stop-color="#293548"/><stop offset="1" stop-color="#151d2c"/>
+    </linearGradient>
+    <linearGradient id="nxBeam" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0" stop-color="#14B8A6" stop-opacity="0"/><stop offset=".5" stop-color="#2dd4bf"/><stop offset="1" stop-color="#14B8A6" stop-opacity="0"/>
+    </linearGradient>
+    <linearGradient id="nxGold" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#e7c877"/><stop offset="1" stop-color="#8a6c25"/>
+    </linearGradient>
+    <filter id="nxBlur"><feGaussianBlur stdDeviation="7"/></filter>
+    <filter id="nxSoft"><feGaussianBlur stdDeviation="1.4"/></filter>
+  </defs>
+
+  <rect width="1600" height="640" fill="url(#nxSky)"/>
+  <rect width="1600" height="640" fill="url(#nxGlow)"/>
+
+  <!-- starfield / data particles -->
+  <g fill="#94a3b8" opacity=".5">
+    <circle cx="140" cy="90" r="1.4"/><circle cx="340" cy="60" r="1"/><circle cx="520" cy="130" r="1.2"/>
+    <circle cx="760" cy="55" r="1.5"/><circle cx="980" cy="100" r="1"/><circle cx="1180" cy="70" r="1.3"/>
+    <circle cx="1370" cy="120" r="1"/><circle cx="1500" cy="80" r="1.4"/><circle cx="640" cy="170" r="1"/>
+    <circle cx="1080" cy="160" r="1.1"/><circle cx="240" cy="180" r="1"/><circle cx="1460" cy="190" r="1.2"/>
+  </g>
+
+  <!-- chasm between domains -->
+  <path d="M0 520 L560 520 Q620 470 660 620 L0 640 Z" fill="#0b1424"/>
+  <path d="M1600 520 L1040 520 Q980 470 940 620 L1600 640 Z" fill="#0b1424"/>
+  <path d="M660 620 Q800 700 940 620 L1600 640 L0 640 Z" fill="#060a14"/>
+  <path d="M660 618 Q800 690 940 618" stroke="#14B8A6" stroke-opacity=".35" stroke-width="2" fill="none" filter="url(#nxSoft)"/>
+
+  <!-- PAYER citadel (left) -->
+  <g>
+    <rect x="120" y="300" width="200" height="220" fill="url(#nxPylon)" stroke="#3b4a63" stroke-width="1.5"/>
+    <rect x="150" y="250" width="140" height="60" fill="#26334a" stroke="#3b4a63"/>
+    <rect x="185" y="205" width="70" height="55" fill="#1c2941" stroke="#3b4a63"/>
+    <rect x="212" y="168" width="16" height="42" fill="url(#nxGold)"/>
+    <circle cx="220" cy="160" r="7" fill="#2dd4bf"><animate attributeName="opacity" values="1;.35;1" dur="3.2s" repeatCount="indefinite"/></circle>
+    <g fill="#14B8A6" opacity=".8">
+      <rect x="145" y="330" width="18" height="26"/><rect x="181" y="330" width="18" height="26"/>
+      <rect x="217" y="330" width="18" height="26"/><rect x="253" y="330" width="18" height="26"/>
+      <rect x="145" y="386" width="18" height="26" opacity=".55"/><rect x="217" y="386" width="18" height="26" opacity=".55"/>
+    </g>
+    <text x="220" y="560" fill="#8fa0bd" font-family="Inter,system-ui,sans-serif" font-size="21" font-weight="600" text-anchor="middle" letter-spacing="4">PAYER DOMAIN</text>
+  </g>
+
+  <!-- PROVIDER citadel (right) -->
+  <g>
+    <rect x="1280" y="300" width="200" height="220" fill="url(#nxPylon)" stroke="#3b4a63" stroke-width="1.5"/>
+    <rect x="1310" y="250" width="140" height="60" fill="#26334a" stroke="#3b4a63"/>
+    <rect x="1345" y="205" width="70" height="55" fill="#1c2941" stroke="#3b4a63"/>
+    <rect x="1372" y="168" width="16" height="42" fill="url(#nxGold)"/>
+    <circle cx="1380" cy="160" r="7" fill="#2dd4bf"><animate attributeName="opacity" values=".35;1;.35" dur="3.2s" repeatCount="indefinite"/></circle>
+    <g fill="#14B8A6" opacity=".8">
+      <rect x="1305" y="330" width="18" height="26"/><rect x="1341" y="330" width="18" height="26"/>
+      <rect x="1377" y="330" width="18" height="26"/><rect x="1413" y="330" width="18" height="26"/>
+      <rect x="1341" y="386" width="18" height="26" opacity=".55"/><rect x="1413" y="386" width="18" height="26" opacity=".55"/>
+    </g>
+    <text x="1380" y="560" fill="#8fa0bd" font-family="Inter,system-ui,sans-serif" font-size="21" font-weight="600" text-anchor="middle" letter-spacing="4">PROVIDER DOMAIN</text>
+  </g>
+
+  <!-- verification bridge -->
+  <g>
+    <!-- suspension arcs -->
+    <path d="M320 430 Q800 220 1280 430" stroke="#3b4a63" stroke-width="7" fill="none"/>
+    <path d="M320 430 Q800 236 1280 430" stroke="#0f9c8c" stroke-width="2" fill="none" opacity=".8"/>
+    <!-- deck -->
+    <rect x="300" y="428" width="1000" height="30" fill="url(#nxDeck)" stroke="#3b4a63" stroke-width="1.4"/>
+    <rect x="300" y="424" width="1000" height="5" fill="url(#nxBeam)" filter="url(#nxSoft)"/>
+    <!-- suspender cables -->
+    <g stroke="#334155" stroke-width="2.4">
+      <line x1="440" y1="384" x2="440" y2="428"/><line x1="560" y1="352" x2="560" y2="428"/>
+      <line x1="680" y1="330" x2="680" y2="428"/><line x1="800" y1="323" x2="800" y2="428"/>
+      <line x1="920" y1="330" x2="920" y2="428"/><line x1="1040" y1="352" x2="1040" y2="428"/>
+      <line x1="1160" y1="384" x2="1160" y2="428"/>
+    </g>
+
+    <!-- three verification gates on the deck -->
+    <g font-family="Inter,system-ui,sans-serif" font-size="15.5" font-weight="700" text-anchor="middle">
+      <g>
+        <rect x="528" y="336" width="64" height="92" rx="6" fill="#111c30" stroke="#14B8A6" stroke-width="2"/>
+        <path d="M544 380 h32 M560 364 v32" stroke="#2dd4bf" stroke-width="3.4"/>
+        <text x="560" y="326" fill="#6ee7d5">IDG-01</text>
+        <text x="560" y="478" fill="#8fa0bd" font-weight="500" font-size="13.5">Disclose identity</text>
+      </g>
+      <g>
+        <rect x="768" y="322" width="64" height="106" rx="6" fill="#111c30" stroke="#14B8A6" stroke-width="2"/>
+        <circle cx="800" cy="366" r="15" fill="none" stroke="#2dd4bf" stroke-width="3.2"/>
+        <path d="M794 366 l5 6 9 -12" stroke="#2dd4bf" stroke-width="3.2" fill="none"/>
+        <text x="800" y="312" fill="#6ee7d5">PDX-01</text>
+        <text x="800" y="478" fill="#8fa0bd" font-weight="500" font-size="13.5">Verify before PHI</text>
+      </g>
+      <g>
+        <rect x="1008" y="336" width="64" height="92" rx="6" fill="#111c30" stroke="#14B8A6" stroke-width="2"/>
+        <path d="M1026 396 q14 -26 28 0 M1040 372 a7 7 0 1 0 .1 0" stroke="#2dd4bf" stroke-width="3" fill="none"/>
+        <text x="1040" y="326" fill="#6ee7d5">EIT-01</text>
+        <text x="1040" y="478" fill="#8fa0bd" font-weight="500" font-size="13.5">Human escalation</text>
+      </g>
+    </g>
+
+    <!-- moving verified-call pulse -->
+    <circle r="6.5" fill="#2dd4bf" filter="url(#nxSoft)">
+      <animateMotion dur="6s" repeatCount="indefinite" path="M330 442 H1270"/>
+    </circle>
+    <circle r="13" fill="#14B8A6" opacity=".25" filter="url(#nxBlur)">
+      <animateMotion dur="6s" repeatCount="indefinite" path="M330 442 H1270"/>
+    </circle>
+  </g>
+
+  <!-- ambient reflection -->
+  <ellipse cx="800" cy="612" rx="430" ry="15" fill="#14B8A6" opacity=".07" filter="url(#nxBlur)"/>
+</svg>

--- a/assets/images/3d-svg/trust-stack.svg
+++ b/assets/images/3d-svg/trust-stack.svg
@@ -1,0 +1,120 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 760" role="img" aria-labelledby="tz-t tz-d">
+  <title id="tz-t">Five-Layer Trust Stack — conceptual visualization</title>
+  <desc id="tz-d">Illustrative cross-section of the NHID-Clinical five-layer trust architecture as a stepped monument: network foundation, behavioral disclosure gates, cryptographic authorization, audit ledger, and observability spire. Conceptual render for clarity; layer order matches the specification's five-layer trust stack.</desc>
+  <defs>
+    <linearGradient id="tzBg" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#0F172A"/><stop offset="1" stop-color="#070c18"/>
+    </linearGradient>
+    <radialGradient id="tzHalo" cx=".5" cy=".22" r=".55">
+      <stop offset="0" stop-color="#14B8A6" stop-opacity=".3"/><stop offset="1" stop-color="#14B8A6" stop-opacity="0"/>
+    </radialGradient>
+    <!-- per-layer face gradients: top face lighter, front darker -->
+    <linearGradient id="tzTop" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#46536b"/><stop offset="1" stop-color="#2b3850"/>
+    </linearGradient>
+    <linearGradient id="tzFront" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#243349"/><stop offset="1" stop-color="#141d2f"/>
+    </linearGradient>
+    <linearGradient id="tzVein" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0" stop-color="#14B8A6" stop-opacity="0"/><stop offset=".5" stop-color="#2dd4bf"/><stop offset="1" stop-color="#14B8A6" stop-opacity="0"/>
+    </linearGradient>
+    <linearGradient id="tzGold" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#e7c877"/><stop offset="1" stop-color="#8a6c25"/>
+    </linearGradient>
+    <filter id="tzGlow"><feGaussianBlur stdDeviation="5"/></filter>
+    <filter id="tzSoft"><feGaussianBlur stdDeviation="1.2"/></filter>
+  </defs>
+
+  <rect width="900" height="760" fill="url(#tzBg)"/>
+  <rect width="900" height="760" fill="url(#tzHalo)"/>
+
+  <!-- volumetric side light -->
+  <polygon points="0,0 260,0 120,760 0,760" fill="#14B8A6" opacity=".045" filter="url(#tzGlow)"/>
+
+  <!-- ═ Layer 1 · Network foundation (bottom, widest) ═ -->
+  <g id="l1">
+    <polygon points="110,676 790,676 750,640 150,640" fill="url(#tzTop)" stroke="#4b5a75" stroke-width="1.3"/>
+    <rect x="110" y="676" width="680" height="58" fill="url(#tzFront)" stroke="#33415c" stroke-width="1.3"/>
+    <rect x="110" y="700" width="680" height="3.5" fill="url(#tzVein)" filter="url(#tzSoft)"/>
+    <!-- protocol engravings -->
+    <g stroke="#3f5170" stroke-width="1.4" opacity=".85">
+      <path d="M150 690 h40 M210 690 h24 M254 690 h52 M326 690 h30 M376 690 h44"/>
+      <path d="M470 718 h44 M534 718 h28 M582 718 h50 M652 718 h26 M698 718 h50"/>
+    </g>
+    <text x="450" y="668" fill="#dbe4f2" font-family="Inter,system-ui,sans-serif" font-size="16.5" font-weight="700" text-anchor="middle">LAYER 1 · NETWORK &amp; TRANSPORT FOUNDATION</text>
+  </g>
+
+  <!-- ═ Layer 2 · Behavioral disclosure gates ═ -->
+  <g id="l2">
+    <polygon points="170,584 730,584 694,550 206,550" fill="url(#tzTop)" stroke="#4b5a75" stroke-width="1.3"/>
+    <rect x="170" y="584" width="560" height="56" fill="url(#tzFront)" stroke="#33415c" stroke-width="1.3"/>
+    <rect x="170" y="608" width="560" height="3.5" fill="url(#tzVein)" filter="url(#tzSoft)"/>
+    <!-- gate arches -->
+    <g fill="#0d1626" stroke="#2dd4bf" stroke-width="1.7">
+      <path d="M232 640 v-24 a13 13 0 0 1 26 0 v24 z"/>
+      <path d="M436 640 v-24 a13 13 0 0 1 26 0 v24 z"/>
+      <path d="M640 640 v-24 a13 13 0 0 1 26 0 v24 z"/>
+    </g>
+    <text x="450" y="576" fill="#dbe4f2" font-family="Inter,system-ui,sans-serif" font-size="16.5" font-weight="700" text-anchor="middle">LAYER 2 · BEHAVIORAL DISCLOSURE (IDG-01 · PDX-01 · DBC-01 · EIT-01)</text>
+  </g>
+
+  <!-- ═ Layer 3 · Cryptographic authorization ═ -->
+  <g id="l3">
+    <polygon points="228,492 672,492 640,460 262,460" fill="url(#tzTop)" stroke="#4b5a75" stroke-width="1.3"/>
+    <rect x="228" y="492" width="444" height="54" fill="url(#tzFront)" stroke="#33415c" stroke-width="1.3"/>
+    <rect x="228" y="515" width="444" height="3.5" fill="url(#tzVein)" filter="url(#tzSoft)"/>
+    <!-- chain links + NPI binding sigil -->
+    <g stroke="#e7c877" stroke-width="2" fill="none" opacity=".92">
+      <ellipse cx="300" cy="521" rx="12" ry="7.5"/><ellipse cx="322" cy="521" rx="12" ry="7.5"/><ellipse cx="344" cy="521" rx="12" ry="7.5"/>
+      <ellipse cx="556" cy="521" rx="12" ry="7.5"/><ellipse cx="578" cy="521" rx="12" ry="7.5"/><ellipse cx="600" cy="521" rx="12" ry="7.5"/>
+    </g>
+    <rect x="428" y="505" width="44" height="30" rx="4" fill="#0d1626" stroke="url(#tzGold)" stroke-width="1.8"/>
+    <text x="450" y="525" fill="#e7c877" font-family="Inter,system-ui,sans-serif" font-size="11.5" font-weight="700" text-anchor="middle">NPI</text>
+    <text x="450" y="484" fill="#dbe4f2" font-family="Inter,system-ui,sans-serif" font-size="16.5" font-weight="700" text-anchor="middle">LAYER 3 · CRYPTOGRAPHIC AUTHORIZATION (NHID-Auth v2 · Ed25519)</text>
+  </g>
+
+  <!-- ═ Layer 4 · Audit ledger ═ -->
+  <g id="l4">
+    <polygon points="286,402 614,402 586,372 314,372" fill="url(#tzTop)" stroke="#4b5a75" stroke-width="1.3"/>
+    <rect x="286" y="402" width="328" height="52" fill="url(#tzFront)" stroke="#33415c" stroke-width="1.3"/>
+    <rect x="286" y="424" width="328" height="3.5" fill="url(#tzVein)" filter="url(#tzSoft)"/>
+    <!-- ledger ruling -->
+    <g stroke="#3f5170" stroke-width="1.3">
+      <line x1="304" y1="412" x2="596" y2="412"/><line x1="304" y1="436" x2="596" y2="436"/><line x1="304" y1="446" x2="596" y2="446"/>
+    </g>
+    <g fill="#2dd4bf" opacity=".9">
+      <rect x="318" y="429" width="7" height="4"/><rect x="352" y="429" width="16" height="4"/><rect x="392" y="429" width="10" height="4"/>
+      <rect x="430" y="429" width="20" height="4"/><rect x="476" y="429" width="9" height="4"/><rect x="512" y="429" width="17" height="4"/><rect x="556" y="429" width="11" height="4"/>
+    </g>
+    <text x="450" y="396" fill="#dbe4f2" font-family="Inter,system-ui,sans-serif" font-size="16.5" font-weight="700" text-anchor="middle">LAYER 4 · AUDIT LEDGER (ATR-01)</text>
+  </g>
+
+  <!-- ═ Layer 5 · Observability spire (top) ═ -->
+  <g id="l5">
+    <polygon points="352,314 548,314 526,288 374,288" fill="url(#tzTop)" stroke="#4b5a75" stroke-width="1.3"/>
+    <rect x="352" y="314" width="196" height="48" fill="url(#tzFront)" stroke="#33415c" stroke-width="1.3"/>
+    <text x="450" y="308" fill="#dbe4f2" font-family="Inter,system-ui,sans-serif" font-size="15.5" font-weight="700" text-anchor="middle">LAYER 5 · OBSERVABILITY &amp; CAS</text>
+    <!-- spire + beacon -->
+    <polygon points="436,288 464,288 452,196 448,196" fill="#33415c" stroke="#4b5a75"/>
+    <rect x="443" y="230" width="14" height="26" fill="url(#tzGold)" opacity=".95"/>
+    <circle cx="450" cy="186" r="9" fill="#2dd4bf" filter="url(#tzSoft)">
+      <animate attributeName="opacity" values="1;.3;1" dur="2.8s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="450" cy="186" r="22" fill="#14B8A6" opacity=".2" filter="url(#tzGlow)">
+      <animate attributeName="r" values="18;28;18" dur="2.8s" repeatCount="indefinite"/>
+    </circle>
+    <!-- signal arcs -->
+    <g stroke="#14B8A6" fill="none" opacity=".5">
+      <path d="M416 168 a44 44 0 0 1 68 0" stroke-width="2.4"/>
+      <path d="M400 150 a62 62 0 0 1 100 0" stroke-width="1.8" opacity=".7"/>
+    </g>
+  </g>
+
+  <!-- rising verification pulse through all layers -->
+  <circle r="5" fill="#2dd4bf" filter="url(#tzSoft)">
+    <animateMotion dur="5.5s" repeatCount="indefinite" path="M450 730 V200"/>
+  </circle>
+
+  <!-- ground reflection -->
+  <ellipse cx="450" cy="742" rx="330" ry="11" fill="#14B8A6" opacity=".08" filter="url(#tzGlow)"/>
+</svg>

--- a/developers.html
+++ b/developers.html
@@ -10,6 +10,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=IBM+Plex+Mono:wght@400;500&display=swap" rel="stylesheet"/>
   <link rel="stylesheet" href="/nhid-clinical-ui.css"/>
+  <link rel="stylesheet" href="/assets/css/premium.css"/>
   <script>try{document.documentElement.setAttribute('data-theme',localStorage.getItem('nhid-theme')||'light')}catch(e){}</script>
   <script defer data-domain="nhid-clinical.org" src="https://plausible.io/js/script.js"></script>
 </head>
@@ -376,6 +377,16 @@ python tests/trace_generator.py --offline</pre>
   </section>
 </main>
 
+
+<section class="page-section" style="padding-top:0">
+  <div class="container" style="max-width:60rem">
+    <div class="premium-callout">
+      <h3>Architecture, visualized</h3>
+      <p>The interactive five-layer trust stack on the homepage shows where adapters, the policy engine, NHID-Auth v2, and the audit ledger sit relative to each other.</p>
+      <a href="/#trust-stack">View the Trust Stack →</a>&nbsp;&nbsp; <a href="/simulator.html?scenario=idg-01">Deep-link a scenario: /simulator.html?scenario=idg-01 →</a>&nbsp;&nbsp;
+    </div>
+  </div>
+</section>
 <footer id="contact" class="site-footer">
   <div class="container footer-inner">
     <p>© 2026 Brianna Baynard | NIST-2025-0035-0026 | CC BY 4.0</p>
@@ -387,6 +398,7 @@ python tests/trace_generator.py --offline</pre>
     </div>
 
   </div>
+  <p class="footer-copy" style="margin-top:.4rem">This is a living open proposal — feedback and contributions welcome. <a href="https://github.com/NHID-Clinical/NHID-Clinical">GitHub</a> · NIST-2025-0035-0026 · CC BY 4.0</p>
 </footer>
 
 <script src="/site.js"></script>

--- a/docs/ai-governance-map-enhancement-spec.md
+++ b/docs/ai-governance-map-enhancement-spec.md
@@ -1,0 +1,98 @@
+# AI Governance Map — NHID-Clinical Enhancement Spec
+
+Target: https://ai-governance-map.vercel.app/ (separate repo/deployment; this spec is
+the implementable blueprint). Written 2026-07-05 to match the premium visual layer
+shipped on nhid-clinical.org. Ethos preserved throughout: local-only, no tracking,
+reference tool — NHID-Clinical remains an open voluntary proposal, never a product.
+
+## 1. Visual language sync
+
+- Palette: deep navy `#0F172A` base, teal `#14B8A6` accents, slate/silver text,
+  sparing gold inlays — identical tokens to `assets/css/premium.css` on the site.
+- Feature visuals: reuse the SAME asset set the site ships. Preferred order per slot:
+  `assets/images/3d-renders/<name>.webp` (raster, when generated) →
+  `assets/images/3d-svg/<name>.svg` (always available, self-contained, animated).
+  Copy the SVGs into the map's public/ dir; they are dependency-free.
+- Alt/caption convention (verbatim pattern): "Illustrative 3D visualization of … —
+  conceptual render for clarity." Never present a visual as a product diagram.
+
+## 2. NHID-Clinical panel upgrade
+
+- Header visual: `trust-stack.svg` (or `trust-stack-ziggurat.webp` when present) as
+  a large feature image, framed with the site's `.premium-3d` treatment
+  (12px radius, `#1e2a44` border, deep shadow).
+- Body keeps the existing factual copy; append the standing disclaimer line:
+  "Open voluntary proposal · NIST-2025-0035-0026 · CC BY 4.0 · not a product,
+  not a certification."
+- Primary link back: "Read the v1.3 specification →" (https://nhid-clinical.org/specification.html).
+
+## 3. NEW module: Healthcare Voice Trust Stack Explorer
+
+An interactive five-layer component (mirrors the homepage `#trust-stack` section so
+users see one architecture in both places).
+
+Layer data (id → label → mapped frameworks → deep link):
+
+| id | Label | Maps to (show as chips) | Deep link |
+|---|---|---|---|
+| l1 | Network & Transport Foundation | CCM IVS/DSP transport controls; NIST AI RMF Govern | https://nhid-clinical.org/interoperability.html |
+| l2 | Behavioral Disclosure (IDG-01 · PDX-01 · DBC-01 · EIT-01) | NIST AI RMF Measure/Manage; EU AI Act transparency Art. 50; ISO/IEC 42001 ops | https://nhid-clinical.org/simulator.html?scenario=idg-01 |
+| l3 | Cryptographic Authorization (NHID-Auth v2) | CCM IAM; NIST SP 800-63 alignment notes | https://nhid-clinical.org/developers.html |
+| l4 | Audit Ledger (ATR-01) | CCM LOG/AIS; NIST AI RMF Govern/Map documentation | https://nhid-clinical.org/evidence-pack.html |
+| l5 | Observability & CAS | NIST AI RMF Measure; model-risk monitoring practices | https://nhid-clinical.org/simulator.html |
+
+Behavior:
+- Click/keyboard-select a layer → detail card slides in: what the layer does (2–3
+  sentences, copy from the homepage stack section), mapped-framework chips, the
+  known GAPS the proposal aims at (e.g. "no standard verification pathway today —
+  impersonation latency effectively infinite"), and the deep link above.
+- The simulator deep links WORK today: nhid-clinical.org/simulator.html accepts
+  `?scenario=<name|control-id>` (`idg-01`, `dbc-01` → spoofed-identity; `pdx-01` →
+  eligibility; `eit-01` → handoff; `atr-01` → prior-auth; or the scenario names
+  `prior-auth|expedited|eligibility|handoff|spoofed-identity`).
+- Accessibility: role=tablist/tab/tabpanel, focus-visible teal outline,
+  prefers-reduced-motion disables the slide.
+
+## 4. Globe / USA map enhancement
+
+- Keep the existing rotatable globe/US map; add an OPTIONAL "healthcare voice"
+  overlay toggle: a subtle heat tint labeled explicitly as **illustrative** —
+  "Illustrative overlay: where impersonation-latency exposure concentrates
+  (concept, not measured data)." Never present as real incident data.
+- Premium detailing: darken ocean to `#0a0f1e`, teal graticule at 6% opacity,
+  gold-tinted specular highlight.
+
+## 5. Controls / Posture views
+
+- Cards get a subtle 3D tilt on hover (framer-motion `rotateX/rotateY` ≤ 4°,
+  spring stiffness ~150; disabled under prefers-reduced-motion).
+- Tooltips: richer two-line pattern — line 1 the control name, line 2 the mapped
+  NHID control(s) with a mini deep link.
+
+## 6. Exports
+
+- Report/PDF exports embed the same visuals (SVG rasterized at 2x) with the
+  caption convention from §1, plus the standing disclaimer line from §2 in the
+  footer of every exported page.
+
+## 7. Bidirectional linking (copy, verbatim)
+
+- Site → Map (already live on nhid-clinical.org buttons):
+  "Explore Full Context in AI Governance Map" and, on regulatory pages,
+  "See NHID v1.3 in full multi-framework context (including CCM, NIST, ISO, EU AI Act)".
+- Map → Site: every NHID mention links contextually — controls to
+  `/specification.html`, hands-on to `/simulator.html?scenario=…`, procurement to
+  `/for-payers.html`, code to the GitHub repo.
+
+## 8. Guardrails (non-negotiable)
+
+- No product CTAs, pricing, signup, or certification language.
+- Local-only/no-tracking ethos unchanged; no third-party analytics added.
+- Every illustrative visual is captioned as such.
+
+## Implementation note
+
+If the map's repository is added to this session (`add_repo`), this spec can be
+implemented directly; the asset files referenced in §1 already exist in this repo
+under `assets/images/3d-svg/` and the prompts for the raster set under
+`assets/images/3d-renders/PROMPTS.md`.

--- a/for-payers.html
+++ b/for-payers.html
@@ -10,6 +10,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=IBM+Plex+Mono:wght@400;500&display=swap" rel="stylesheet"/>
   <link rel="stylesheet" href="/nhid-clinical-ui.css"/>
+  <link rel="stylesheet" href="/assets/css/premium.css"/>
   <script>try{document.documentElement.setAttribute('data-theme',localStorage.getItem('nhid-theme')||'light')}catch(e){}</script>
   <style>
     .step-num {
@@ -341,6 +342,16 @@
   </section>
 </main>
 
+
+<section class="page-section" style="padding-top:0">
+  <div class="container" style="max-width:60rem">
+    <div class="premium-callout">
+      <h3>Procurement &amp; Shadow Evaluation, at a glance</h3>
+      <p>A 90-day shadow evaluation runs beside your live traffic: no vendor changes, no production risk, deterministic evidence out. Checklist: (1) pick one call type, (2) mirror transcripts to the conformance API, (3) review the evidence bundle with your compliance team.</p>
+      <a href="/shadow-evaluation-guide.html">Read the Shadow Evaluation Guide →</a>&nbsp;&nbsp; <a href="/evidence-pack.html">See what the evidence looks like →</a>&nbsp;&nbsp;
+    </div>
+  </div>
+</section>
 <footer id="contact" class="site-footer">
   <div class="container footer-inner">
     <p>© 2026 Brianna Baynard | NIST-2025-0035-0026 | CC BY 4.0</p>
@@ -352,6 +363,7 @@
     </div>
 
   </div>
+  <p class="footer-copy" style="margin-top:.4rem">This is a living open proposal — feedback and contributions welcome. <a href="https://github.com/NHID-Clinical/NHID-Clinical">GitHub</a> · NIST-2025-0035-0026 · CC BY 4.0</p>
 </footer>
 
 <script src="/site.js"></script>

--- a/index.html
+++ b/index.html
@@ -10,6 +10,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=IBM+Plex+Mono:wght@400;500&display=swap" rel="stylesheet"/>
   <link rel="stylesheet" href="/nhid-clinical-ui.css"/>
+  <link rel="stylesheet" href="/assets/css/premium.css"/>
   <script>try{document.documentElement.setAttribute('data-theme',localStorage.getItem('nhid-theme')||'light')}catch(e){}</script>
   <script defer data-domain="nhid-clinical.org" src="https://plausible.io/js/script.js"></script>
 </head>
@@ -124,29 +125,37 @@
 
 <main>
 
-  <!-- ── Section 1: Hero ─────────────────────────────────────────────────── -->
-  <section class="hero-section">
-    <div class="container hero-grid">
-      <div class="hero-copy">
-        <h1>NHID-Clinical</h1>
-        <p class="hero-body"><strong>Practical controls for AI voice agents in payer–provider calls, built by a former payer operations associate who saw the problem firsthand on live calls.</strong></p>
-        <p class="hero-body">I worked in payer operations — eligibility, claims, prior authorization — protecting PHI on live calls. Starting in 2025, our call center began receiving AI voice agents calling on behalf of provider offices. They passed verification, so we treated them as regular calls. Over time the problems became consistent: disclosure after PHI had already moved, no way to verify authorization, no escalation path. This project documents those patterns and proposes a voluntary, testable behavioral baseline. It is not a standard and not a certification. It is an open reference implementation.</p>
-        <div class="callout">
-          <strong>Current state:</strong>
-          The v1.3 conformance API is live — no key required for demo and vendor routes.
-          VAPI and Twilio adapters accept native call payloads and return a pass/fail result.
-          The v2 cryptographic authorization layer is public reference code in the repository.
-          Zero production pilots — we are seeking the first shadow evaluation partners.
-          — <a href="/for-payers.html">Start a shadow evaluation →</a>
-        </div>
-        <p class="hero-body" style="margin-top:1rem;font-size:.9rem;color:var(--ink-soft)">CC BY 4.0 &nbsp;·&nbsp; NIST Public Comment: NIST-2025-0035-0026</p>
-        <div class="hero-actions" style="flex-wrap:wrap;gap:.75rem">
-          <a class="secondary-button" href="/simulator.html">Governance Simulator <span aria-hidden="true">→</span></a>
-        </div>
+  <!-- ── Section 1: Cinematic Hero ───────────────────────────────────────── -->
+  <section class="section-premium hero-premium">
+    <div class="container">
+      <span class="hero-kicker">Open proposal · v1.3 behavioral baseline</span>
+      <h1>NHID-Clinical</h1>
+      <p class="tagline">Open Behavioral Baseline for Transparent AI Voice Agents in Healthcare</p>
+      <p class="disclaimer"><strong>Practical controls for AI voice agents in payer–provider calls, built by a former payer operations associate who saw the problem firsthand on live calls.</strong></p>
+      <p class="disclaimer">I worked in payer operations — eligibility, claims, prior authorization — protecting PHI on live calls. Starting in 2025, our call center began receiving AI voice agents calling on behalf of provider offices. They passed verification, so we treated them as regular calls. Over time the problems became consistent: disclosure after PHI had already moved, no way to verify authorization, no escalation path. This project documents those patterns and proposes a voluntary, testable behavioral baseline. It is not a standard and not a certification. It is an open reference implementation.</p>
+      <p class="disclaimer">A voluntary, testable reference implementation. Submitted as public comment to NIST (NIST-2025-0035-0026). <strong>Not a product. Not a certification. Not an official standard.</strong> An open proposal for the ecosystem. CC&nbsp;BY&nbsp;4.0.</p>
+
+      <div class="hero-actions-premium">
+        <a href="/specification.html" class="btn-premium">Read the v1.3 Specification</a>
+        <a href="/simulator.html" class="btn-premium">Launch Governance Simulator</a>
+        <a href="https://ai-governance-map.vercel.app/" class="btn-ghost">Explore Full Context in AI Governance Map</a>
+        <a href="https://github.com/NHID-Clinical/NHID-Clinical" class="btn-ghost">GitHub · Contribute</a>
       </div>
-      <div class="hero-art" aria-label="NHID-Clinical logo">
-        <img class="theme-img theme-img-light" src="/assets/logo-light.jpg" alt="NHID-Clinical" />
-        <img class="theme-img theme-img-dark" src="/assets/logo-dark.jpg" alt="NHID-Clinical" />
+
+      <picture class="premium-3d">
+        <source srcset="/assets/images/3d-renders/nexus-trust-bridge.webp" type="image/webp"/>
+        <img src="/assets/images/3d-svg/nexus.svg" class="premium-3d"
+             alt="Illustrative 3D visualization of the NHID-Clinical Trust Verification Nexus — a verification bridge between payer and provider domains with disclosure, verification, and escalation gates. Conceptual render for clarity."/>
+      </picture>
+      <p class="visual-caption">Illustrative visualization of the trust verification pathway — conceptual render for clarity, not a product diagram.</p>
+
+      <div class="callout" style="margin-top:2rem;background:rgba(148,163,184,.07);border:1px solid var(--premium-line);color:#b7c3d8">
+        <strong style="color:#e2e8f0">Current state:</strong>
+        The v1.3 conformance API is live — no key required for demo and vendor routes.
+        VAPI and Twilio adapters accept native call payloads and return a pass/fail result.
+        The v2 cryptographic authorization layer is public reference code in the repository.
+        Zero production pilots — we are seeking the first shadow evaluation partners.
+        — <a href="/for-payers.html">Start a shadow evaluation →</a>
       </div>
     </div>
   </section>
@@ -161,6 +170,104 @@
         </div>
         <a class="cta-button" href="/for-payers.html" style="flex-shrink:0;white-space:nowrap">Become a Pilot Partner <span aria-hidden="true">→</span></a>
       </div>
+    </div>
+  </section>
+
+  <!-- ── Visualizing the Five-Layer Trust Stack ──────────────────────────── -->
+  <section class="section-premium" id="trust-stack">
+    <div class="container">
+      <h2>Visualizing the Five-Layer Trust Stack</h2>
+      <p class="lead">The proposal's architecture in one picture: each layer is testable on its own, and together they turn "trust me" into a verifiable pathway. Click a layer to see what it does and where to try it.</p>
+      <div class="stack-wrap">
+        <div>
+          <picture class="premium-3d">
+            <source srcset="/assets/images/3d-renders/trust-stack-ziggurat.webp" type="image/webp"/>
+            <img src="/assets/images/3d-svg/trust-stack.svg" class="premium-3d" style="max-width:34rem"
+                 alt="Illustrative 3D visualization of the NHID-Clinical five-layer trust stack as a stepped monument: network foundation, behavioral disclosure gates, cryptographic authorization, audit ledger, observability spire. Conceptual render for clarity."/>
+          </picture>
+          <p class="visual-caption">Conceptual render for clarity — the authoritative definitions live in the specification.</p>
+        </div>
+        <div>
+          <div role="tablist" aria-label="Trust stack layers" style="display:flex;flex-direction:column;gap:.5rem;margin-bottom:1rem">
+            <button class="btn-ghost stack-layer" role="tab" data-layer="l5" aria-selected="false">Layer 5 · Observability &amp; CAS</button>
+            <button class="btn-ghost stack-layer" role="tab" data-layer="l4" aria-selected="false">Layer 4 · Audit Ledger (ATR-01)</button>
+            <button class="btn-ghost stack-layer" role="tab" data-layer="l3" aria-selected="false">Layer 3 · Cryptographic Authorization (NHID-Auth v2)</button>
+            <button class="btn-ghost stack-layer active" role="tab" data-layer="l2" aria-selected="true">Layer 2 · Behavioral Disclosure Controls</button>
+            <button class="btn-ghost stack-layer" role="tab" data-layer="l1" aria-selected="false">Layer 1 · Network &amp; Transport Foundation</button>
+          </div>
+          <div class="stack-detail" id="stack-detail" role="tabpanel" aria-live="polite"></div>
+        </div>
+      </div>
+      <p class="disclaimer-small">This is an open voluntary reference implementation, not a product or certification. Layer definitions and control text are normative only in the <a href="/specification.html">v1.3 specification</a>.</p>
+    </div>
+  </section>
+
+  <script>
+  (function(){
+    var LAYERS = {
+      l1: { tag: "Layer 1", title: "Network & Transport Foundation",
+        body: "The carrier plumbing every call rides on — SIP, telephony metadata, transport security. NHID-Clinical does not replace it; it builds testable behavior on top of it and proposes SIP-header attestation hooks for the future.",
+        links: [["Interoperability notes","/interoperability.html"],["Technical stack","/technical-stack.html"]] },
+      l2: { tag: "Layer 2", title: "Behavioral Disclosure Controls (IDG-01 · PDX-01 · DBC-01 · EIT-01)",
+        body: "The heart of v1.3: disclose non-human identity before anything else (IDG-01), verify before any PHI moves (PDX-01), never imply a human is speaking (DBC-01), and honor a request for a human (EIT-01). Each is deterministic and testable.",
+        links: [["Try in Simulator","/simulator.html?scenario=spoofed-identity"],["Read the controls","/specification.html"]] },
+      l3: { tag: "Layer 3", title: "Cryptographic Authorization (NHID-Auth v2)",
+        body: "Ed25519 agent passports: a provider signs a delegation binding an agent key to an NPI and scope; the receiving side verifies offline. Reference code is public in the repository — no registry, no gatekeeper.",
+        links: [["Developer guide","/developers.html"],["v2 integration","/technical-stack.html"]] },
+      l4: { tag: "Layer 4", title: "Audit Ledger (ATR-01)",
+        body: "Every event carries a complete, replayable audit envelope — actor, timestamps, state transitions, execution context. Missing fields are CRITICAL findings. Evidence, not vibes.",
+        links: [["Evidence pack","/evidence-pack.html"],["Audit requirements","/specification.html"]] },
+      l5: { tag: "Layer 5", title: "Observability & Call Authorization Score",
+        body: "CAS condenses identity assurance, operational confidence, and envelope completeness into one 0–1 score with plain trust tiers. Below the conditional-trust threshold, a human reviews. Scores are measurements, not certifications.",
+        links: [["Governance Simulator","/simulator.html"],["For payers","/for-payers.html"]] }
+    };
+    var detail = document.getElementById("stack-detail");
+    var tabs = document.querySelectorAll(".stack-layer");
+    function show(id){
+      var L = LAYERS[id]; if(!L || !detail) return;
+      detail.innerHTML = '<span class="layer-tag">'+L.tag+'</span><h3>'+L.title+'</h3><p>'+L.body+'</p>'+
+        '<div class="stack-links">'+L.links.map(function(a){return '<a href="'+a[1]+'">'+a[0]+' →</a>';}).join("")+'</div>';
+      tabs.forEach(function(t){ var on = t.dataset.layer===id; t.classList.toggle("active",on); t.setAttribute("aria-selected", on?"true":"false"); });
+    }
+    tabs.forEach(function(t){ t.addEventListener("click", function(){ show(t.dataset.layer); }); });
+    show("l2");
+  })();
+  </script>
+
+  <!-- ── The Impersonation Latency Crisis ────────────────────────────────── -->
+  <section class="section-premium" id="latency-problem" style="padding-top:3.5rem">
+    <div class="container">
+      <h2>The Impersonation Latency Crisis</h2>
+      <p class="lead">Impersonation latency is the measurable trust delay between an AI agent initiating a call and the receiving system verifying that the caller is authorized to represent the claimed provider organization. In many current healthcare workflows, that delay is effectively infinite — because no standard verification pathway exists.</p>
+
+      <picture class="premium-3d">
+        <source srcset="/assets/images/3d-renders/impersonation-vs-verified.webp" type="image/webp"/>
+        <img src="/assets/images/3d-svg/latency-split.svg" class="premium-3d"
+             alt="Illustrative 3D visualization contrasting the impersonation latency problem (left: an unverified caller reaching PHI with no checks) with the verified trust pathway enabled by NHID-Clinical (right: disclosure gate, verification checkpoint, sealed PHI, human escalation). Conceptual render for clarity."/>
+      </picture>
+
+      <div class="two-column">
+        <div class="col-bad">
+          <h3>Without a Standard</h3>
+          <ul>
+            <li>No proactive identity disclosure</li>
+            <li>PHI potentially exchanged before verification</li>
+            <li>No consistent escalation or audit trail</li>
+            <li>Infinite trust delay for the receiving system</li>
+          </ul>
+        </div>
+        <div class="col-good">
+          <h3>With NHID-Clinical v1.3</h3>
+          <ul>
+            <li>Mandatory early disclosure gate (IDG-01)</li>
+            <li>Pre-data exchange verification checkpoint (PDX-01)</li>
+            <li>Defined human handoff + full audit requirements (EIT-01 · ATR-01)</li>
+            <li>Measurable, testable trust pathway</li>
+          </ul>
+        </div>
+      </div>
+
+      <p class="disclaimer-small">This is an open voluntary reference implementation, not a product or certification. It is contributed to improve ecosystem trust and has been submitted as public comment to NIST (NIST-2025-0035-0026).</p>
     </div>
   </section>
 
@@ -346,6 +453,7 @@
     </div>
     <p class="footer-copy">© 2026 Brianna Baynard | NIST-2025-0035-0026 | CC BY 4.0 | contact@nhid-clinical.org | nhid-clinical.org</p>
   </div>
+  <p class="footer-copy" style="margin-top:.4rem">This is a living open proposal — feedback and contributions welcome. <a href="https://github.com/NHID-Clinical/NHID-Clinical">GitHub</a> · NIST-2025-0035-0026 · CC BY 4.0</p>
 </footer>
 
 <script src="/site.js"></script>

--- a/regulatory-alignment.html
+++ b/regulatory-alignment.html
@@ -10,6 +10,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=IBM+Plex+Mono:wght@400;500&display=swap" rel="stylesheet"/>
   <link rel="stylesheet" href="/nhid-clinical-ui.css"/>
+  <link rel="stylesheet" href="/assets/css/premium.css"/>
   <script>try{document.documentElement.setAttribute('data-theme',localStorage.getItem('nhid-theme')||'light')}catch(e){}</script>
   <script defer data-domain="nhid-clinical.org" src="https://plausible.io/js/script.js"></script>
 </head>
@@ -219,6 +220,16 @@
   </section>
 </main>
 
+
+<section class="page-section" style="padding-top:0">
+  <div class="container" style="max-width:60rem">
+    <div class="premium-callout">
+      <h3>NHID v1.3 in full multi-framework context</h3>
+      <p>See how the proposal sits alongside CCM, NIST, ISO, and the EU AI Act — including the gaps it aims to close.</p>
+      <a href="https://ai-governance-map.vercel.app/">Open the AI Governance Map →</a>&nbsp;&nbsp;
+    </div>
+  </div>
+</section>
 <footer id="contact" class="site-footer">
   <div class="container footer-inner">
     <p>&copy; 2026 Brianna Baynard | NIST-2025-0035-0026 | CC BY 4.0</p>
@@ -229,6 +240,7 @@
       <a href="https://twitter.com/NHIDClinical">@NHIDClinical</a>
     </div>
   </div>
+  <p class="footer-copy" style="margin-top:.4rem">This is a living open proposal — feedback and contributions welcome. <a href="https://github.com/NHID-Clinical/NHID-Clinical">GitHub</a> · NIST-2025-0035-0026 · CC BY 4.0</p>
 </footer>
 
 <script src="/site.js"></script>

--- a/roadmap.html
+++ b/roadmap.html
@@ -10,6 +10,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=IBM+Plex+Mono:wght@400;500&display=swap" rel="stylesheet"/>
   <link rel="stylesheet" href="/nhid-clinical-ui.css"/>
+  <link rel="stylesheet" href="/assets/css/premium.css"/>
   <script>try{document.documentElement.setAttribute('data-theme',localStorage.getItem('nhid-theme')||'light')}catch(e){}</script>
   <script defer data-domain="nhid-clinical.org" src="https://plausible.io/js/script.js"></script>
 </head>
@@ -254,6 +255,16 @@ python examples/issue_and_verify.py          # end-to-end credential walkthrough
   </section>
 </main>
 
+
+<section class="page-section" style="padding-top:0">
+  <div class="container" style="max-width:60rem">
+    <div class="premium-callout">
+      <h3>Where this is heading</h3>
+      <p>Milestones are commitments to the open proposal, not product promises. Pilot results directly shape v2.</p>
+      <a href="/for-payers.html">Become a shadow-evaluation partner →</a>&nbsp;&nbsp;
+    </div>
+  </div>
+</section>
 <footer id="contact" class="site-footer">
   <div class="container footer-inner">
     <p>© 2026 Brianna Baynard | NIST-2025-0035-0026 | CC BY 4.0</p>
@@ -265,6 +276,7 @@ python examples/issue_and_verify.py          # end-to-end credential walkthrough
     </div>
     <p class="footer-copy">© 2026 Brianna Baynard | NIST-2025-0035-0026 | CC BY 4.0 | contact@nhid-clinical.org | nhid-clinical.org</p>
   </div>
+  <p class="footer-copy" style="margin-top:.4rem">This is a living open proposal — feedback and contributions welcome. <a href="https://github.com/NHID-Clinical/NHID-Clinical">GitHub</a> · NIST-2025-0035-0026 · CC BY 4.0</p>
 </footer>
 
 <script src="/site.js"></script>

--- a/scripts/confusion_matrix.py
+++ b/scripts/confusion_matrix.py
@@ -51,7 +51,15 @@ def load(argv: list[str]) -> list[dict]:
     raise SystemExit(__doc__)
 
 
-def run(conversations: list[dict]) -> None:
+def compute(conversations: list[dict]) -> dict:
+    """Pure confusion-matrix computation shared by the CLI and other callers.
+
+    Detection is measured over conversations that declare each control in
+    `expected_violations`; false positives over the DISJOINT population of
+    conversations whose `scenario_type == "compliant"`. ATR-01 is excluded
+    (untestable in transcript replay). Returns structured results; prints
+    nothing.
+    """
     detect = {c: {"expected": 0, "detected": 0, "missed": []} for c in ALL_CONTROLS}
     fp = {c: {"clean": 0, "fp": 0, "fp_ids": []} for c in ALL_CONTROLS}
 
@@ -80,6 +88,33 @@ def run(conversations: list[dict]) -> None:
                 if ctrl in detected and ctrl not in expected:
                     fp[ctrl]["fp"] += 1
                     fp[ctrl]["fp_ids"].append(cid)
+
+    controls = []
+    for ctrl in ALL_CONTROLS:
+        d, f = detect[ctrl], fp[ctrl]
+        controls.append({
+            "control": ctrl,
+            "expected": d["expected"],
+            "detected": d["detected"],
+            "detection_rate": (d["detected"] / d["expected"]) if d["expected"] else None,
+            "missed": d["missed"],
+            "clean": f["clean"],
+            "fp": f["fp"],
+            "fp_rate": (f["fp"] / f["clean"]) if f["clean"] else None,
+            "fp_ids": f["fp_ids"],
+        })
+    return {"n_conversations": len(conversations),
+            "n_compliant": n_compliant, "controls": controls}
+
+
+def run(conversations: list[dict]) -> None:
+    result = compute(conversations)
+    by = {c["control"]: c for c in result["controls"]}
+    detect = {c: {"expected": by[c]["expected"], "detected": by[c]["detected"],
+                  "missed": by[c]["missed"]} for c in ALL_CONTROLS}
+    fp = {c: {"clean": by[c]["clean"], "fp": by[c]["fp"],
+              "fp_ids": by[c]["fp_ids"]} for c in ALL_CONTROLS}
+    n_compliant = result["n_compliant"]
 
     print(f"\nCorpus: {len(conversations)} conversations "
           f"({n_compliant} scenario_type=compliant)\n")

--- a/simulator.html
+++ b/simulator.html
@@ -10,6 +10,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=IBM+Plex+Mono:wght@400;500&display=swap" rel="stylesheet"/>
   <link rel="stylesheet" href="/nhid-clinical-ui.css"/>
+  <link rel="stylesheet" href="/assets/css/premium.css"/>
   <script>try{document.documentElement.setAttribute('data-theme',localStorage.getItem('nhid-theme')||'light')}catch(e){}</script>
   <style>
 /* ── Simulator variables (extend site palette) ──────────────── */
@@ -453,6 +454,7 @@
 
       <div class="sim-sb-foot">
         <button class="sim-run-btn" id="run-btn" type="button">Run Simulation</button>
+        <a class="btn-ghost" href="/evidence-pack.html" style="display:block;text-align:center;margin-top:.6rem;color:var(--ink);border-color:var(--line)">Download Evidence Bundle →</a>
         <p class="sim-foot-disc">Synthetic data only. Same inputs → identical trace output.</p>
       </div>
     </aside>
@@ -1252,6 +1254,28 @@ document.getElementById('try-failing-btn').addEventListener('click',function(){
   document.querySelectorAll('input[name="b"]').forEach(function(b){b.checked=false;});
   document.getElementById('run-btn').click();
 });
+
+/* ── Deep-link support: ?scenario=<name|control-id> pre-selects a scenario.
+   Lets external tools (e.g. the AI Governance Map) link straight into a
+   pre-loaded scenario. Control IDs map to the closest scenario. ─────────── */
+(function(){
+  var q=new URLSearchParams(window.location.search).get('scenario');
+  if(!q) return;
+  q=q.toLowerCase();
+  var ALIAS={
+    'idg-01':'spoofed-identity','idg01':'spoofed-identity',
+    'dbc-01':'spoofed-identity','dbc01':'spoofed-identity',
+    'pdx-01':'eligibility','pdx01':'eligibility',
+    'eit-01':'handoff','eit01':'handoff',
+    'atr-01':'prior-auth','atr01':'prior-auth'
+  };
+  var key=SC[q]?q:ALIAS[q];
+  if(key&&SC[key]){
+    scEl.value=key;
+    scEl.dispatchEvent(new Event('change'));
+    scEl.scrollIntoView({block:'center'});
+  }
+})();
 
 })();
 </script>

--- a/specification.html
+++ b/specification.html
@@ -10,6 +10,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=IBM+Plex+Mono:wght@400;500&display=swap" rel="stylesheet"/>
   <link rel="stylesheet" href="/nhid-clinical-ui.css"/>
+  <link rel="stylesheet" href="/assets/css/premium.css"/>
   <script>try{document.documentElement.setAttribute('data-theme',localStorage.getItem('nhid-theme')||'light')}catch(e){}</script>
   <!-- Mermaid CDN -->
   <script src="https://cdn.jsdelivr.net/npm/mermaid@10/dist/mermaid.min.js"></script>
@@ -271,6 +272,16 @@ sequenceDiagram
   </section>
 </main>
 
+
+<section class="page-section" style="padding-top:0">
+  <div class="container" style="max-width:60rem">
+    <div class="premium-callout">
+      <h3>See this specification in multi-framework context</h3>
+      <p>Every v1.3 control maps into the broader governance landscape — CCM, NIST AI RMF, ISO, and the EU AI Act.</p>
+      <a href="https://ai-governance-map.vercel.app/">Explore in the AI Governance Map →</a>&nbsp;&nbsp; <a href="/simulator.html">Try the controls in the Simulator →</a>&nbsp;&nbsp;
+    </div>
+  </div>
+</section>
 <footer id="contact" class="site-footer">
   <div class="container footer-inner">
     <p>&copy; 2026 Brianna Baynard | NIST-2025-0035-0026 | CC BY 4.0</p>
@@ -281,6 +292,7 @@ sequenceDiagram
       <a href="https://twitter.com/NHIDClinical">@NHIDClinical</a>
     </div>
   </div>
+  <p class="footer-copy" style="margin-top:.4rem">This is a living open proposal — feedback and contributions welcome. <a href="https://github.com/NHID-Clinical/NHID-Clinical">GitHub</a> · NIST-2025-0035-0026 · CC BY 4.0</p>
 </footer>
 
 <script src="/site.js"></script>

--- a/technical-stack.html
+++ b/technical-stack.html
@@ -10,6 +10,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=IBM+Plex+Mono:wght@400;500&display=swap" rel="stylesheet"/>
   <link rel="stylesheet" href="/nhid-clinical-ui.css"/>
+  <link rel="stylesheet" href="/assets/css/premium.css"/>
   <script>try{document.documentElement.setAttribute('data-theme',localStorage.getItem('nhid-theme')||'light')}catch(e){}</script>
   <script defer data-domain="nhid-clinical.org" src="https://plausible.io/js/script.js"></script>
 </head>
@@ -195,6 +196,16 @@
   </section>
 </main>
 
+
+<section class="page-section" style="padding-top:0">
+  <div class="container" style="max-width:60rem">
+    <div class="premium-callout">
+      <h3>The five-layer trust stack, visualized</h3>
+      <p>The homepage now carries an interactive layer-by-layer view of the architecture this page documents.</p>
+      <a href="/#trust-stack">View the Trust Stack →</a>&nbsp;&nbsp; <a href="https://ai-governance-map.vercel.app/">Explore in the AI Governance Map →</a>&nbsp;&nbsp;
+    </div>
+  </div>
+</section>
 <footer id="contact" class="site-footer">
   <div class="container footer-inner">
     <p>&copy; 2026 Brianna Baynard | NIST-2025-0035-0026 | CC BY 4.0</p>
@@ -205,6 +216,7 @@
       <a href="https://twitter.com/NHIDClinical">@NHIDClinical</a>
     </div>
   </div>
+  <p class="footer-copy" style="margin-top:.4rem">This is a living open proposal — feedback and contributions welcome. <a href="https://github.com/NHID-Clinical/NHID-Clinical">GitHub</a> · NIST-2025-0035-0026 · CC BY 4.0</p>
 </footer>
 
 <script src="/site.js"></script>

--- a/webplatform/README.md
+++ b/webplatform/README.md
@@ -33,6 +33,7 @@ python -m uvicorn webplatform.app:app --host 0.0.0.0 --port 8080
 | Dashboard | `/` | CAS trust-tier distribution, per-control detection rates, audit KPIs | Payer executives |
 | Transcript Analyzer | `/analyzer` | Runs a transcript through the live engine (decision + CAS + violations + review routing) | Ops / QA |
 | Synthetic Generator | `/generator` | Runs the real eval loop over the Fabricate corpus; ingests events | Your team |
+| Conformance Suite | `/conformance` | Runs the 18 CTS cases + the disjoint-population confusion matrix (detection **and** FP) | Regulators / team |
 | Vendor Verification | `/vendors` | Adapter conformance check + Ed25519 passport verify (with tamper demo) | Vendors |
 | Audit Log | `/audit` | Durable event trail + DBC-01 human-review queue (one-way resolution) | Regulators |
 
@@ -43,6 +44,7 @@ python -m uvicorn webplatform.app:app --host 0.0.0.0 --port 8080
 - `GET  /api/scenarios`
 - `POST /api/analyze`  `{scenario}` or `{turns, conversation_id}`
 - `POST /api/generate` `{sample_size, persist}`
+- `GET  /api/cts`  · `GET /api/confusion?sample_size=N`
 - `POST /api/verify/passport` `{tamper}` or `{mode:"supplied", passport:{…}}`
 - `POST /api/adapters/{vendor}/check`  (vendor ∈ vapi, twilio, vonage, retell, connect)
 - `GET  /api/audit/events?limit=N` · `GET /api/audit/reviews`

--- a/webplatform/app.py
+++ b/webplatform/app.py
@@ -46,6 +46,7 @@ NAV = [
     {"href": "/", "label": "Dashboard"},
     {"href": "/analyzer", "label": "Transcript Analyzer"},
     {"href": "/generator", "label": "Synthetic Generator"},
+    {"href": "/conformance", "label": "Conformance Suite"},
     {"href": "/vendors", "label": "Vendor Verification"},
     {"href": "/audit", "label": "Audit Log"},
 ]
@@ -73,6 +74,11 @@ def analyzer(request: Request):
 @app.get("/generator")
 def generator(request: Request):
     return _page(request, "generator.html", "/generator")
+
+
+@app.get("/conformance")
+def conformance(request: Request):
+    return _page(request, "conformance.html", "/conformance")
 
 
 @app.get("/vendors")
@@ -144,6 +150,16 @@ async def api_generate(request: Request):
     global _detection_snapshot
     _detection_snapshot = result["controls"]
     return result
+
+
+@app.get("/api/confusion")
+def api_confusion(sample_size: int = 550):
+    return bridge.confusion_matrix(sample_size)
+
+
+@app.get("/api/cts")
+def api_cts():
+    return bridge.run_cts()
 
 
 @app.post("/api/verify/passport")

--- a/webplatform/nhid_bridge.py
+++ b/webplatform/nhid_bridge.py
@@ -21,7 +21,7 @@ from typing import Any
 
 # ── Make the existing repo importable regardless of CWD ──────────────────────
 _REPO_ROOT = Path(__file__).resolve().parent.parent
-for _p in (str(_REPO_ROOT), str(_REPO_ROOT / "src")):
+for _p in (str(_REPO_ROOT), str(_REPO_ROOT / "src"), str(_REPO_ROOT / "scripts")):
     if _p not in sys.path:
         sys.path.insert(0, _p)
 
@@ -52,6 +52,7 @@ from src.synthetic_eval_loop import (  # noqa: E402
     compute_detection_rates,
 )
 from adapters.fabricate_adapter import convert_csv  # noqa: E402
+from confusion_matrix import compute as _compute_matrix  # noqa: E402  (scripts/)
 
 CORPUS_CONV = str(_REPO_ROOT / "fixtures" / "fabricate" / "conversations.csv")
 CORPUS_TURNS = str(_REPO_ROOT / "fixtures" / "fabricate" / "turns.csv")
@@ -242,6 +243,34 @@ def generate_and_evaluate(sample_size: int = 100, persist: bool = False) -> dict
         "controls": controls,
         "ingested_events": ingested,
     }
+
+
+# ── Confusion matrix (reuses scripts/confusion_matrix.compute) ───────────────
+def confusion_matrix(sample_size: int = 550) -> dict:
+    """Detection + disjoint-population false-positive matrix over a corpus sample.
+
+    Reuses the exact `compute()` the CLI uses (scripts/confusion_matrix.py), so
+    the numbers match `python3 scripts/confusion_matrix.py` byte for byte on the
+    full corpus. ATR-01 is excluded by design (untestable in transcript replay).
+    """
+    corpus = _load_corpus()
+    sample = corpus[: max(1, min(sample_size, len(corpus)))]
+    result = _compute_matrix(sample)
+    for c in result["controls"]:
+        c["detection_pct"] = (round(c["detection_rate"] * 100, 1)
+                              if c["detection_rate"] is not None else None)
+        c["fp_pct"] = (round(c["fp_rate"] * 100, 1)
+                       if c["fp_rate"] is not None else None)
+        # Trim id lists for transport; keep counts.
+        c["missed_sample"] = c.pop("missed")[:8]
+        c["fp_sample"] = c.pop("fp_ids")[:8]
+    return result
+
+
+# ── Conformance Test Suite (reuses the real /v1/cts/evaluate route) ──────────
+def run_cts(test_ids: list[str] | None = None) -> dict:
+    body = {"test_ids": test_ids} if test_ids else {}
+    return _invoke("/v1/cts/evaluate", body)
 
 
 # ── Vendor adapter conformance check (reuses the real adapter routes) ────────

--- a/webplatform/templates/conformance.html
+++ b/webplatform/templates/conformance.html
@@ -1,0 +1,67 @@
+{% extends "base.html" %}
+{% block title %}Conformance Suite{% endblock %}
+{% block content %}
+<h1>Conformance Suite &amp; Confusion Matrix</h1>
+<p class="sub">For regulators &amp; the core team: the canonical CTS test cases (pass/fail against the real engine) and the honest disjoint-population confusion matrix (detection <em>and</em> false positives).</p>
+
+<div class="card">
+  <div class="row"><h2 style="margin:0">Conformance Test Suite (CTS)</h2>
+    <button id="run-cts" style="margin-left:auto">Run CTS</button>
+    <span class="mut" id="cts-status"></span></div>
+  <p class="mut" style="font-size:13px">Runs <code>src.cts_runner.run_cts</code> via the production <code>/v1/cts/evaluate</code> route over the machine-readable <code>conformance/nhid_conformance_test_suite_v1.yaml</code> cases.</p>
+  <div id="cts"><p class="mut">Not run yet.</p></div>
+</div>
+
+<div class="card" style="margin-top:16px">
+  <div class="row"><h2 style="margin:0">Confusion matrix</h2>
+    <button class="ghost" id="run-cm" style="margin-left:auto">Compute over full corpus</button>
+    <span class="mut" id="cm-status"></span></div>
+  <p class="mut" style="font-size:13px">Detection measured over conversations that declare each violation; false positives over the disjoint <code>scenario_type == "compliant"</code> population. Reuses the exact <code>scripts/confusion_matrix.py</code> computation — ATR-01 excluded by design (untestable in transcript replay).</p>
+  <div id="cm"><p class="mut">Not computed yet.</p></div>
+</div>
+
+<script>
+async function runCts() {
+  spin(el("cts-status"));
+  const d = await api("/api/cts");
+  el("cts-status").textContent = "";
+  const rows = (d.results || []).map(r => `
+    <tr>
+      <td class="mono">${esc(r.test_id)}</td>
+      <td><span class="chip">${esc(r.nhid_test_ref)}</span></td>
+      <td>${r.status === "pass" ? '<span class="pill ok">pass</span>' : (r.status === "skip" ? '<span class="pill warn">skip</span>' : '<span class="pill bad">fail</span>')}</td>
+      <td class="mono" style="font-size:12px">${esc(r.expected_action)} → ${esc(r.actual_action)}</td>
+    </tr>`).join("");
+  el("cts").innerHTML = `
+    <div class="row" style="gap:10px;margin-bottom:10px">
+      <span class="pill ok">${d.passed} passed</span>
+      ${d.failed ? `<span class="pill bad">${d.failed} failed</span>` : ''}
+      <span class="pill warn">${d.skipped} skipped</span>
+      <span class="chip">${d.total} total</span>
+    </div>
+    <table><tr><th>Test</th><th>Control</th><th>Status</th><th>Action (exp → act)</th></tr>${rows}</table>`;
+}
+async function runCm() {
+  spin(el("cm-status"));
+  const d = await api("/api/confusion");
+  el("cm-status").textContent = "";
+  const rows = d.controls.map(c => `
+    <tr>
+      <td><b>${c.control}</b></td>
+      <td class="mono">${c.detected}/${c.expected}</td>
+      <td>
+        <div class="bar" style="width:120px;display:inline-block;vertical-align:middle"><span style="width:${c.detection_pct ?? 0}%"></span></div>
+        <span class="mono" style="margin-left:8px">${c.detection_pct ?? "n/a"}%</span>
+      </td>
+      <td class="mono">${c.fp}/${c.clean}</td>
+      <td class="mono"><span class="${(c.fp_pct||0) > 5 ? 'pill bad' : 'pill ok'}">${c.fp_pct ?? "n/a"}%</span></td>
+    </tr>`).join("");
+  el("cm").innerHTML = `
+    <p class="mut">${d.n_conversations} conversations · ${d.n_compliant} compliant.</p>
+    <table><tr><th>Control</th><th>Detected</th><th>Detection rate</th><th>FP / clean</th><th>FP rate</th></tr>${rows}</table>`;
+}
+el("run-cts").onclick = runCts;
+el("run-cm").onclick = runCm;
+runCts(); runCm();
+</script>
+{% endblock %}

--- a/webplatform/tests/test_platform.py
+++ b/webplatform/tests/test_platform.py
@@ -127,6 +127,31 @@ def test_audit_events_and_review_resolution():
     assert len(events) > 0
 
 
+def test_conformance_page_renders():
+    r = client.get("/conformance")
+    assert r.status_code == 200
+    assert "Conformance Suite" in r.text
+
+
+def test_cts_runs_all_cases():
+    body = client.get("/api/cts").json()
+    assert body["total"] >= 18
+    assert body["failed"] == 0
+    assert body["passed"] >= 1
+    assert isinstance(body["results"], list) and len(body["results"]) == body["total"]
+
+
+def test_confusion_matrix_detection_and_fp():
+    body = client.get("/api/confusion?sample_size=550").json()
+    controls = {c["control"]: c for c in body["controls"]}
+    assert set(controls) == {"IDG-01", "PDX-01", "DBC-01", "EIT-01"}
+    # DBC-01 baseline on the full corpus (as of 2026-07): 183/200 detected, 5 FP.
+    assert controls["DBC-01"]["detected"] == 183
+    assert controls["DBC-01"]["expected"] == 200
+    assert controls["DBC-01"]["fp"] == 5
+    assert body["n_compliant"] == 127
+
+
 def test_bad_disposition_rejected():
     client.post("/api/analyze", json={"scenario": "dbc01"})
     reviews = client.get("/api/audit/reviews").json()["reviews"]


### PR DESCRIPTION
## Summary

Two enhancements on this branch:

### 1. webplatform: Conformance Suite page (CTS + confusion matrix)
- New `/conformance` page + `GET /api/cts` and `GET /api/confusion` routes.
- CTS panel runs the 18 conformance cases via the production `/v1/cts/evaluate` route (16 passed / 2 skipped).
- Confusion-matrix panel shows detection **and** disjoint-population FP rates per control (ATR-01 excluded by design).
- `scripts/confusion_matrix.py` gains a pure `compute()` shared by CLI and platform — CLI output byte-identical (DBC-01 183/200 91.5%, 5 FP).
- 3 new self-tests (16 total pass).

### 2. Site: premium visual layer (nhid-clinical.org)
Elevates the site while protecting the core — open voluntary proposal, **not a product, not a certification** — every enhanced section keeps its disclaimer + open-source CTAs.
- `assets/css/premium.css`: additive cinematic dark-band layer (navy `#0F172A` / teal `#14B8A6`), premium buttons, framed visuals; light theme untouched; reduced-motion + focus-visible support.
- Three self-contained animated SVG visuals (`assets/images/3d-svg/`): trust-verification nexus, five-layer trust-stack ziggurat, impersonation-latency split scene. `<picture>` slots auto-upgrade to `assets/images/3d-renders/*.webp` when high-res renders are dropped in — `PROMPTS.md` carries the exact generation prompts/filenames (zero code changes needed later).
- `index.html`: cinematic hero (first-person story verbatim; CTAs: spec / simulator / governance map / GitHub), interactive **Five-Layer Trust Stack** section (accessible tabs + deep links), **Impersonation Latency Crisis** section with the canonical definition.
- `simulator.html`: `?scenario=<name|control-id>` deep-link pre-selection (control aliases: idg-01→spoofed-identity, pdx-01→eligibility, eit-01→handoff, atr-01→prior-auth) + "Download Evidence Bundle" CTA; synthetic-data disclaimer unchanged.
- Six subpages: premium callout panels + "living open proposal" footer line.
- `docs/ai-governance-map-enhancement-spec.md`: implementable spec for the separate Vercel map app (trust-stack explorer whose simulator deep links work today, bidirectional link copy, export + no-tracking guardrails).

## Verification
- `python -m pytest webplatform/tests -q` → 16 passed.
- All 8 touched site pages serve HTTP 200 locally; new sections render; SVGs valid XML; all local hrefs resolve.
- `python3 scripts/validate_ci.py` → `CI PASS: 330 passed` (no engine/test-count impact).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XorMR2iJBdCQ4EqjkS4jao

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a premium visual layer across key pages, refreshing hero sections, callouts, buttons, and trust-stack visuals.
  * Introduced a new **Conformance Suite** page with interactive CTS and confusion-matrix results.
  * Added simulator deep-linking and a download option for evidence bundles.
  * Expanded navigation and cross-links between the homepage, governance map, simulator, and related pages.

* **Documentation**
  * Added and updated guidance for 3D renders, governance mapping, and the project’s living proposal messaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->