### PR TITLE
Brand visual system: SVG logo, icons, diagrams + site integration

### DIFF
--- a/.claude/prompts/nhid-core-architect.md
+++ b/.claude/prompts/nhid-core-architect.md
@@ -1,0 +1,25 @@
+# Fable 5 System Prompt — NHID-Clinical Core Repo (Open Standard)
+
+> Provenance: authored by the user (advisor session, 2026-07), saved verbatim for reuse.
+> Use when driving Fable 5 (or an Opus 4.8 fallback) as architect/advisor on this open-core repo.
+
+```markdown
+You are operating as a senior principal architect for NHID-Clinical (open governance framework for healthcare voice AI identity).
+
+Core rules (non-negotiable):
+- Stay in advisor/architect mode. Propose structure, logic, visuals, and improvements. Do not rewrite large sections of code unless explicitly asked.
+- Be extremely concise. No chit-chat, no re-explaining decisions we already made, no narrating options you won't pursue.
+- Visual direction: Match the new premium 3D/glass/metallic logo style from the latest references (navy #0F172A + teal #14B8A6 + cyan accents, rounded geometry, subtle material depth, transparent backgrounds). Never generate flat/generic/AI-slop visuals.
+- Always reference the AI Governance Map when relevant for framework alignment or control mapping.
+- When touching visuals, logos, or diagrams, prioritize SVG-first, production-ready output that matches the new premium language shown in the latest assets.
+- For tests: Flag weak spots (duplicates, schema gaps, PII, missing sections) but only propose targeted fixes unless asked for a full sweep.
+- Output format: Always lead with the key recommendation or change, then supporting details. Use short bullets or tables.
+
+Current priorities:
+- Tighten README and positioning
+- Upgrade visuals (logo system, icons, key diagrams) to match the new premium 3D/glass references
+- Improve test quality where genuinely weak
+- Keep scope tight to B2B healthcare voice identity + delegated authorization
+
+Begin.
+```

--- a/.claude/prompts/nhid-saas-architect.md
+++ b/.claude/prompts/nhid-saas-architect.md
@@ -1,0 +1,26 @@
+# Fable 5 System Prompt — NHID-Clinical SaaS Layer (Commercial Product)
+
+> Provenance: authored by the user (advisor session, 2026-07), saved verbatim for reuse.
+> NOTE: the SaaS layer lives in a SEPARATE repository (NHID-Clinical-SaaS). This prompt is
+> stored here only as a reference artifact — do NOT build SaaS code inside the open-core
+> NHID-Clinical repo. Use this when working in the SaaS repo itself.
+
+```markdown
+You are operating as a senior principal architect for the NHID-Clinical SaaS layer (the commercial enforcement platform).
+
+Core rules (non-negotiable):
+- Stay in advisor/architect mode. Focus on architecture, integration patterns, billing, multi-tenancy, and dashboard design. Do not touch or rewrite core NHID policy engine code.
+- Be extremely concise. Cut all filler. State the decision or recommendation first.
+- Visual direction: Use the same premium 3D/glass/metallic language as the core NHID brand (navy + teal + cyan, rounded geometry, subtle depth). SaaS UI should feel like calm, precise internal governance tooling — not startup SaaS or consumer product.
+- Reference the AI Governance Map when discussing control scoring, posture, or framework alignment.
+- Respect the isolation rule: SaaS layer talks to core NHID only via HTTP bridge (never direct Python imports of nhid_event_store, nhid_policy, etc.).
+- When working on dashboards or visuals, prioritize calm enterprise density, progressive disclosure, and excellent empty states.
+
+Current priorities:
+- SaaS architecture & bridge patterns
+- Dashboard / governance tooling visuals
+- Billing, tenant isolation, and audit chain integrity
+- Keeping the public open core clean while the SaaS layer adds commercial features
+
+Begin.
+```

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 <p align="center">
   <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="assets/logo-dark.jpg">
-    <source media="(prefers-color-scheme: light)" srcset="assets/logo-light.jpg">
-    <img alt="NHID-Clinical" src="assets/logo-light.jpg" width="480">
+    <source media="(prefers-color-scheme: dark)" srcset="assets/brand/logo-lockup-dark.svg">
+    <source media="(prefers-color-scheme: light)" srcset="assets/brand/logo-lockup.svg">
+    <img alt="NHID-Clinical" src="assets/brand/logo-lockup.svg" width="520">
   </picture>
 </p>
 
@@ -50,7 +50,7 @@ The governance gap is well documented; large-scale production evidence is still 
 **Standards alignment (mapped, not certified):** Explicitly supports EU AI Act Article 50 transparency obligations for AI systems interacting with humans. Mapped to NIST AI RMF 1.0 Map and Measure functions for identity disclosure and risk. Aligns with ISO/IEC 42001 Annex A controls on system transparency and auditability.
 
 <p align="center">
-  <img alt="NHID-Clinical Trust Verification Pathway" src="assets/images/3d-svg/nexus.svg" width="720">
+  <img alt="NHID-Clinical trust verification pathway: payer and provider bridged by conformance verification" src="assets/images/3d-svg/nexus.svg" width="760">
   <br>
   <sub><em>Clean vector visualization of the trust verification pathway — conceptual, not a product diagram.</em></sub>
 </p>
@@ -61,7 +61,7 @@ The governance gap is well documented; large-scale production evidence is still 
 | :--- | :--- | :--- |
 | **IDG-01** | Identity Disclosure Gate | Disclose non-human identity **before** any PHI exchange |
 | **PDX-01** | Pre-Data Exchange Gate | No protected data until identity is disclosed |
-| **DBC-01** | Deceptive Behavior Check | No mimicry of human voice or behavior |
+| **DBC-01** | Deceptive Behavior Check | No synthetic human-presence artifacts (e.g. fake breathing/hesitation) or explicit human-status claims |
 | **EIT-01** | Escalation Implementation Test | Clear human handoff path, honored on request |
 
 Plus **ATR-01** (audit trail) — every call must produce a machine-readable trace.  
@@ -72,7 +72,8 @@ Plus **ATR-01** (audit trail) — every call must produce a machine-readable tra
 ## Five-Layer Trust Stack
 
 <p align="center">
-  <img alt="Five-layer trust stack" src="assets/images/3d-svg/trust-stack.svg" width="640">
+  <img alt="Five-layer trust stack: STIR/SHAKEN, NHID-Clinical v1.3, NHID-Auth v2, FHIR AuditEvent R4, OpenTelemetry" src="assets/images/3d-svg/trust-stack.svg" width="680">
+
 </p>
 
 | Layer | Standard | Role |
@@ -89,7 +90,8 @@ Plus **ATR-01** (audit trail) — every call must produce a machine-readable tra
 ## The Impersonation Latency Crisis
 
 <p align="center">
-  <img alt="Impersonation vs verified pathway" src="assets/images/3d-svg/latency-split.svg" width="720">
+  <img alt="Contrast between unverified caller path and NHID-Clinical verified pathway" src="assets/images/3d-svg/latency-split.svg" width="760">
+
   <br>
   <sub><em>Without a standard: disclosure after PHI moves, no audit trail. With v1.3: early disclosure, verification checkpoint, human escalation, sealed audit.</em></sub>
 </p>

--- a/about.html
+++ b/about.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1"/>
   <meta name="description" content="About NHID-Clinical — why this proposal exists, the Impersonation Latency problem, and how this proposal is structured."/>
   <title>About | NHID-Clinical</title>
+  <link rel="icon" href="/assets/brand/favicon.svg" type="image/svg+xml"/>
   <link rel="icon" href="/assets/brand-icon.png" type="image/png"/>
   <link rel="preconnect" href="https://fonts.googleapis.com"/>
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>

--- a/assets/brand/favicon.svg
+++ b/assets/brand/favicon.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+  <!-- Favicon: the mark on a rounded tile so it reads at 16px in both themes. -->
+  <rect x="0" y="0" width="512" height="512" rx="96" fill="#0f2440"/>
+  <g transform="translate(46,46) scale(0.82)">
+    <rect x="28" y="148" width="150" height="214" rx="44" fill="#4a6f9b"/>
+    <path d="M252 14 H318 Q362 14 362 58 V264 Q362 290 346 301 Q336 308 328 300 L214 186 Q206 178 206 166 V58 Q206 14 252 14 Z" fill="#6f9cd0"/>
+    <path d="M232 230 Q222 222 218 234 V426 Q218 470 262 470 H318 Q362 470 362 426 V362 Z" fill="#2fbfa9"/>
+    <circle cx="446" cy="146" r="52" fill="#5c86b5"/>
+    <rect x="398" y="304" width="106" height="106" rx="30" fill="#9fdbe0"/>
+  </g>
+</svg>

--- a/assets/brand/logo-lockup-dark.svg
+++ b/assets/brand/logo-lockup-dark.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1480 260" role="img" aria-label="NHID-Clinical">
+  <!-- Horizontal lockup, dark backgrounds: lifted mark + light wordmark. -->
+  <g transform="translate(10,10) scale(0.469)">
+    <rect x="28" y="148" width="150" height="214" rx="44" fill="#33516f"/>
+    <path d="M252 14 H318 Q362 14 362 58 V264 Q362 290 346 301 Q336 308 328 300 L214 186 Q206 178 206 166 V58 Q206 14 252 14 Z" fill="#6f9cd0"/>
+    <path d="M232 230 Q222 222 218 234 V426 Q218 470 262 470 H318 Q362 470 362 426 V362 Z" fill="#2fbfa9"/>
+    <circle cx="446" cy="146" r="52" fill="#456f9f"/>
+    <rect x="398" y="304" width="106" height="106" rx="30" fill="#9fdbe0"/>
+  </g>
+  <text x="300" y="128" font-family="'Segoe UI','Helvetica Neue',Arial,sans-serif" font-size="88" font-weight="700" letter-spacing="1" fill="#e8f1fb">NHID<tspan fill="#2fbfa9">-</tspan>Clinical</text>
+  <text x="304" y="188" font-family="'Segoe UI','Helvetica Neue',Arial,sans-serif" font-size="34" font-weight="500" letter-spacing="6" fill="#a0b8d0">TRANSPARENT AI VOICE AGENTS IN HEALTHCARE</text>
+</svg>

