### PR TITLE
Homepage redesign pass 2: control-layer grid + floating API mockup

### DIFF
--- a/index.html
+++ b/index.html
@@ -291,6 +291,82 @@
     </div>
   </section>
 
+  <!-- ── The control layer (capability grid) ───────────────────────────────── -->
+  <section class="page-section">
+    <div class="container">
+      <p class="section-kicker reveal">The control layer</p>
+      <h2 class="reveal" style="max-width:22ch">Six checks on every AI-agent call.</h2>
+      <p class="reveal" style="color:var(--body);max-width:62ch;margin-bottom:2rem">Each is observable on a real call and checkable against a machine-readable trace. Mapped, not certified.</p>
+      <div class="feature-grid">
+        <div class="feature-card reveal">
+          <span class="feature-ico"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="5" width="18" height="14" rx="2"/><circle cx="8.5" cy="12" r="2.2"/><path d="M13 10h5M13 14h5"/></svg></span>
+          <span class="code">IDG-01</span>
+          <h3>Identity Disclosure Gate</h3>
+          <p>Disclose non-human identity before any PHI is exchanged.</p>
+        </div>
+        <div class="feature-card reveal">
+          <span class="feature-ico"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3l7 3v5c0 4.5-3 7.5-7 9-4-1.5-7-4.5-7-9V6z"/><path d="M8.5 12h7"/></svg></span>
+          <span class="code">PDX-01</span>
+          <h3>Pre-Data Exchange Gate</h3>
+          <p>No protected data moves until identity is disclosed.</p>
+        </div>
+        <div class="feature-card reveal">
+          <span class="feature-ico"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M2 12s3.5-6 10-6 10 6 10 6-3.5 6-10 6S2 12 2 12z"/><circle cx="12" cy="12" r="2.6"/></svg></span>
+          <span class="code">DBC-01</span>
+          <h3>Deceptive Behavior Check</h3>
+          <p>No synthetic human-presence cues or false human-status claims.</p>
+        </div>
+        <div class="feature-card reveal">
+          <span class="feature-ico"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="7" r="3"/><path d="M6 20a6 6 0 0 1 12 0"/><path d="M12 14v-2m0 0-2 2m2-2 2 2" transform="translate(0 -6)"/></svg></span>
+          <span class="code">EIT-01</span>
+          <h3>Escalation Implementation Test</h3>
+          <p>A clear human handoff, honored on request.</p>
+        </div>
+        <div class="feature-card reveal">
+          <span class="feature-ico"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><rect x="5" y="3" width="14" height="18" rx="2"/><path d="M9 8h6M9 12h6M9 16h3"/></svg></span>
+          <span class="code">ATR-01</span>
+          <h3>Audit Trail</h3>
+          <p>Every call produces a machine-readable trace.</p>
+        </div>
+        <div class="feature-card reveal">
+          <span class="feature-ico"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M4 15a8 8 0 0 1 16 0"/><path d="M12 15l4-4"/><circle cx="12" cy="15" r="1.4" fill="currentColor" stroke="none"/></svg></span>
+          <span class="code">CAS</span>
+          <h3>Call Authorization Score</h3>
+          <p>One per-call score summarizing conformance across the controls.</p>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ── Live conformance API (floating UI mockup) ─────────────────────────── -->
+  <section class="page-section" style="background:var(--mist)">
+    <div class="container split-visual">
+      <div class="reveal">
+        <p class="section-kicker">Live conformance API</p>
+        <h2>One call in, a verdict out.</h2>
+        <p style="color:var(--body);max-width:52ch;line-height:1.7">Send a native VAPI or Twilio call payload and get a deterministic pass/fail across the controls, plus a per-call Call Authorization Score. No key required for demo routes.</p>
+        <div style="margin-top:1.4rem">
+          <a class="cta-button" href="/docs.html">Try the live API <span aria-hidden="true">→</span></a>
+        </div>
+      </div>
+      <div class="mock-ui reveal" role="img" aria-label="Illustrative conformance result: all five controls pass.">
+        <div class="mock-ui-bar">
+          <span class="mock-dot"></span><span class="mock-dot"></span><span class="mock-dot"></span>
+          <span class="mock-route">POST /v1/adapters/vapi/check</span>
+        </div>
+        <div class="mock-body">
+          <div class="mock-result"><strong>Result</strong><span class="mock-pill">CONFORMANT</span></div>
+          <div class="mock-row"><span>IDG-01 · Identity disclosure</span><span class="ok">✓</span></div>
+          <div class="mock-row"><span>PDX-01 · Pre-data exchange</span><span class="ok">✓</span></div>
+          <div class="mock-row"><span>DBC-01 · Deceptive behavior</span><span class="ok">✓</span></div>
+          <div class="mock-row"><span>EIT-01 · Escalation path</span><span class="ok">✓</span></div>
+          <div class="mock-row"><span>ATR-01 · Audit trace emitted</span><span class="ok">✓</span></div>
+          <p class="mock-tag">Illustrative result — not a live API response.</p>
+        </div>
+      </div>
+    </div>
+  </section>
+
   <!-- ── Section 2: What it is / What it is not ─────────────────────────── -->
   <section class="page-section">
     <div class="container" style="max-width:60rem">

