### PR TITLE
Cross-link Governance Simulator to the interactive Zero Latency simulator

### DIFF
--- a/simulator.html
+++ b/simulator.html
@@ -406,6 +406,13 @@
     <a href="/developers.html" style="font-size:.82rem;color:var(--blue);font-weight:600">Full technical reference →</a>
   </div>
 
+  <div style="max-width:1400px;margin:0 auto 1rem;display:flex;align-items:center;justify-content:space-between;flex-wrap:wrap;gap:.75rem;padding:.7rem 1rem;border:1px solid var(--sim-gb,rgba(8,42,91,.10));border-radius:12px;background:var(--blue-soft,#eaf5fb)">
+    <div style="font-size:.85rem;color:var(--ink)">
+      <strong>Prefer a hands-on walkthrough?</strong> Try the interactive Zero Latency simulator — a guided, scenario-based training experience for the same NHID-Clinical controls.
+    </div>
+    <a href="https://nhid-clinical.github.io/Simulator/" style="font-size:.82rem;color:var(--blue);font-weight:600;white-space:nowrap">Open the interactive simulator →</a>
+  </div>
+
   <div class="sim-app">
 
     <!-- ── Sidebar ─────────────────────────────────────────── -->


### PR DESCRIPTION
## Summary

Adds a cross-link callout on `simulator.html` (the Governance Simulator) pointing to the hands-on, scenario-based **Zero Latency simulator** at `nhid-clinical.github.io/Simulator`, which walks through the same NHID-Clinical controls (IDG-01, PDX-01, DBC-01, EIT-01, ATR-01) as a guided training experience.

This is the "cross-link, no move" approach: the existing Governance Simulator stays exactly where it is at `/simulator.html` (and remains reachable at `/governance-simulator.html`), and we simply surface the interactive simulator alongside it. No content was moved and no existing behavior changed.

## Change

- A single self-contained callout `<div>` (inline styles with CSS-variable fallbacks that match the site theme) inserted between the page header and the simulator app, with a link to the interactive simulator.

## Notes

The reverse cross-link (from the Zero Latency simulator back to nhid-clinical.org) is added in the Simulator repo. If you later decide you want the interactive simulator to fully take the `/simulator.html` slot with a redirect from GitHub Pages, that's a larger port I can do as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015ZLsCPtwiCjpwJS3RMLUZH)_