--- a/assets/brand/logo-lockup.svg
+++ b/assets/brand/logo-lockup.svg
@@ -1,0 +1,23 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1480 260" role="img" aria-label="NHID-Clinical">
+  <!-- Horizontal lockup, light backgrounds: rich mark + wordmark. -->
+  <defs>
+    <linearGradient id="lQuad" x1="0.15" y1="0" x2="0.7" y2="1">
+      <stop offset="0" stop-color="#6493c6"/><stop offset="0.55" stop-color="#3b6aa0"/><stop offset="1" stop-color="#27517f"/>
+    </linearGradient>
+    <linearGradient id="lWedge" x1="0.2" y1="0" x2="0.8" y2="1">
+      <stop offset="0" stop-color="#35c2ab"/><stop offset="0.6" stop-color="#189a8a"/><stop offset="1" stop-color="#0e7568"/>
+    </linearGradient>
+    <linearGradient id="lSlab" x1="0" y1="0" x2="0.4" y2="1">
+      <stop offset="0" stop-color="#1b3a5f"/><stop offset="1" stop-color="#0a1a30"/>
+    </linearGradient>
+  </defs>
+  <g transform="translate(10,10) scale(0.469)">
+    <rect x="28" y="148" width="150" height="214" rx="44" fill="url(#lSlab)"/>
+    <path d="M252 14 H318 Q362 14 362 58 V264 Q362 290 346 301 Q336 308 328 300 L214 186 Q206 178 206 166 V58 Q206 14 252 14 Z" fill="url(#lQuad)"/>
+    <path d="M232 230 Q222 222 218 234 V426 Q218 470 262 470 H318 Q362 470 362 426 V362 Z" fill="url(#lWedge)"/>
+    <circle cx="446" cy="146" r="52" fill="#16385f"/>
+    <rect x="398" y="304" width="106" height="106" rx="30" fill="#7fc4c9"/>
+  </g>
+  <text x="300" y="128" font-family="'Segoe UI','Helvetica Neue',Arial,sans-serif" font-size="88" font-weight="700" letter-spacing="1" fill="#082a5b">NHID<tspan fill="#189a8a">-</tspan>Clinical</text>
+  <text x="304" y="188" font-family="'Segoe UI','Helvetica Neue',Arial,sans-serif" font-size="34" font-weight="500" letter-spacing="6" fill="#5d6b7a">TRANSPARENT AI VOICE AGENTS IN HEALTHCARE</text>
+</svg>

--- a/assets/brand/logo-mark-dark.svg
+++ b/assets/brand/logo-mark-dark.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" role="img" aria-label="NHID-Clinical mark (dark mode)">
+  <!-- NHID-Clinical primary mark — dark-mode variant: tones lifted so the mark
+       holds against navy/near-black backgrounds. Same geometry as logo-mark.svg. -->
+  <g>
+    <rect x="28" y="148" width="150" height="214" rx="44" fill="#33516f"/>
+    <path d="M252 14 H318 Q362 14 362 58 V264 Q362 290 346 301 Q336 308 328 300 L214 186 Q206 178 206 166 V58 Q206 14 252 14 Z" fill="#6f9cd0"/>
+    <path d="M232 230 Q222 222 218 234 V426 Q218 470 262 470 H318 Q362 470 362 426 V362 Z" fill="#2fbfa9"/>
+    <circle cx="446" cy="146" r="52" fill="#456f9f"/>
+    <rect x="398" y="304" width="106" height="106" rx="30" fill="#9fdbe0"/>
+  </g>
+</svg>

--- a/assets/brand/logo-mark-rich.svg
+++ b/assets/brand/logo-mark-rich.svg
@@ -1,0 +1,32 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" role="img" aria-label="NHID-Clinical mark">
+  <!-- NHID-Clinical primary mark — rich material variant (SVG approximation of
+       the glass/metal render: per-shape gradients + rim light). Same geometry
+       as logo-mark.svg; keep the two files' paths in sync. -->
+  <defs>
+    <linearGradient id="gSlab" x1="0" y1="0" x2="0.4" y2="1">
+      <stop offset="0" stop-color="#1b3a5f"/><stop offset="1" stop-color="#0a1a30"/>
+    </linearGradient>
+    <linearGradient id="gQuad" x1="0.15" y1="0" x2="0.7" y2="1">
+      <stop offset="0" stop-color="#6493c6"/><stop offset="0.55" stop-color="#3b6aa0"/><stop offset="1" stop-color="#27517f"/>
+    </linearGradient>
+    <linearGradient id="gWedge" x1="0.2" y1="0" x2="0.8" y2="1">
+      <stop offset="0" stop-color="#35c2ab"/><stop offset="0.6" stop-color="#189a8a"/><stop offset="1" stop-color="#0e7568"/>
+    </linearGradient>
+    <linearGradient id="gDot" x1="0.2" y1="0.1" x2="0.8" y2="1">
+      <stop offset="0" stop-color="#2c5787"/><stop offset="1" stop-color="#122e52"/>
+    </linearGradient>
+    <linearGradient id="gTile" x1="0.2" y1="0" x2="0.8" y2="1">
+      <stop offset="0" stop-color="#aadfe4"/><stop offset="1" stop-color="#6db6bd"/>
+    </linearGradient>
+    <linearGradient id="gRim" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#ffffff" stop-opacity="0.55"/><stop offset="0.4" stop-color="#ffffff" stop-opacity="0.08"/><stop offset="1" stop-color="#ffffff" stop-opacity="0"/>
+    </linearGradient>
+  </defs>
+  <g stroke="url(#gRim)" stroke-width="2.5">
+    <rect x="28" y="148" width="150" height="214" rx="44" fill="url(#gSlab)"/>
+    <path d="M252 14 H318 Q362 14 362 58 V264 Q362 290 346 301 Q336 308 328 300 L214 186 Q206 178 206 166 V58 Q206 14 252 14 Z" fill="url(#gQuad)"/>
+    <path d="M232 230 Q222 222 218 234 V426 Q218 470 262 470 H318 Q362 470 362 426 V362 Z" fill="url(#gWedge)"/>
+    <circle cx="446" cy="146" r="52" fill="url(#gDot)"/>
+    <rect x="398" y="304" width="106" height="106" rx="30" fill="url(#gTile)"/>
+  </g>
+</svg>

--- a/assets/brand/logo-mark.svg
+++ b/assets/brand/logo-mark.svg
@@ -1,0 +1,19 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" role="img" aria-label="NHID-Clinical mark">
+  <!-- NHID-Clinical primary mark — flat/minimal variant.
+       Five geometric forms composing an abstract "N" with a speech-bubble
+       silhouette: left slab, upper quad with diagonal cut, teal counter-wedge,
+       signal dot, data tile. The white diagonal channel between quad and wedge
+       is the load-bearing negative space. Palette: ink navy / steel blue / teal. -->
+  <g>
+    <!-- Left slab -->
+    <rect x="28" y="148" width="150" height="214" rx="44" fill="#0f2440"/>
+    <!-- Upper quad: rounded top, diagonal cut toward lower-left -->
+    <path d="M252 14 H318 Q362 14 362 58 V264 Q362 290 346 301 Q336 308 328 300 L214 186 Q206 178 206 166 V58 Q206 14 252 14 Z" fill="#3b6aa0"/>
+    <!-- Teal counter-wedge with rounded foot -->
+    <path d="M232 230 Q222 222 218 234 V426 Q218 470 262 470 H318 Q362 470 362 426 V362 Z" fill="#189a8a"/>
+    <!-- Signal dot -->
+    <circle cx="446" cy="146" r="52" fill="#16385f"/>
+    <!-- Data tile -->
+    <rect x="398" y="304" width="106" height="106" rx="30" fill="#7fc4c9"/>
+  </g>
+</svg>

--- a/assets/brand/shield-waveform.svg
+++ b/assets/brand/shield-waveform.svg
@@ -1,0 +1,42 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 480 560" role="img" aria-label="NHID-Clinical conformance shield">
+  <!-- Glass shield + voice waveform motif, for conformance/audit surfaces. -->
+  <defs>
+    <linearGradient id="sGlass" x1="0.2" y1="0" x2="0.85" y2="1">
+      <stop offset="0" stop-color="#b8c9dd" stop-opacity="0.85"/>
+      <stop offset="0.45" stop-color="#5f7fa5" stop-opacity="0.92"/>
+      <stop offset="1" stop-color="#2c4a6e" stop-opacity="0.95"/>
+    </linearGradient>
+    <linearGradient id="sEdge" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#ffffff" stop-opacity="0.7"/>
+      <stop offset="1" stop-color="#ffffff" stop-opacity="0.12"/>
+    </linearGradient>
+    <linearGradient id="sSheen" x1="0" y1="0" x2="0.6" y2="1">
+      <stop offset="0" stop-color="#ffffff" stop-opacity="0.35"/>
+      <stop offset="0.5" stop-color="#ffffff" stop-opacity="0.05"/>
+      <stop offset="1" stop-color="#ffffff" stop-opacity="0"/>
+    </linearGradient>
+  </defs>
+  <!-- Shield body -->
+  <path d="M240 18 C300 52 366 66 432 70 C438 214 430 330 384 414 C346 483 296 524 240 546 C184 524 134 483 96 414 C50 330 42 214 48 70 C114 66 180 52 240 18 Z"
+        fill="url(#sGlass)" stroke="url(#sEdge)" stroke-width="5"/>
+  <!-- Sheen -->
+  <path d="M240 30 C296 60 356 74 420 79 C424 170 420 250 402 318 C300 290 180 300 70 250 C62 190 58 130 60 79 C124 74 184 60 240 30 Z"
+        fill="url(#sSheen)"/>
+  <!-- Waveform -->
+  <g stroke="#f2f7fc" stroke-width="7" stroke-linecap="round" opacity="0.95">
+    <line x1="96"  y1="272" x2="96"  y2="288"/>
+    <line x1="118" y1="266" x2="118" y2="294"/>
+    <line x1="140" y1="256" x2="140" y2="304"/>
+    <line x1="162" y1="244" x2="162" y2="316"/>
+    <line x1="184" y1="252" x2="184" y2="308"/>
+    <line x1="206" y1="228" x2="206" y2="332"/>
+    <line x1="228" y1="196" x2="228" y2="364"/>
+    <line x1="250" y1="212" x2="250" y2="348"/>
+    <line x1="272" y1="180" x2="272" y2="380"/>
+    <line x1="294" y1="224" x2="294" y2="336"/>
+    <line x1="316" y1="248" x2="316" y2="312"/>
+    <line x1="338" y1="258" x2="338" y2="302"/>
+    <line x1="360" y1="266" x2="360" y2="294"/>
+    <line x1="382" y1="272" x2="382" y2="288"/>
+  </g>
+</svg>

--- a/assets/icons/nhid-icons.svg
+++ b/assets/icons/nhid-icons.svg
@@ -198,5 +198,71 @@
     <line x1="71" y1="31" x2="77" y2="37" stroke="#fff" stroke-width="2.6" stroke-linecap="round"/>
     <line x1="77" y1="31" x2="71" y2="37" stroke="#fff" stroke-width="2.6" stroke-linecap="round"/>
   </symbol>
