### PR TITLE
Disable CodeRabbit automatic reviews

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,16 @@
+# CodeRabbit configuration — reviews disabled.
+# Automatic PR reviews, summaries, and status comments are turned off.
+# To remove CodeRabbit entirely, uninstall the CodeRabbit GitHub App from
+# the repository/organization settings (this file only silences it).
+# Schema: https://coderabbit.ai/integrations/schema.v2.json
+reviews:
+  request_changes_workflow: false
+  high_level_summary: false
+  poem: false
+  review_status: false
+  collapse_walkthrough: true
+  auto_review:
+    enabled: false
+    drafts: false
+chat:
+  auto_reply: false


### PR DESCRIPTION
Adds `.coderabbit.yaml` that turns off CodeRabbit's automatic reviews, high-level summaries, review-status comments, and chat auto-reply — silencing it repo-wide.

Opened as a **draft** on purpose: CodeRabbit skips draft PRs, so it won't comment on this one.

> **Note:** this config silences CodeRabbit but does not uninstall it. To remove it entirely, uninstall the CodeRabbit GitHub App from repository/organization settings (**Settings → Integrations / GitHub Apps → CodeRabbit → Configure → Uninstall**, or github.com/settings/installations).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K6naAZodVs6Cftbq2miy1L

---
_Generated by [Claude Code](https://claude.ai/code/session_01K6naAZodVs6Cftbq2miy1L)_