--- a/nhid-clinical-ui.css
+++ b/nhid-clinical-ui.css
@@ -3280,3 +3280,28 @@ h2 { font-weight: 700; }
 .stats-strip { display: flex; flex-wrap: wrap; justify-content: center; gap: 2.5rem 3.5rem; text-align: center; }
 .stats-strip .stat b { display: block; font-family: var(--display); font-weight: 800; font-size: clamp(1.6rem, 3vw, 2.2rem); color: var(--ink); letter-spacing: -0.02em; line-height: 1; }
 .stats-strip .stat span { display: block; margin-top: .4rem; font-size: .84rem; color: var(--body); max-width: 20ch; }
+
+/* Capability (feature) grid — simple stroke icons */
+.feature-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(16.5rem, 1fr)); gap: 1.1rem; }
+.feature-card { padding: 1.5rem 1.5rem; border: 1px solid var(--line); border-radius: 16px; background: var(--paper); transition: transform .28s ease, box-shadow .28s ease, border-color .28s ease; }
+.feature-card:hover { transform: translateY(-4px); box-shadow: 0 18px 42px -24px rgba(15,23,42,.30); border-color: rgba(20,184,166,.45); }
+.feature-ico { width: 44px; height: 44px; border-radius: 12px; display: grid; place-items: center; background: var(--teal-soft); color: var(--teal-bright); margin-bottom: .95rem; }
+.feature-ico svg { width: 23px; height: 23px; }
+.feature-card .code { font-family: "IBM Plex Mono", monospace; font-size: .72rem; font-weight: 600; color: var(--teal-bright); letter-spacing: .04em; }
+.feature-card h3 { font-size: 1.05rem; margin: .1rem 0 .4rem; color: var(--ink); }
+.feature-card p { font-size: .9rem; color: var(--body); line-height: 1.6; margin: 0; }
+
+/* Split: copy + floating UI mockup */
+.split-visual { display: grid; grid-template-columns: 1fr 1fr; gap: 3rem; align-items: center; }
+@media (max-width: 820px) { .split-visual { grid-template-columns: 1fr; gap: 2rem; } }
+.mock-ui { border-radius: 16px; border: 1px solid var(--line); background: var(--paper); box-shadow: 0 34px 64px -34px rgba(15,23,42,.40); overflow: hidden; }
+.mock-ui-bar { display: flex; align-items: center; gap: .45rem; padding: .7rem 1rem; border-bottom: 1px solid var(--line); background: var(--mist); }
+.mock-dot { width: 10px; height: 10px; border-radius: 50%; background: var(--line); }
+.mock-route { font-family: "IBM Plex Mono", monospace; font-size: .76rem; color: var(--body); margin-left: .4rem; }
+.mock-body { padding: 1.25rem 1.4rem; }
+.mock-result { display: flex; align-items: center; justify-content: space-between; margin-bottom: .6rem; }
+.mock-result strong { font-family: var(--display); font-size: 1.05rem; color: var(--ink); }
+.mock-pill { font-size: .76rem; font-weight: 700; color: #0e7568; background: var(--teal-soft); border: 1px solid rgba(20,184,166,.4); padding: .3rem .75rem; border-radius: 999px; }
+.mock-row { display: flex; align-items: center; justify-content: space-between; padding: .58rem 0; border-top: 1px solid var(--line); font-size: .9rem; color: var(--ink-soft); }
+.mock-row .ok { color: var(--teal-bright); font-weight: 800; }
+.mock-tag { margin-top: 1rem; font-size: .72rem; color: var(--body); font-style: italic; }


### PR DESCRIPTION
## Summary

Second homepage pass in the Clutch-inspired visual language (design *principles* only — not a copy). Builds on the merged pass-1 hero. **No architecture/spec/playbook changes, no new claims/numbers**; canonical control names and every disclaimer preserved.

## What changed (index.html + shared CSS)

- **Problem → solution flow.** After the impersonation-latency before/after, a new **"The control layer"** capability grid — six feature cards (**IDG-01 · PDX-01 · DBC-01 · EIT-01 · ATR-01 · CAS**) with simple stroke icons and one-line descriptions.
- **Floating product-UI mockup.** A **"Live conformance API"** split section: left copy + CTA to the live API (`docs.html`), right a clean floating result card (browser bar, `POST /v1/adapters/vapi/check`, **CONFORMANT** pill, per-control ✓ rows). Labelled **"Illustrative — not a live API response"** so nothing reads as a fabricated metric (no invented CAS value).
- Reuses the reduced-motion-safe **`.reveal`** entrance motion and soft hover bloom; new `.feature-grid` / `.mock-ui` styles in `nhid-clinical-ui.css`.

## Verification
- Guards green: `validate_ci.py` **330**, `check_number_drift.py`.
- Chromium light + dark: both new sections render cleanly, icons + mock card crisp, no layout breaks.

## Not done (per your direction)
Headline kept at the bold 3-line size. Specification page and a How-it-works page are the next brief priorities once you're happy with the homepage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K6naAZodVs6Cftbq2miy1L

---
_Generated by [Claude Code](https://claude.ai/code/session_01K6naAZodVs6Cftbq2miy1L)_