+
+  <!-- v1.3 control icons (added with the brand-system pass): one per control
+       plus core primitives. Same grammar as above: 100x110 box, 4.4 stroke,
+       ink base via the icon-base CSS variable so dark surfaces recolor it,
+       teal accent via the icon-accent CSS variable, rounded caps/joins. -->
+  <symbol id="nhid-icon-idg01" viewBox="0 0 100 110">
+    <!-- IDG-01 Identity Disclosure Gate: speech bubble declaring non-human identity -->
+    <path d="M32 36 h36 q6 0 6 6 v20 q0 6 -6 6 h-16 l-9 9 v-9 h-11 q-6 0 -6 -6 v-20 q0 -6 6 -6 z" fill="rgba(24,142,170,0.10)" stroke-width="4.4" stroke-linecap="round" stroke-linejoin="round" style="stroke:var(--icon-base,#0B2E63)"/>
+    <line x1="38" y1="47" x2="38" y2="57" stroke-width="4.2" stroke-linecap="round" style="stroke:var(--icon-accent,#188EAA)"/>
+    <line x1="47" y1="43" x2="47" y2="61" stroke-width="4.2" stroke-linecap="round" style="stroke:var(--icon-accent,#188EAA)"/>
+    <line x1="56" y1="47" x2="56" y2="57" stroke-width="4.2" stroke-linecap="round" style="stroke:var(--icon-accent,#188EAA)"/>
+    <line x1="64" y1="50" x2="64" y2="54" stroke-width="4.2" stroke-linecap="round" style="stroke:var(--icon-accent,#188EAA)"/>
+  </symbol>
+  <symbol id="nhid-icon-pdx01" viewBox="0 0 100 110">
+    <!-- PDX-01 Pre-Data Exchange Gate: data document held behind a lock -->
+    <path d="M34 32 h22 l10 10 v28 q0 4 -4 4 h-28 q-4 0 -4 -4 v-34 q0 -4 4 -4 z" fill="none" stroke-width="4.4" stroke-linecap="round" stroke-linejoin="round" style="stroke:var(--icon-base,#0B2E63)"/>
+    <path d="M56 32 v10 h10" fill="none" stroke-width="4.4" stroke-linecap="round" stroke-linejoin="round" style="stroke:var(--icon-base,#0B2E63)"/>
+    <rect x="52" y="58" width="20" height="15" rx="3.5" fill="rgba(24,142,170,0.14)" stroke-width="4.2" stroke-linejoin="round" style="stroke:var(--icon-accent,#188EAA)"/>
+    <path d="M56.5 58 v-5 a5.5 5.5 0 0 1 11 0 v5" fill="none" stroke-width="4.2" stroke-linecap="round" style="stroke:var(--icon-accent,#188EAA)"/>
+  </symbol>
+  <symbol id="nhid-icon-dbc01" viewBox="0 0 100 110">
+    <!-- DBC-01 Deceptive Behavior Check: human-mimicry mask, struck through -->
+    <path d="M36 36 q14 -7 28 0 q3 14 -3 24 q-5 9 -11 11 q-6 -2 -11 -11 q-6 -10 -3 -24 z" fill="rgba(214,69,69,0.08)" stroke-width="4.4" stroke-linecap="round" stroke-linejoin="round" style="stroke:var(--icon-base,#0B2E63)"/>
+    <circle cx="43.5" cy="49" r="2.4" style="fill:var(--icon-base,#0B2E63)"/>
+    <circle cx="56.5" cy="49" r="2.4" style="fill:var(--icon-base,#0B2E63)"/>
+    <path d="M44 60 q6 4 12 0" fill="none" stroke-width="3.6" stroke-linecap="round" style="stroke:var(--icon-base,#0B2E63)"/>
+    <line x1="30" y1="76" x2="70" y2="32" stroke="#D64545" stroke-width="5" stroke-linecap="round"/>
+  </symbol>
+  <symbol id="nhid-icon-eit01" viewBox="0 0 100 110">
+    <!-- EIT-01 Escalation Implementation Test: honored handoff to a person -->
+    <circle cx="63" cy="42" r="8" fill="none" stroke-width="4.4" style="stroke:var(--icon-base,#0B2E63)"/>
+    <path d="M50 74 q0 -13 13 -13 q13 0 13 13" fill="none" stroke-width="4.4" stroke-linecap="round" style="stroke:var(--icon-base,#0B2E63)"/>
+    <path d="M26 46 h16 m0 0 l-6 -6 m6 6 l-6 6" fill="none" stroke-width="4.4" stroke-linecap="round" stroke-linejoin="round" style="stroke:var(--icon-accent,#188EAA)"/>
+    <path d="M26 62 h10" fill="none" stroke-width="4.4" stroke-linecap="round" opacity="0.55" style="stroke:var(--icon-accent,#188EAA)"/>
+  </symbol>
+  <symbol id="nhid-icon-atr01" viewBox="0 0 100 110">
+    <!-- ATR-01 Audit Trail Requirements: sealed machine-readable record -->
+    <rect x="30" y="30" width="34" height="46" rx="5" fill="none" stroke-width="4.4" stroke-linejoin="round" style="stroke:var(--icon-base,#0B2E63)"/>
+    <line x1="38" y1="42" x2="56" y2="42" stroke-width="3.6" stroke-linecap="round" style="stroke:var(--icon-base,#0B2E63)"/>
+    <line x1="38" y1="51" x2="56" y2="51" stroke-width="3.6" stroke-linecap="round" style="stroke:var(--icon-base,#0B2E63)"/>
+    <line x1="38" y1="60" x2="49" y2="60" stroke-width="3.6" stroke-linecap="round" style="stroke:var(--icon-base,#0B2E63)"/>
+    <circle cx="65" cy="67" r="10" fill="rgba(24,142,170,0.14)" stroke-width="4.2" style="stroke:var(--icon-accent,#188EAA)"/>
+    <path d="M61 67 l3 3.4 6 -7" fill="none" stroke-width="3.6" stroke-linecap="round" stroke-linejoin="round" style="stroke:var(--icon-accent,#188EAA)"/>
+  </symbol>
+  <symbol id="nhid-icon-impersonation-latency" viewBox="0 0 100 110">
+    <!-- Impersonation Latency: the timed window before identity resolution -->
+    <circle cx="46" cy="54" r="19" fill="none" stroke-width="4.4" style="stroke:var(--icon-base,#0B2E63)"/>
+    <line x1="46" y1="54" x2="46" y2="42" stroke-width="4" stroke-linecap="round" style="stroke:var(--icon-base,#0B2E63)"/>
+    <line x1="46" y1="54" x2="55" y2="59" stroke="#D64545" stroke-width="4" stroke-linecap="round"/>
+    <line x1="72" y1="48" x2="72" y2="60" stroke-width="4" stroke-linecap="round" style="stroke:var(--icon-accent,#188EAA)"/>
+    <line x1="79" y1="44" x2="79" y2="64" stroke-width="4" stroke-linecap="round" opacity="0.7" style="stroke:var(--icon-accent,#188EAA)"/>
+  </symbol>
+  <symbol id="nhid-icon-cas" viewBox="0 0 100 110">
+    <!-- CAS: Call Authorization Score gauge -->
+    <path d="M28 66 a22 22 0 0 1 44 0" fill="none" stroke-width="4.4" stroke-linecap="round" style="stroke:var(--icon-base,#0B2E63)"/>
+    <path d="M28 66 a22 22 0 0 1 9 -17.6" fill="none" stroke="#D64545" stroke-width="4.4" stroke-linecap="round" opacity="0.75"/>
+    <path d="M63.5 48.5 a22 22 0 0 1 8.5 17.5" fill="none" stroke-width="4.4" stroke-linecap="round" style="stroke:var(--icon-accent,#188EAA)"/>
+    <line x1="50" y1="66" x2="61" y2="53" stroke-width="4.4" stroke-linecap="round" style="stroke:var(--icon-base,#0B2E63)"/>
+    <circle cx="50" cy="66" r="3.4" style="fill:var(--icon-base,#0B2E63)"/>
+  </symbol>
+  <symbol id="nhid-icon-trust-stack" viewBox="0 0 100 110">
+    <!-- Five-layer trust stack -->
+    <path d="M50 30 l22 10 -22 10 -22 -10 z" fill="rgba(24,142,170,0.14)" stroke-width="4.2" stroke-linejoin="round" style="stroke:var(--icon-accent,#188EAA)"/>
+    <path d="M28 54 l22 10 22 -10" fill="none" stroke-width="4.4" stroke-linecap="round" stroke-linejoin="round" style="stroke:var(--icon-base,#0B2E63)"/>
+    <path d="M28 66 l22 10 22 -10" fill="none" stroke-width="4.4" stroke-linecap="round" stroke-linejoin="round" opacity="0.55" style="stroke:var(--icon-base,#0B2E63)"/>
+  </symbol>
 </defs>
 </svg>

--- a/assets/images/3d-svg/latency-split.svg
+++ b/assets/images/3d-svg/latency-split.svg
@@ -1,116 +1,70 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1600 560" role="img" aria-labelledby="ls-t ls-d">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 520" role="img" aria-labelledby="ls-t ls-d">
   <title id="ls-t">Impersonation latency: without a standard vs a verified trust pathway</title>
-  <desc id="ls-d">Illustrative split scene. Left: an unverified AI call reaches the receiving system with no verification pathway — trust delay effectively infinite, PHI at risk. Right: the NHID-Clinical verified pathway with disclosure gate, pre-data-exchange verification, and human escalation producing a measurable trust delay. Conceptual render for clarity.</desc>
+  <desc id="ls-d">Illustrative contrast. Left: an unverified AI call reaches PHI with no verification pathway — disclosure only after data has moved, no audit trail. Right: the NHID-Clinical verified pathway — early disclosure gate, pre-data-exchange checkpoint, human escalation, sealed audit. Conceptual visualization for clarity.</desc>
   <defs>
-    <linearGradient id="lsBg" x1="0" y1="0" x2="0" y2="1">
-      <stop offset="0" stop-color="#0F172A"/><stop offset="1" stop-color="#070c18"/>
-    </linearGradient>
-    <radialGradient id="lsRed" cx=".25" cy=".35" r=".5">
-      <stop offset="0" stop-color="#e5484d" stop-opacity=".14"/><stop offset="1" stop-color="#e5484d" stop-opacity="0"/>
-    </radialGradient>
-    <radialGradient id="lsTeal" cx=".75" cy=".35" r=".5">
-      <stop offset="0" stop-color="#14B8A6" stop-opacity=".18"/><stop offset="1" stop-color="#14B8A6" stop-opacity="0"/>
-    </radialGradient>
-    <linearGradient id="lsSteel" x1="0" y1="0" x2="0" y2="1">
-      <stop offset="0" stop-color="#3a4a63"/><stop offset="1" stop-color="#182338"/>
-    </linearGradient>
-    <filter id="lsGlow"><feGaussianBlur stdDeviation="5"/></filter>
-    <filter id="lsSoft"><feGaussianBlur stdDeviation="1.2"/></filter>
-    <marker id="lsArrT" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="7" markerHeight="7" orient="auto">
-      <path d="M0 0 L10 5 L0 10 z" fill="#2dd4bf"/>
-    </marker>
-    <marker id="lsArrR" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="7" markerHeight="7" orient="auto">
-      <path d="M0 0 L10 5 L0 10 z" fill="#e5484d"/>
-    </marker>
+    <linearGradient id="lsBad" x1="0" y1="0" x2="0" y2="1"><stop offset="0" stop-color="#d97b6c"/><stop offset="1" stop-color="#b64a3c"/></linearGradient>
+    <linearGradient id="lsGood" x1="0" y1="0" x2="0" y2="1"><stop offset="0" stop-color="#35c2ab"/><stop offset="1" stop-color="#148f80"/></linearGradient>
+    <linearGradient id="lsNode" x1="0" y1="0" x2="0" y2="1"><stop offset="0" stop-color="#33516f"/><stop offset="1" stop-color="#16385f"/></linearGradient>
+    <style>
+      .h { font-family:'Segoe UI','Helvetica Neue',Arial,sans-serif; font-size:23px; font-weight:700; }
+      .s { font-family:'Segoe UI','Helvetica Neue',Arial,sans-serif; font-size:14.5px; fill:#5d6b7a; }
+      .cap { font-family:'Segoe UI','Helvetica Neue',Arial,sans-serif; font-size:13px; font-weight:600; fill:#ffffff; }
+      .tick { font-family:'Segoe UI','Helvetica Neue',Arial,sans-serif; font-size:12.5px; fill:#4a5666; }
+    </style>
   </defs>
 
-  <rect width="1600" height="560" fill="url(#lsBg)"/>
-  <rect width="800" height="560" fill="url(#lsRed)"/>
-  <rect x="800" width="800" height="560" fill="url(#lsTeal)"/>
-  <line x1="800" y1="30" x2="800" y2="530" stroke="#33415c" stroke-width="2" stroke-dasharray="6 8"/>
+  <!-- divider -->
+  <line x1="500" y1="40" x2="500" y2="480" stroke="#dfe5ec" stroke-width="2" stroke-dasharray="6 7"/>
 
-  <g font-family="Inter,system-ui,sans-serif">
-    <text x="400" y="66" fill="#f2a6a9" font-size="24" font-weight="800" text-anchor="middle" letter-spacing="1.5">WITHOUT A STANDARD</text>
-    <text x="400" y="94" fill="#8fa0bd" font-size="14.5" text-anchor="middle">trust delay: effectively infinite — no verification pathway exists</text>
-
-    <g>
-      <circle cx="150" cy="280" r="46" fill="#182338" stroke="#5b3140" stroke-width="2.4"/>
-      <text x="150" y="292" fill="#f2a6a9" font-size="34" font-weight="800" text-anchor="middle">?</text>
-      <text x="150" y="352" fill="#8fa0bd" font-size="13.5" text-anchor="middle">unverified AI caller</text>
-    </g>
-
-    <path d="M200 280 H640" stroke="#e5484d" stroke-width="3.4" marker-end="url(#lsArrR)" stroke-dasharray="12 7"/>
-    <g transform="translate(370 236)">
-      <rect width="90" height="88" rx="6" fill="#131c2e" stroke="#5b3140" stroke-width="2"/>
-      <line x1="12" y1="12" x2="78" y2="76" stroke="#e5484d" stroke-width="4"/>
-      <line x1="78" y1="12" x2="12" y2="76" stroke="#e5484d" stroke-width="4"/>
-      <text x="45" y="112" fill="#8fa0bd" font-size="12.5" text-anchor="middle">no disclosure · no check</text>
-    </g>
-
-    <g transform="translate(600 216)">
-      <rect width="128" height="128" rx="10" fill="url(#lsSteel)" stroke="#5b3140" stroke-width="2.4"/>
-      <rect x="18" y="34" width="92" height="12" rx="3" fill="#e5484d" opacity=".75"/>
-      <rect x="18" y="58" width="70" height="12" rx="3" fill="#e5484d" opacity=".55"/>
-      <rect x="18" y="82" width="84" height="12" rx="3" fill="#e5484d" opacity=".4"/>
-      <text x="64" y="24" fill="#f2a6a9" font-size="13.5" font-weight="700" text-anchor="middle">PHI</text>
-      <text x="64" y="152" fill="#8fa0bd" font-size="12.5" text-anchor="middle">data moves before identity is known</text>
-    </g>
-
-    <g transform="translate(330 420)">
-      <circle cx="70" cy="40" r="38" fill="#131c2e" stroke="#5b3140" stroke-width="2.2"/>
-      <text x="70" y="52" fill="#f2a6a9" font-size="30" font-weight="800" text-anchor="middle">∞</text>
-      <text x="70" y="102" fill="#8fa0bd" font-size="13" text-anchor="middle">impersonation latency</text>
-    </g>
-
-    <text x="1200" y="66" fill="#6ee7d5" font-size="24" font-weight="800" text-anchor="middle" letter-spacing="1.5">WITH NHID-CLINICAL v1.3</text>
-    <text x="1200" y="94" fill="#8fa0bd" font-size="14.5" text-anchor="middle">a measurable, testable trust pathway</text>
-
-    <g>
-      <circle cx="920" cy="280" r="46" fill="#0e2230" stroke="#14B8A6" stroke-width="2.4"/>
-      <text x="920" y="272" fill="#6ee7d5" font-size="15.5" font-weight="800" text-anchor="middle">AI</text>
-      <text x="920" y="294" fill="#8fa0bd" font-size="11" text-anchor="middle">disclosed</text>
-      <circle cx="953" cy="247" r="10" fill="#14B8A6"/>
-      <path d="M948 247 l4 5 7 -9" stroke="#06222b" stroke-width="2.4" fill="none"/>
-      <text x="920" y="352" fill="#8fa0bd" font-size="13.5" text-anchor="middle">identity asserted up front</text>
-    </g>
-
-    <path d="M968 280 H1030" stroke="#2dd4bf" stroke-width="3.2" marker-end="url(#lsArrT)"/>
-    <g transform="translate(1034 232)">
-      <rect width="84" height="96" rx="6" fill="#0d1626" stroke="#14B8A6" stroke-width="2"/>
-      <path d="M42 20 v34 M26 37 h32" stroke="#2dd4bf" stroke-width="3.2"/>
-      <text x="42" y="82" fill="#6ee7d5" font-size="13.5" font-weight="700" text-anchor="middle">IDG-01</text>
-      <text x="42" y="118" fill="#8fa0bd" font-size="12" text-anchor="middle">disclosure gate</text>
-    </g>
-
-    <path d="M1122 280 H1180" stroke="#2dd4bf" stroke-width="3.2" marker-end="url(#lsArrT)"/>
-    <g transform="translate(1184 232)">
-      <rect width="84" height="96" rx="6" fill="#0d1626" stroke="#14B8A6" stroke-width="2"/>
-      <circle cx="42" cy="40" r="17" fill="none" stroke="#2dd4bf" stroke-width="3"/>
-      <path d="M35 40 l5 6 11 -13" stroke="#2dd4bf" stroke-width="3" fill="none"/>
-      <text x="42" y="82" fill="#6ee7d5" font-size="13.5" font-weight="700" text-anchor="middle">PDX-01</text>
-      <text x="42" y="118" fill="#8fa0bd" font-size="12" text-anchor="middle">verify before PHI</text>
-    </g>
-
-    <path d="M1272 280 H1330" stroke="#2dd4bf" stroke-width="3.2" marker-end="url(#lsArrT)"/>
-    <g transform="translate(1334 216)">
-      <rect width="128" height="128" rx="10" fill="url(#lsSteel)" stroke="#14B8A6" stroke-width="2.4"/>
-      <rect x="44" y="46" width="40" height="34" rx="5" fill="#0d1626" stroke="#2dd4bf" stroke-width="2.4"/>
-      <path d="M52 46 v-9 a12 12 0 0 1 24 0 v9" stroke="#2dd4bf" stroke-width="2.6" fill="none"/>
-      <circle cx="64" cy="62" r="4" fill="#2dd4bf"/>
-      <text x="64" y="24" fill="#6ee7d5" font-size="13.5" font-weight="700" text-anchor="middle">PHI</text>
-      <text x="64" y="152" fill="#8fa0bd" font-size="12.5" text-anchor="middle">exchange after verification (EIT-01 · ATR-01)</text>
-    </g>
-
-    <g transform="translate(1130 420)">
-      <circle cx="70" cy="40" r="38" fill="#0d1626" stroke="#14B8A6" stroke-width="2.2"/>
-      <path d="M70 40 L70 14" stroke="#2dd4bf" stroke-width="3.2"/>
-      <path d="M70 40 L90 48" stroke="#6ee7d5" stroke-width="2.4"/>
-      <circle cx="70" cy="40" r="4" fill="#2dd4bf"/>
-      <text x="70" y="102" fill="#8fa0bd" font-size="13" text-anchor="middle">measurable trust delay</text>
-    </g>
-
-    <circle r="5.5" fill="#2dd4bf" filter="url(#lsSoft)">
-      <animateMotion dur="4.6s" repeatCount="indefinite" path="M968 280 H1330"/>
-    </circle>
+  <!-- LEFT: without a standard -->
+  <text x="40" y="52" class="h" fill="#b64a3c">Without a standard</text>
+  <line x1="60" y1="120" x2="440" y2="120" stroke="#e3b8b0" stroke-width="6" stroke-linecap="round"/>
+  <line x1="60" y1="120" x2="420" y2="120" stroke="url(#lsBad)" stroke-width="6" stroke-linecap="round"/>
+  <!-- PHI first, disclosure late -->
+  <g>
+    <circle cx="120" cy="120" r="15" fill="url(#lsBad)"/><text x="120" y="125" text-anchor="middle" class="cap">PHI</text>
+    <text x="120" y="160" text-anchor="middle" class="tick">member ID, DOB</text>
+    <text x="120" y="177" text-anchor="middle" class="tick">requested</text>
   </g>
+  <g>
+    <circle cx="300" cy="120" r="15" fill="url(#lsBad)"/><text x="300" y="125" text-anchor="middle" class="cap">!</text>
+    <text x="300" y="160" text-anchor="middle" class="tick">data exchanged,</text>
+    <text x="300" y="177" text-anchor="middle" class="tick">still unverified</text>
+  </g>
+  <g>
+    <circle cx="410" cy="120" r="15" fill="url(#lsNode)"/>
+    <text x="410" y="160" text-anchor="middle" class="tick">disclosure</text>
+    <text x="410" y="177" text-anchor="middle" class="tick">(too late)</text>
+  </g>
+  <rect x="60" y="228" width="380" height="70" rx="14" fill="#fbeeeb" stroke="#e3b8b0" stroke-width="1.5"/>
+  <text x="80" y="258" class="s" fill="#b64a3c" font-weight="700">Impersonation latency ≈ unbounded</text>
+  <text x="80" y="282" class="s">No disclosure gate · no audit trail · PHI at risk.</text>
+
+  <!-- RIGHT: with NHID-Clinical -->
+  <text x="540" y="52" class="h" fill="#0e7568">With NHID-Clinical v1.3</text>
+  <line x1="560" y1="120" x2="940" y2="120" stroke="#b6e6dc" stroke-width="6" stroke-linecap="round"/>
+  <line x1="560" y1="120" x2="640" y2="120" stroke="url(#lsGood)" stroke-width="6" stroke-linecap="round"/>
+  <g>
+    <circle cx="600" cy="120" r="15" fill="url(#lsGood)"/><text x="600" y="125" text-anchor="middle" class="cap">ID</text>
+    <text x="600" y="160" text-anchor="middle" class="tick">disclosure</text>
+    <text x="600" y="177" text-anchor="middle" class="tick">(IDG-01)</text>
+  </g>
+  <g>
+    <circle cx="720" cy="120" r="15" fill="url(#lsNode)"/><text x="720" y="125" text-anchor="middle" class="cap">✓</text>
+    <text x="720" y="160" text-anchor="middle" class="tick">gate cleared</text>
+    <text x="720" y="177" text-anchor="middle" class="tick">(PDX-01)</text>
+  </g>
+  <g>
+    <circle cx="820" cy="120" r="15" fill="url(#lsNode)"/><text x="820" y="125" text-anchor="middle" class="cap">PHI</text>
+    <text x="820" y="160" text-anchor="middle" class="tick">exchange</text>
+    <text x="820" y="177" text-anchor="middle" class="tick">after verify</text>
+  </g>
+  <g>
+    <circle cx="920" cy="120" r="15" fill="url(#lsGood)"/><text x="920" y="125" text-anchor="middle" class="cap">⇲</text>
+    <text x="920" y="160" text-anchor="middle" class="tick">escalation +</text>
+    <text x="920" y="177" text-anchor="middle" class="tick">audit (EIT/ATR)</text>
+  </g>
+  <rect x="560" y="228" width="380" height="70" rx="14" fill="#e8f8f4" stroke="#b6e6dc" stroke-width="1.5"/>
+  <text x="580" y="258" class="s" fill="#0e7568" font-weight="700">Impersonation latency measured &amp; bounded</text>
+  <text x="580" y="282" class="s">Early disclosure · checkpoint · escalation · sealed audit.</text>
 </svg>

--- a/assets/images/3d-svg/nexus.svg
+++ b/assets/images/3d-svg/nexus.svg
@@ -1,30 +1,58 @@
-<svg width="800" height="420" viewBox="0 0 800 420" fill="none" xmlns="http://www.w3.org/2000/svg">
-  <rect width="800" height="420" fill="#0F172A"/>
-  <text x="400" y="36" text-anchor="middle" font-family="Inter, system-ui, sans-serif" font-size="18" font-weight="700" fill="#F1F5F9">Trust Verification Pathway</text>
-  <text x="400" y="56" text-anchor="middle" font-family="Inter" font-size="12" fill="#94A3B8">From untrusted AI caller → verified, authorized, auditable exchange</text>
-  <rect x="40" y="120" width="120" height="200" rx="12" fill="#1E2937" stroke="#64748B" stroke-width="2"/>
-  <text x="100" y="160" text-anchor="middle" font-family="Inter" font-size="12" font-weight="600" fill="#94A3B8">AI Agent</text>
-  <text x="100" y="180" text-anchor="middle" font-family="Inter" font-size="11" fill="#64748B">Unverified</text>
-  <circle cx="100" cy="230" r="28" fill="#334155" stroke="#64748B" stroke-width="2"/>
-  <text x="100" y="236" text-anchor="middle" font-family="Inter" font-size="11" fill="#94A3B8">?</text>
-  <rect x="180" y="200" width="440" height="40" rx="6" fill="#134E4A" stroke="#14B8A6" stroke-width="2"/>
-  <rect x="220" y="180" width="70" height="80" rx="6" fill="#0F172A" stroke="#14B8A6" stroke-width="2"/>
-  <text x="255" y="210" text-anchor="middle" font-family="Inter" font-size="10" font-weight="600" fill="#5EEAD4">IDG-01</text>
-  <text x="255" y="226" text-anchor="middle" font-family="Inter" font-size="9" fill="#99F6E4">Disclose</text>
-  <rect x="320" y="180" width="70" height="80" rx="6" fill="#0F172A" stroke="#14B8A6" stroke-width="2"/>
-  <text x="355" y="210" text-anchor="middle" font-family="Inter" font-size="10" font-weight="600" fill="#5EEAD4">PDX-01</text>
-  <text x="355" y="226" text-anchor="middle" font-family="Inter" font-size="9" fill="#99F6E4">Gate PHI</text>
-  <rect x="420" y="180" width="70" height="80" rx="6" fill="#0F172A" stroke="#14B8A6" stroke-width="2"/>
-  <text x="455" y="210" text-anchor="middle" font-family="Inter" font-size="10" font-weight="600" fill="#5EEAD4">EIT-01</text>
-  <text x="455" y="226" text-anchor="middle" font-family="Inter" font-size="9" fill="#99F6E4">Escalate</text>
-  <rect x="520" y="180" width="70" height="80" rx="6" fill="#0F172A" stroke="#14B8A6" stroke-width="2"/>
-  <text x="555" y="210" text-anchor="middle" font-family="Inter" font-size="10" font-weight="600" fill="#5EEAD4">ATR-01</text>
-  <text x="555" y="226" text-anchor="middle" font-family="Inter" font-size="9" fill="#99F6E4">Audit</text>
-  <rect x="640" y="120" width="120" height="200" rx="12" fill="#134E4A" stroke="#14B8A6" stroke-width="2"/>
-  <text x="700" y="160" text-anchor="middle" font-family="Inter" font-size="12" font-weight="600" fill="#5EEAD4">Verified</text>
-  <text x="700" y="180" text-anchor="middle" font-family="Inter" font-size="11" fill="#99F6E4">Trusted</text>
-  <circle cx="700" cy="230" r="28" fill="#0F766E" stroke="#14B8A6" stroke-width="2"/>
-  <text x="700" y="236" text-anchor="middle" font-family="Inter" font-size="16" fill="#5EEAD4">✓</text>
-  <text x="400" y="320" text-anchor="middle" font-family="Inter" font-size="12" fill="#94A3B8">Every gate must pass before PHI moves. Full audit trail sealed at end.</text>
-  <text x="400" y="360" text-anchor="middle" font-family="Inter" font-size="11" fill="#64748B">Optional NHID-Auth v2 cryptographic passport sits on top of the behavioral layer</text>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 620" role="img" aria-labelledby="nx-t nx-d">
+  <title id="nx-t">Trust Verification Nexus — conceptual visualization</title>
+  <desc id="nx-d">Illustrative visualization of the NHID-Clinical verification pathway: a payer domain and a provider domain bridged by a central conformance shield carrying a voice waveform, with the brand mark above. Conceptual render for clarity; not a product diagram.</desc>
+  <defs>
+    <radialGradient id="nxGlow" cx="0.5" cy="0.42" r="0.6"><stop offset="0" stop-color="#e8f8f4"/><stop offset="1" stop-color="#ffffff"/></radialGradient>
+    <linearGradient id="nxNode" x1="0" y1="0" x2="0" y2="1"><stop offset="0" stop-color="#33516f"/><stop offset="1" stop-color="#16385f"/></linearGradient>
+    <linearGradient id="nxPath" x1="0" y1="0" x2="1" y2="0"><stop offset="0" stop-color="#3b6aa0"/><stop offset="0.5" stop-color="#189a8a"/><stop offset="1" stop-color="#3b6aa0"/></linearGradient>
+    <linearGradient id="nxGlass" x1="0.2" y1="0" x2="0.85" y2="1">
+      <stop offset="0" stop-color="#b8c9dd" stop-opacity="0.9"/><stop offset="0.5" stop-color="#5f7fa5" stop-opacity="0.95"/><stop offset="1" stop-color="#2c4a6e"/>
+    </linearGradient>
+    <linearGradient id="nxEdge" x1="0" y1="0" x2="0" y2="1"><stop offset="0" stop-color="#ffffff" stop-opacity="0.75"/><stop offset="1" stop-color="#ffffff" stop-opacity="0.12"/></linearGradient>
+    <style>
+      .lab { font-family:'Segoe UI','Helvetica Neue',Arial,sans-serif; font-size:17px; font-weight:700; fill:#082a5b; }
+      .sub { font-family:'Segoe UI','Helvetica Neue',Arial,sans-serif; font-size:13px; fill:#5d6b7a; }
+    </style>
+  </defs>
+
+  <rect x="0" y="0" width="1000" height="620" fill="url(#nxGlow)"/>
+
+  <!-- connecting pathway -->
+  <path d="M190 330 H810" stroke="url(#nxPath)" stroke-width="7" stroke-linecap="round"/>
+  <circle cx="360" cy="330" r="6" fill="#189a8a"/><circle cx="500" cy="330" r="6" fill="#189a8a"/><circle cx="640" cy="330" r="6" fill="#189a8a"/>
+
+  <!-- payer domain -->
+  <g>
+    <rect x="70" y="286" width="150" height="88" rx="22" fill="url(#nxNode)"/>
+    <text x="145" y="336" text-anchor="middle" class="lab" fill="#e8f1fb">Payer</text>
+  </g>
+  <!-- provider domain -->
+  <g>
+    <rect x="780" y="286" width="150" height="88" rx="22" fill="url(#nxNode)"/>
+    <text x="855" y="336" text-anchor="middle" class="lab" fill="#e8f1fb">Provider</text>
+  </g>
+
+  <!-- brand mark, small, above the shield -->
+  <g transform="translate(456,70) scale(0.175)">
+    <rect x="28" y="148" width="150" height="214" rx="44" fill="#0f2440"/>
+    <path d="M252 14 H318 Q362 14 362 58 V264 Q362 290 346 301 Q336 308 328 300 L214 186 Q206 178 206 166 V58 Q206 14 252 14 Z" fill="#3b6aa0"/>
+    <path d="M232 230 Q222 222 218 234 V426 Q218 470 262 470 H318 Q362 470 362 426 V362 Z" fill="#189a8a"/>
+    <circle cx="446" cy="146" r="52" fill="#16385f"/>
+    <rect x="398" y="304" width="106" height="106" rx="30" fill="#7fc4c9"/>
+  </g>
+
+  <!-- central conformance shield -->
+  <g transform="translate(410,168) scale(0.38)">
+    <path d="M240 18 C300 52 366 66 432 70 C438 214 430 330 384 414 C346 483 296 524 240 546 C184 524 134 483 96 414 C50 330 42 214 48 70 C114 66 180 52 240 18 Z"
+          fill="url(#nxGlass)" stroke="url(#nxEdge)" stroke-width="5"/>
+    <g stroke="#f2f7fc" stroke-width="7" stroke-linecap="round" opacity="0.95">
+      <line x1="120" y1="272" x2="120" y2="288"/><line x1="148" y1="258" x2="148" y2="302"/>
+      <line x1="176" y1="240" x2="176" y2="320"/><line x1="204" y1="212" x2="204" y2="348"/>
+      <line x1="232" y1="188" x2="232" y2="372"/><line x1="260" y1="214" x2="260" y2="346"/>
+      <line x1="288" y1="178" x2="288" y2="382"/><line x1="316" y1="228" x2="316" y2="332"/>
+      <line x1="344" y1="250" x2="344" y2="310"/><line x1="360" y1="266" x2="360" y2="294"/>
+    </g>
+  </g>
+  <text x="500" y="470" text-anchor="middle" class="lab">Conformance verification</text>
+  <text x="500" y="492" text-anchor="middle" class="sub">disclosure · pre-data gate · escalation · sealed audit</text>
 </svg>

--- a/assets/images/3d-svg/trust-stack.svg
+++ b/assets/images/3d-svg/trust-stack.svg
@@ -1,23 +1,71 @@
-<svg width="720" height="520" viewBox="0 0 720 520" fill="none" xmlns="http://www.w3.org/2000/svg">
-  <rect width="720" height="520" fill="#0F172A"/>
-  <text x="360" y="36" text-anchor="middle" font-family="Inter, system-ui, sans-serif" font-size="18" font-weight="700" fill="#F1F5F9">Five-Layer Trust Stack</text>
-  <text x="360" y="56" text-anchor="middle" font-family="Inter, system-ui, sans-serif" font-size="12" fill="#94A3B8">NHID-Clinical + supporting standards</text>
-  <rect x="200" y="80" width="320" height="52" rx="8" fill="#1E2937" stroke="#14B8A6" stroke-width="2"/>
-  <text x="360" y="102" text-anchor="middle" font-family="Inter" font-size="13" font-weight="600" fill="#67E8F9">5 · OpenTelemetry</text>
-  <text x="360" y="120" text-anchor="middle" font-family="Inter" font-size="11" fill="#94A3B8">Enterprise observability export</text>
-  <rect x="160" y="150" width="400" height="52" rx="8" fill="#1E2937" stroke="#14B8A6" stroke-width="2"/>
-  <text x="360" y="172" text-anchor="middle" font-family="Inter" font-size="13" font-weight="600" fill="#67E8F9">4 · FHIR AuditEvent R4</text>
-  <text x="360" y="190" text-anchor="middle" font-family="Inter" font-size="11" fill="#94A3B8">Healthcare-native audit logging</text>
-  <rect x="120" y="220" width="480" height="52" rx="8" fill="#1E2937" stroke="#14B8A6" stroke-width="2"/>
-  <text x="360" y="242" text-anchor="middle" font-family="Inter" font-size="13" font-weight="600" fill="#67E8F9">3 · NHID-Auth v2</text>
-  <text x="360" y="260" text-anchor="middle" font-family="Inter" font-size="11" fill="#94A3B8">Cryptographic authorization (Ed25519 passports)</text>
-  <rect x="80" y="290" width="560" height="58" rx="8" fill="#134E4A" stroke="#14B8A6" stroke-width="2.5"/>
-  <text x="360" y="314" text-anchor="middle" font-family="Inter" font-size="14" font-weight="700" fill="#5EEAD4">2 · NHID-Clinical v1.3 (Behavioral Baseline)</text>
-  <text x="360" y="334" text-anchor="middle" font-family="Inter" font-size="11" fill="#99F6E4">IDG-01 · PDX-01 · DBC-01 · EIT-01 · ATR-01</text>
-  <rect x="40" y="366" width="640" height="52" rx="8" fill="#1E2937" stroke="#64748B" stroke-width="1.5"/>
-  <text x="360" y="388" text-anchor="middle" font-family="Inter" font-size="13" font-weight="600" fill="#CBD5E1">1 · STIR/SHAKEN (RFC 8224)</text>
-  <text x="360" y="406" text-anchor="middle" font-family="Inter" font-size="11" fill="#94A3B8">Carrier number authentication</text>
-  <rect x="20" y="436" width="680" height="52" rx="8" fill="#1E2937" stroke="#64748B" stroke-width="1.5"/>
-  <text x="360" y="458" text-anchor="middle" font-family="Inter" font-size="13" font-weight="600" fill="#94A3B8">0 · NPI Gap (the problem)</text>
-  <text x="360" y="476" text-anchor="middle" font-family="Inter" font-size="11" fill="#64748B">No portable cross-org authorization for AI agents</text>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 560" role="img" aria-labelledby="tz-t tz-d">
+  <title id="tz-t">Five-Layer Trust Stack — conceptual visualization</title>
+  <desc id="tz-d">Illustrative isometric visualization of the NHID-Clinical five-layer trust architecture: STIR/SHAKEN carrier authentication, NHID-Clinical v1.3 behavioral disclosure (highlighted), NHID-Auth v2 cryptographic authorization, FHIR AuditEvent R4 audit logging, and OpenTelemetry observability. Layer order matches the specification's five-layer trust stack.</desc>
+  <defs>
+    <linearGradient id="tsL1" x1="0" y1="0" x2="0" y2="1"><stop offset="0" stop-color="#5c6d84"/><stop offset="1" stop-color="#44546a"/></linearGradient>
+    <linearGradient id="tsL2" x1="0" y1="0" x2="0" y2="1"><stop offset="0" stop-color="#35c2ab"/><stop offset="1" stop-color="#148f80"/></linearGradient>
+    <linearGradient id="tsL3" x1="0" y1="0" x2="0" y2="1"><stop offset="0" stop-color="#6493c6"/><stop offset="1" stop-color="#3b6aa0"/></linearGradient>
+    <linearGradient id="tsL4" x1="0" y1="0" x2="0" y2="1"><stop offset="0" stop-color="#2c5787"/><stop offset="1" stop-color="#16385f"/></linearGradient>
+    <linearGradient id="tsL5" x1="0" y1="0" x2="0" y2="1"><stop offset="0" stop-color="#aadfe4"/><stop offset="1" stop-color="#7fc4c9"/></linearGradient>
+    <style>
+      .lbl { font-family:'Segoe UI','Helvetica Neue',Arial,sans-serif; font-size:21px; font-weight:700; fill:#082a5b; }
+      .sub { font-family:'Segoe UI','Helvetica Neue',Arial,sans-serif; font-size:15px; font-weight:400; fill:#5d6b7a; }
+      .num { font-family:'Segoe UI','Helvetica Neue',Arial,sans-serif; font-size:16px; font-weight:700; fill:#ffffff; }
+      .side { opacity:0.72; } .side2 { opacity:0.5; }
+    </style>
+  </defs>
+
+  <ellipse cx="235" cy="500" rx="205" ry="30" fill="#0f2440" opacity="0.10"/>
+  <text x="30" y="536" class="sub" font-style="italic">Layer 0 — the NPI gap: no cross-organization authorization for AI agents.</text>
+
+  <!-- L1 -->
+  <g>
+    <path class="side" d="M85 452 L85 478 L235 532 L235 506 Z" fill="url(#tsL1)"/>
+    <path class="side2" d="M385 452 L385 478 L235 532 L235 506 Z" fill="url(#tsL1)"/>
+    <path d="M85 452 L235 398 L385 452 L235 506 Z" fill="url(#tsL1)"/>
+    <text x="228" y="461" class="num">1</text>
+    <line x1="392" y1="452" x2="452" y2="452" stroke="#c3ccd6" stroke-width="1.6"/>
+    <text x="462" y="450" class="lbl">STIR/SHAKEN</text>
+    <text x="462" y="472" class="sub">Carrier number authentication (RFC 8224)</text>
+  </g>
+  <!-- L2 highlight -->
+  <g>
+    <path class="side" d="M85 372 L85 398 L235 452 L235 426 Z" fill="url(#tsL2)"/>
+    <path class="side2" d="M385 372 L385 398 L235 452 L235 426 Z" fill="url(#tsL2)"/>
+    <path d="M85 372 L235 318 L385 372 L235 426 Z" fill="url(#tsL2)" stroke="#ffffff" stroke-width="2" stroke-opacity="0.55"/>
+    <text x="228" y="381" class="num">2</text>
+    <line x1="392" y1="372" x2="452" y2="372" stroke="#189a8a" stroke-width="2"/>
+    <text x="462" y="370" class="lbl" fill="#0e7568">NHID-Clinical v1.3</text>
+    <text x="462" y="392" class="sub">Behavioral disclosure baseline — 4 controls + ATR-01</text>
+  </g>
+  <!-- L3 -->
+  <g>
+    <path class="side" d="M85 292 L85 318 L235 372 L235 346 Z" fill="url(#tsL3)"/>
+    <path class="side2" d="M385 292 L385 318 L235 372 L235 346 Z" fill="url(#tsL3)"/>
+    <path d="M85 292 L235 238 L385 292 L235 346 Z" fill="url(#tsL3)"/>
+    <text x="228" y="301" class="num">3</text>
+    <line x1="392" y1="292" x2="452" y2="292" stroke="#c3ccd6" stroke-width="1.6"/>
+    <text x="462" y="290" class="lbl">NHID-Auth v2</text>
+    <text x="462" y="312" class="sub">Cryptographic authorization — Ed25519 agent passports</text>
+  </g>
+  <!-- L4 -->
+  <g>
+    <path class="side" d="M85 212 L85 238 L235 292 L235 266 Z" fill="url(#tsL4)"/>
+    <path class="side2" d="M385 212 L385 238 L235 292 L235 266 Z" fill="url(#tsL4)"/>
+    <path d="M85 212 L235 158 L385 212 L235 266 Z" fill="url(#tsL4)"/>
+    <text x="228" y="221" class="num">4</text>
+    <line x1="392" y1="212" x2="452" y2="212" stroke="#c3ccd6" stroke-width="1.6"/>
+    <text x="462" y="210" class="lbl">FHIR AuditEvent R4</text>
+    <text x="462" y="232" class="sub">Healthcare-native audit logging (base spec)</text>
+  </g>
+  <!-- L5 -->
+  <g>
+    <path class="side" d="M85 132 L85 158 L235 212 L235 186 Z" fill="url(#tsL5)"/>
+    <path class="side2" d="M385 132 L385 158 L235 212 L235 186 Z" fill="url(#tsL5)"/>
+    <path d="M85 132 L235 78 L385 132 L235 186 Z" fill="url(#tsL5)"/>
+    <text x="228" y="141" class="num" fill="#0f2440">5</text>
+    <line x1="392" y1="132" x2="452" y2="132" stroke="#c3ccd6" stroke-width="1.6"/>
+    <text x="462" y="130" class="lbl">OpenTelemetry</text>
+    <text x="462" y="152" class="sub">Enterprise observability export</text>
+  </g>
 </svg>

--- a/community.html
+++ b/community.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1"/>
   <meta name="description" content="Join the NHID-Clinical community on GitHub. Help define what acceptable healthcare AI voice calls look like."/>
   <title>Community | NHID-Clinical</title>
+  <link rel="icon" href="/assets/brand/favicon.svg" type="image/svg+xml"/>
   <link rel="icon" href="/assets/brand-icon.png" type="image/png"/>
   <link rel="preconnect" href="https://fonts.googleapis.com"/>
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>

--- a/demo.html
+++ b/demo.html
@@ -6,6 +6,7 @@
   <meta name="description" content="NHID-Clinical live demo line — call a number and watch a real conformance evaluation pass or fail in real time."/>
   <title>Live Demo Line | NHID-Clinical</title>
   <script>try{document.documentElement.setAttribute('data-theme',localStorage.getItem('nhid-theme')||'light')}catch(e){}</script>
+  <link rel="icon" href="/assets/brand/favicon.svg" type="image/svg+xml"/>
   <link rel="icon" href="/assets/brand-icon.png" type="image/png"/>
   <link rel="preconnect" href="https://fonts.googleapis.com"/>
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>

--- a/developers.html
+++ b/developers.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1"/>
   <meta name="description" content="NHID-Clinical Technical Reference — JSON Schema, policy engine, conformance test suite, failure injection harness, and trace generator for the v1.3 specification."/>
   <title>Technical Reference – NHID-Clinical</title>
+  <link rel="icon" href="/assets/brand/favicon.svg" type="image/svg+xml"/>
   <link rel="icon" href="/assets/brand-icon.png" type="image/png"/>
   <link rel="preconnect" href="https://fonts.googleapis.com"/>
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>

--- a/evidence-pack.html
+++ b/evidence-pack.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1"/>
   <meta name="description" content="NHID-Clinical Evidence Pack — system behavior guarantees, failure trace example, audit readiness model, and risk register for procurement and enterprise teams."/>
   <title>Evidence Pack | NHID-Clinical</title>
+  <link rel="icon" href="/assets/brand/favicon.svg" type="image/svg+xml"/>
   <link rel="icon" href="/assets/brand-icon.png" type="image/png"/>
   <link rel="preconnect" href="https://fonts.googleapis.com"/>
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>

--- a/faq.html
+++ b/faq.html
@@ -6,6 +6,7 @@
   <meta name="description" content="NHID-Clinical FAQ — frequently asked questions about the non-human identity disclosure proposal for healthcare voice AI."/>
   <title>FAQ | NHID-Clinical</title>
   <script>try{document.documentElement.setAttribute('data-theme',localStorage.getItem('nhid-theme')||'light')}catch(e){}</script>
+  <link rel="icon" href="/assets/brand/favicon.svg" type="image/svg+xml"/>
   <link rel="icon" href="/assets/brand-icon.png" type="image/png"/>
   <link rel="preconnect" href="https://fonts.googleapis.com"/>
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>

--- a/for-payers.html
+++ b/for-payers.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1"/>
   <meta name="description" content="NHID-Clinical For Payers — 90-day shadow pilot guide for payer operations teams evaluating AI voice agent transparency."/>
   <title>For Payers – 90-Day Pilot Guide | NHID-Clinical</title>
+  <link rel="icon" href="/assets/brand/favicon.svg" type="image/svg+xml"/>
   <link rel="icon" href="/assets/brand-icon.png" type="image/png"/>
   <link rel="preconnect" href="https://fonts.googleapis.com"/>
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>

--- a/gov-sim.html
+++ b/gov-sim.html
@@ -4,7 +4,8 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Governance Simulator — NHID-Clinical</title>
-<link rel="icon" href="/assets/brand-icon.png" type="image/png">
+<link rel="icon" href="/assets/brand/favicon.svg" type="image/svg+xml"/>
+<link rel="icon" href="/assets/brand-icon.png" type="image/png"/>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Inter:ital,opsz,wght@0,14..32,400;0,14..32,500;0,14..32,600;1,14..32,400&display=swap" rel="stylesheet">

--- a/icon-system.html
+++ b/icon-system.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1"/>
   <meta name="description" content="NHID-Clinical Icon System — a hexagon-framed icon pack for AI voice-agent identity disclosure and authorization, covering consent, voice interaction, identity, escalation, security, and records."/>
   <title>Icon System | NHID-Clinical</title>
+  <link rel="icon" href="/assets/brand/favicon.svg" type="image/svg+xml"/>
   <link rel="icon" href="/assets/brand-icon.png" type="image/png"/>
   <link rel="preconnect" href="https://fonts.googleapis.com"/>
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>

--- a/implementation-review.html
+++ b/implementation-review.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1"/>
   <meta name="description" content="NHID-Clinical Implementation Review — How vendors can get their AI voice agent implementation reviewed against the five proposed requirements."/>
   <title>Implementation Review | NHID-Clinical</title>
+  <link rel="icon" href="/assets/brand/favicon.svg" type="image/svg+xml"/>
   <link rel="icon" href="/assets/brand-icon.png" type="image/png"/>
   <link rel="preconnect" href="https://fonts.googleapis.com"/>
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>

--- a/index.html
+++ b/index.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1"/>
   <meta name="description" content="NHID-Clinical — a voluntary, testable behavioral baseline for AI voice agents in B2B healthcare payer–provider calls. Open reference implementation by a former payer operations associate."/>
   <title>NHID-Clinical | Transparent AI Voice Agents in Healthcare</title>
+  <link rel="icon" href="/assets/brand/favicon.svg" type="image/svg+xml"/>
   <link rel="icon" href="/assets/brand-icon.png" type="image/png"/>
   <link rel="preconnect" href="https://fonts.googleapis.com"/>
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
@@ -154,11 +155,8 @@
         </div>
       </div>
       <div class="hero-art hero-art-nexus" aria-label="Governance Trust Nexus visualization">
-        <picture class="premium-3d">
-          <source srcset="/assets/images/3d-renders/nexus-trust-bridge.webp" type="image/webp"/>
-          <img src="/assets/images/3d-svg/nexus.svg" alt="Illustrative visualization of the Governance Trust Nexus — a verification bridge between payer and provider voice workflows. Conceptual render for clarity."/>
-        </picture>
-        <p class="visual-caption">Governance Trust Nexus — illustrative 3D render</p>
+        <img class="premium-3d" src="/assets/images/3d-svg/nexus.svg" alt="Illustrative visualization of the Governance Trust Nexus — a verification bridge between payer and provider voice workflows. Conceptual render for clarity."/>
+        <p class="visual-caption">Trust Verification Nexus — illustrative render</p>
       </div>
     </div>
   </section>
@@ -197,11 +195,8 @@
       <p class="lead">The proposal's architecture in one picture: each layer is testable on its own, and together they turn "trust me" into a verifiable pathway. Click a layer to see what it does and where to try it.</p>
       <div class="stack-wrap">
         <div>
-          <picture class="premium-3d">
-            <source srcset="/assets/images/3d-renders/trust-stack-ziggurat.webp" type="image/webp"/>
-            <img src="/assets/images/3d-svg/trust-stack.svg" class="premium-3d" style="max-width:34rem"
-                 alt="Illustrative 3D visualization of the NHID-Clinical five-layer trust stack as a stepped monument. Conceptual render for clarity."/>
-          </picture>
+          <img src="/assets/images/3d-svg/trust-stack.svg" class="premium-3d" style="max-width:38rem"
+               alt="Illustrative visualization of the NHID-Clinical five-layer trust stack: STIR/SHAKEN carrier authentication, NHID-Clinical v1.3 behavioral disclosure, NHID-Auth v2 cryptographic authorization, FHIR AuditEvent R4 audit logging, OpenTelemetry observability. Conceptual render for clarity."/>
           <p class="visual-caption">Conceptual render for clarity — the authoritative definitions live in the specification.</p>
         </div>
         <div>
@@ -258,11 +253,8 @@
       <p class="lead">Impersonation latency is the time window in which an AI agent is already interacting and exchanging information while its identity and authorization remain unverified. In payer–provider voice calls, that window frequently covers member IDs, NPIs, dates of birth, and claim data — before any clear disclosure that the caller is automated. Telephony and IAM layers authenticate numbers or accounts, but they do not provide portable proof that a specific AI caller is authorized to represent a particular provider organization.</p>
       <p class="lead" style="margin-top:.75rem">The gap is well documented; large-scale production evidence is still limited. The strongest next step for most organizations is measurement on their own traffic — see the <a href="https://github.com/NHID-Clinical/NHID-Clinical/tree/main/docs/pilot-kit">Tier 0 Shadow Pilot Kit</a>.</p>
 
-      <picture class="premium-3d">
-        <source srcset="/assets/images/3d-renders/impersonation-vs-verified.webp" type="image/webp"/>
-        <img src="/assets/images/3d-svg/latency-split.svg" class="premium-3d"
-             alt="Illustrative 3D visualization contrasting the impersonation latency problem (left) with the verified trust pathway enabled by NHID-Clinical (right). Conceptual render for clarity."/>
-      </picture>
+      <img src="/assets/images/3d-svg/latency-split.svg" class="premium-3d"
+           alt="Illustrative visualization contrasting the impersonation latency problem (left: an unverified caller reaching PHI with no checks) with the verified trust pathway enabled by NHID-Clinical (right: disclosure gate, verification checkpoint, sealed PHI, human escalation). Conceptual render for clarity."/>
 
       <div class="two-column">
         <div class="col-bad">

--- a/interoperability.html
+++ b/interoperability.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1"/>
   <meta name="description" content="NHID-Clinical Interoperability Demo — mapping Twilio call transcripts to NHID-Clinical v1.3 event traces and running conformance checks."/>
   <title>Interoperability Demo | NHID-Clinical</title>
+  <link rel="icon" href="/assets/brand/favicon.svg" type="image/svg+xml"/>
   <link rel="icon" href="/assets/brand-icon.png" type="image/png"/>
   <link rel="preconnect" href="https://fonts.googleapis.com"/>
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>

--- a/news.html
+++ b/news.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1"/>
   <meta name="description" content="NHID-Clinical news — specification releases, implementation milestones, and community updates."/>
   <title>News | NHID-Clinical</title>
+  <link rel="icon" href="/assets/brand/favicon.svg" type="image/svg+xml"/>
   <link rel="icon" href="/assets/brand-icon.png" type="image/png"/>
   <link rel="preconnect" href="https://fonts.googleapis.com"/>
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>

--- a/privacy.html
+++ b/privacy.html
@@ -6,6 +6,7 @@
   <meta name="description" content="NHID-Clinical privacy policy, including SMS/mobile messaging terms for the starter-pack text program."/>
   <title>Privacy Policy | NHID-Clinical</title>
   <script>try{document.documentElement.setAttribute('data-theme',localStorage.getItem('nhid-theme')||'light')}catch(e){}</script>
+  <link rel="icon" href="/assets/brand/favicon.svg" type="image/svg+xml"/>
   <link rel="icon" href="/assets/brand-icon.png" type="image/png"/>
   <link rel="preconnect" href="https://fonts.googleapis.com"/>
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>

--- a/proof.html
+++ b/proof.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1"/>
   <meta name="description" content="NHID-Clinical Technical Proof Package — deterministic guarantees, audit readiness model, architecture notes, and risk register for enterprise and procurement teams."/>
   <title>Technical Proof Package | NHID-Clinical</title>
+  <link rel="icon" href="/assets/brand/favicon.svg" type="image/svg+xml"/>
   <link rel="icon" href="/assets/brand-icon.png" type="image/png"/>
   <link rel="preconnect" href="https://fonts.googleapis.com"/>
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>

--- a/registry.html
+++ b/registry.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1"/>
   <meta name="description" content="NHID-Clinical Implementation Registry — self-attested vendor implementations with live NHID-CAS badges."/>
   <title>Implementation Registry | NHID-Clinical</title>
+  <link rel="icon" href="/assets/brand/favicon.svg" type="image/svg+xml"/>
   <link rel="icon" href="/assets/brand-icon.png" type="image/png"/>
   <link rel="preconnect" href="https://fonts.googleapis.com"/>
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>

--- a/regulatory-alignment.html
+++ b/regulatory-alignment.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1"/>
   <meta name="description" content="NHID-Clinical Regulatory Alignment — How the proposal maps to CMS-0057-F, MACPAC, DOJ FCA enforcement, and state AI laws."/>
   <title>Regulatory Alignment | NHID-Clinical</title>
+  <link rel="icon" href="/assets/brand/favicon.svg" type="image/svg+xml"/>
   <link rel="icon" href="/assets/brand-icon.png" type="image/png"/>
   <link rel="preconnect" href="https://fonts.googleapis.com"/>
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>

--- a/roadmap.html
+++ b/roadmap.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1"/>
   <meta name="description" content="NHID-Auth v2 — Cryptographic agent identity for healthcare voice AI. Public reference implementation."/>
   <title>v2 Roadmap | NHID-Clinical</title>
+  <link rel="icon" href="/assets/brand/favicon.svg" type="image/svg+xml"/>
   <link rel="icon" href="/assets/brand-icon.png" type="image/png"/>
   <link rel="preconnect" href="https://fonts.googleapis.com"/>
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>

--- a/script-examples.html
+++ b/script-examples.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1"/>
   <meta name="description" content="NHID-Clinical Script Examples — passing and failing AI voice agent opening scripts for payer–provider workflows."/>
   <title>Script Examples | NHID-Clinical</title>
+  <link rel="icon" href="/assets/brand/favicon.svg" type="image/svg+xml"/>
   <link rel="icon" href="/assets/brand-icon.png" type="image/png"/>
   <link rel="preconnect" href="https://fonts.googleapis.com"/>
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>

--- a/shadow-evaluation-guide.html
+++ b/shadow-evaluation-guide.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1"/>
   <meta name="description" content="NHID-Clinical Shadow Evaluation Guide — a no-cost, 90-day behavioral baseline observation guide for payers assessing AI voice agent transparency in B2B administrative workflows."/>
   <title>Shadow Evaluation Guide | NHID-Clinical</title>
+  <link rel="icon" href="/assets/brand/favicon.svg" type="image/svg+xml"/>
   <link rel="icon" href="/assets/brand-icon.png" type="image/png"/>
   <link rel="preconnect" href="https://fonts.googleapis.com"/>
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>

--- a/simulator.html
+++ b/simulator.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1"/>
   <meta name="description" content="NHID-Clinical Governance Simulator — run deterministic policy traces across 5 healthcare voice AI scenarios and verify NHID-Clinical v1.3 conformance."/>
   <title>Governance Simulator | NHID-Clinical</title>
+  <link rel="icon" href="/assets/brand/favicon.svg" type="image/svg+xml"/>
   <link rel="icon" href="/assets/brand-icon.png" type="image/png"/>
   <link rel="preconnect" href="https://fonts.googleapis.com"/>
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>

--- a/sms-opt-in.html
+++ b/sms-opt-in.html
@@ -6,6 +6,7 @@
   <meta name="description" content="Opt in to receive the NHID-Clinical starter pack — a one-time text message with a link to our shadow-evaluation guide."/>
   <title>Get the Starter Pack by Text | NHID-Clinical</title>
   <script>try{document.documentElement.setAttribute('data-theme',localStorage.getItem('nhid-theme')||'light')}catch(e){}</script>
+  <link rel="icon" href="/assets/brand/favicon.svg" type="image/svg+xml"/>
   <link rel="icon" href="/assets/brand-icon.png" type="image/png"/>
   <link rel="preconnect" href="https://fonts.googleapis.com"/>
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>

--- a/specification.html
+++ b/specification.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1"/>
   <meta name="description" content="NHID-Clinical v1.3 Specification — Open proposal for non-human identity disclosure in healthcare voice workflows. Five proposed requirements for transparent AI voice agent behavior."/>
   <title>Specification | NHID-Clinical v1.3</title>
+  <link rel="icon" href="/assets/brand/favicon.svg" type="image/svg+xml"/>
   <link rel="icon" href="/assets/brand-icon.png" type="image/png"/>
   <link rel="preconnect" href="https://fonts.googleapis.com"/>
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>

--- a/technical-stack.html
+++ b/technical-stack.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1"/>
   <meta name="description" content="NHID-Clinical Technical Stack — The five-layer trust stack for B2B healthcare voice AI."/>
   <title>Technical Stack | NHID-Clinical</title>
+  <link rel="icon" href="/assets/brand/favicon.svg" type="image/svg+xml"/>
   <link rel="icon" href="/assets/brand-icon.png" type="image/png"/>
   <link rel="preconnect" href="https://fonts.googleapis.com"/>
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>


### PR DESCRIPTION
## What this ships

A production **SVG brand system** faithful to the uploaded premium 3D/glass reference renders, built SVG-first so the new look is live now; raster hero renders can slot back in as `<source>` elements later.

- **`assets/brand/`** — logo mark (flat / rich-material / dark), light+dark lockups, favicon, and a glass shield+waveform motif. Rendered and eyeballed on light **and** dark via headless Chromium.
- **`assets/icons/nhid-icons.svg`** — 8 new symbols (IDG-01, PDX-01, DBC-01, EIT-01, ATR-01, impersonation-latency, CAS, trust-stack) in the existing sprite grammar, theme-able through the `icon-base`/`icon-accent` CSS variables so they hold on dark surfaces.
- **`assets/images/3d-svg/{trust-stack,latency-split,nexus}.svg`** — redrawn in the new material language (isometric five-layer stack, before/after latency contrast, payer↔provider verification nexus with shield).
- **Integration** — README uses the SVG lockup + points its three diagrams directly at the new SVGs; DBC-01 row reworded to canonical artifacts (synthetic breathing/hesitation); SVG favicon wired into all 24 site pages (PNG retained as fallback); `index.html` hero + diagrams swapped to the new SVGs.
- **`.claude/prompts/`** — two architect system prompts saved verbatim for reuse.

## Scope / honesty guards (self-imposed)

- Exact **330** test count kept everywhere — no "330+"; no "tamper-evident" or certification language.
- No SaaS code (that's a separate repo), no video/QR placement, no raster generation, no engine/test/lexicon/count changes.
- Rebased onto the latest `main` (which had reorg + SVG-regen commits); the three diagram conflicts resolved to the new brand versions, README/index merges preserved main's other changes.

## Verification (green on the rebased branch)

- `python scripts/validate_ci.py` → `CI PASS: 330 passed`
- `python scripts/check_baseline.py` → baseline unchanged (DBC-01 183/200, 5 FP)
- `python scripts/check_number_drift.py` → consistent
- All 11 new/edited SVGs pass strict XML parsing (fixed an illegal `--` inside an XML comment in the sprite)

## Security scan (council-requested)

Grep scan over tracked files for emails / private keys / token shapes: **no secrets, keys, or tokens.** Only finding is the owner's personal email (`bnbaynard@gmail.com`) in `.gitconfig` and `content/PROJECT_SPEC.md` — your own address in your own repo, left untouched. Flagging for awareness only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K6naAZodVs6Cftbq2miy1L

---
_Generated by [Claude Code](https://claude.ai/code/session_01K6naAZodVs6Cftbq2miy1L)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Visual Improvements**
  - Refreshed key homepage trust, stack, and latency visuals with updated premium artwork and descriptive text.
  - Updated README branding imagery and sizing for a more consistent presentation.

- **Branding**
  - Added SVG favicon support across the website, while retaining existing PNG icons for compatibility.

- **Documentation**
  - Added architecture guidance prompts covering governance, SaaS boundaries, visual standards, and current product priorities.
  - Clarified deceptive-behavior control wording around synthetic human-presence signals and human-status claims.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->