### PR TITLE
Add "Identity Is the Missing Layer" commentary page + news/portfolio cross-links

### DIFF
--- a/identity-layer.html
+++ b/identity-layer.html
@@ -1,0 +1,158 @@
+﻿<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8"/>
+  <meta name="viewport" content="width=device-width, initial-scale=1"/>
+  <meta name="description" content="Independent AI governance commentary — why identity, not the model, is the missing layer of responsible AI, framed around Impersonation Latency and the five NHID-Clinical controls (NIST AI RMF, ISO/IEC 42001, HIPAA)."/>
+  <title>Why Identity Is the Missing Layer of Responsible AI | NHID-Clinical</title>
+  <link rel="icon" href="/assets/brand/favicon.svg" type="image/svg+xml"/>
+  <link rel="icon" href="/assets/brand-icon.png" type="image/png"/>
+  <link rel="preconnect" href="https://fonts.googleapis.com"/>
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
+  <link href="https://fonts.googleapis.com/css2?family=Raleway:wght@600;700;800&family=Inter:wght@400;500;600;700;800&family=IBM+Plex+Mono:wght@400;500&display=swap" rel="stylesheet"/>
+  <link rel="stylesheet" href="/nhid-clinical-ui.css"/>
+  <script>try{document.documentElement.setAttribute('data-theme',localStorage.getItem('nhid-theme')||'light')}catch(e){}</script>
+  <script defer data-domain="nhid-clinical.org" src="https://plausible.io/js/script.js"></script>
+</head>
+<body>
+
+<div class="status-strip">
+  <span class="status-strip-inner"><strong>Open governance framework · v1.3</strong> · Practitioner-led · not an accredited standard, certification, or regulatory requirement · seeking shadow-evaluation partners</span>
+</div>
+
+
+<header class="site-header">
+  <nav class="container nav" aria-label="Primary navigation">
+    <a class="brand" href="/" aria-label="NHID-Clinical home">
+      <span class="brand-mark" aria-hidden="true"><img src="/assets/brand-icon.png" alt="NHID-Clinical" /></span>
+      <span>
+        <strong>NHID-Clinical</strong>
+        <small>A Behavioral Baseline for Healthcare Voice AI</small>
+      </span>
+    </a>
+                <div class="nav-links">
+      <a href="/">Home</a>
+      <a href="/about.html">About</a>
+      <a href="/research-portfolio.html">Portfolio</a>
+      <div class="nav-dropdown">
+        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Specification <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
+        <div class="nav-dropdown-menu">
+          <a href="/specification.html">Specification</a>
+          <a href="/technical-stack.html">Technical Stack</a>
+          <a href="/regulatory-alignment.html">Regulatory Alignment</a>
+        </div>
+      </div>
+      <div class="nav-dropdown">
+        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Implement <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
+        <div class="nav-dropdown-menu">
+          <a href="/developers.html">Developers</a>
+          <a href="/interoperability.html">Interoperability</a>
+          <a href="/evidence-pack.html">Evidence Pack</a>
+          <a href="/shadow-evaluation-guide.html">Shadow Evaluation</a>
+          <a href="/registry.html">Implementation Registry</a>
+          <a href="/icon-system.html">Icon System</a>
+        </div>
+      </div>
+      <div class="nav-dropdown">
+        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Pilot <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
+        <div class="nav-dropdown-menu">
+          <a href="/for-payers.html">For Payers</a>          <a href="/roadmap.html">Roadmap</a>
+          <a href="/news.html">News</a>
+        </div>
+      </div>
+      <a href="/simulator.html">Simulator</a>
+      <a href="https://ai-governance-map.vercel.app/" target="_blank" rel="noopener noreferrer">AI Map &#x2197;</a>
+    </div>
+    <div class="nav-actions">
+      <button class="icon-button search-toggle" type="button" aria-label="Search" id="search-toggle">
+        <svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><path d="m21 21-4.35-4.35"/></svg>
+      </button>
+      <button class="icon-button theme-toggle" type="button" aria-label="Toggle dark mode" id="theme-toggle">
+        <svg class="sun-icon" viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M6.34 17.66l-1.41 1.41M19.07 4.93l-1.41 1.41"/></svg>
+        <svg class="moon-icon" viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>
+      </button>
+      <a class="primary-pill" href="/for-payers.html">Start a pilot</a>
+      <button class="icon-button menu-button" type="button" aria-label="Open menu" aria-expanded="false" aria-controls="mobile-nav">
+        <svg viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><path d="M4 7h16M4 12h16M4 17h16"/></svg>
+      </button>
+    </div>
+  </nav>
+  <div class="search-overlay" id="search-overlay" hidden>
+    <div class="container search-overlay-inner">
+      <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" style="flex-shrink:0;color:var(--body)"><circle cx="11" cy="11" r="8"/><path d="m21 21-4.35-4.35"/></svg>
+      <input type="search" id="search-input" class="search-input" placeholder="Search NHID-Clinical…" autocomplete="off" aria-label="Search site"/>
+      <button class="icon-button search-close" id="search-close" type="button" aria-label="Close search">
+        <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><path d="M18 6 6 18M6 6l12 12"/></svg>
+      </button>
+    </div>
+    <div class="container">
+      <div class="search-results" id="search-results" role="listbox" aria-label="Search results"></div>
+    </div>
+  </div>
+</header>
+
+<nav class="mobile-nav" id="mobile-nav" aria-label="Mobile navigation">
+  <a href="/">Home</a>
+  <a href="/about.html">About</a>
+  <a href="/research-portfolio.html">Portfolio</a>
+  <a href="/simulator.html">Simulator</a>
+  <strong class="mobile-nav-group">Specification</strong>
+  <a href="/specification.html">Specification</a>
+  <a href="/technical-stack.html">Technical Stack</a>
+  <a href="/regulatory-alignment.html">Regulatory Alignment</a>
+  <strong class="mobile-nav-group">Implement</strong>
+  <a href="/developers.html">Developers</a>
+  <a href="/interoperability.html">Interoperability</a>
+  <a href="/evidence-pack.html">Evidence Pack</a>
+  <a href="/shadow-evaluation-guide.html">Shadow Evaluation</a>
+  <a href="/registry.html">Implementation Registry</a>
+  <a href="/icon-system.html">Icon System</a>
+  <strong class="mobile-nav-group">Pilot</strong>
+  <a href="/for-payers.html">For Payers</a>  <a href="/roadmap.html">Roadmap</a>
+  <a href="/news.html">News</a>
+  <a href="https://ai-governance-map.vercel.app/" target="_blank" rel="noopener noreferrer">AI Map &#x2197;</a>
+  <div class="mobile-nav-footer">
+    <button class="theme-toggle mobile-theme-toggle" type="button" aria-label="Toggle dark mode">
+      <svg class="sun-icon" viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M6.34 17.66l-1.41 1.41M19.07 4.93l-1.41 1.41"/></svg>
+      <svg class="moon-icon" viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>
+      <span class="mobile-theme-label">Switch to dark mode</span>
+    </button>
+  </div>
+</nav>
+<div class="nav-backdrop" id="nav-backdrop"></div>
+
+<main>
+  <section class="inner-hero">
+    <div class="container">
+      <div class="crumbs"><a href="/">Home</a><span>/</span><a href="/news.html">News</a><span>/</span><span>Commentary</span></div>
+      <p class="eyebrow">Commentary</p>
+      <h1>Why Identity Is the Missing Layer of Responsible AI</h1>
+      <p class="lede">Independent commentary on Impersonation Latency and the five NHID-Clinical controls, mapped to NIST AI RMF, ISO/IEC 42001, and HIPAA.</p>
+    </div>
+  </section>
+  <section class="page-section">
+    <div class="container" style="max-width:900px">
+      <iframe src="https://gamma.app/embed/pxtip0mjdj59tv6"
+        style="width:100%; max-width:900px; height:6800px; border:none;"
+        allow="fullscreen"
+        title="AI Governance Starts Before the Model: Why Identity Is the Missing Layer of Responsible AI"></iframe>
+      <p class="disclaimer-small" style="margin-top:1rem">If the embedded commentary does not load, <a href="https://gamma.app/embed/pxtip0mjdj59tv6" target="_blank" rel="noopener noreferrer">open it directly on Gamma &#x2197;</a></p>
+    </div>
+  </section>
+</main>
+
+<footer id="contact" class="site-footer">
+  <div class="container footer-inner">
+    <p>© 2026 Brianna Baynard | NIST-2025-0035-0026 | CC BY 4.0</p>
+    <div>
+      <a href="/privacy.html">Privacy</a>
+      <a href="mailto:contact@nhid-clinical.org">Contact</a>
+      <a href="https://nhid-clinical.org">nhid-clinical.org</a>
+    </div>
+    <p class="footer-copy">© 2026 Brianna Baynard | NIST-2025-0035-0026 | CC BY 4.0 | contact@nhid-clinical.org | nhid-clinical.org</p>
+  </div>
+</footer>
+
+<script src="/site.js"></script>
+</body>
+</html>

--- a/news.html
+++ b/news.html
@@ -135,6 +135,17 @@
       <div class="news-list">
         <article class="news-card">
           <div class="news-meta">
+            <span class="news-badge badge-comm">Commentary</span>
+            <time class="news-date">July 2026</time>
+          </div>
+          <h2>Why Identity Is the Missing Layer of Responsible AI</h2>
+          <p>Independent commentary on Impersonation Latency and the five NHID-Clinical controls, mapped to NIST AI RMF, ISO/IEC 42001, and HIPAA.</p>
+          <div class="news-actions">
+            <a class="news-link" href="/identity-layer.html">Read the commentary &rarr;</a>
+          </div>
+        </article>
+        <article class="news-card">
+          <div class="news-meta">
             <span class="news-badge badge-release">Release</span>
             <time class="news-date">June 2026</time>
           </div>

--- a/research-portfolio.html
+++ b/research-portfolio.html
@@ -222,6 +222,11 @@
           <p>Released kit: measure impersonation latency on your own call logs in 2&ndash;4 weeks &mdash; observe-only, no vendor changes.</p>
           <a class="card-link" href="https://github.com/NHID-Clinical/NHID-Clinical/blob/main/docs/pilot-kit/README.md" target="_blank" rel="noopener noreferrer">Get the pilot kit &#x2197;</a>
         </div>
+        <div class="content-card">
+          <h3>Why Identity Is the Missing Layer of Responsible AI</h3>
+          <p>Independent commentary on Impersonation Latency and the five NHID-Clinical controls, mapped to NIST AI RMF, ISO/IEC 42001, and HIPAA.</p>
+          <a class="card-link" href="/identity-layer.html">Read the commentary &rarr;</a>
+        </div>
       </div>
     </div>
   </section>


### PR DESCRIPTION
## Summary
Adds a new commentary page and cross-links it from News and the Research Portfolio. Content-only; no changes to the homepage, navigation, engine, or tests.

## Changes
- **New `identity-layer.html`** — `<head>` and header/nav copied verbatim from `news.html`; only the `<title>`, meta description, and page heading changed. The main content embeds the Gamma piece *"AI Governance Starts Before the Model: Why Identity Is the Missing Layer of Responsible AI"* plus a small fallback link.
- **`news.html`** — one new `news-card` at the top of the list: `badge-comm` "Commentary", July 2026, matching the existing card markup exactly.
- **`research-portfolio.html`** — one new `content-card` in the **Evidence & Publications** grid, alongside Evidence Pack / Executive Brief / Technical Proof Package / Tier 0 Shadow Pilot Kit.

## ⚠️ One thing to verify in a browser — iframe height
The Gamma is a **long-form, ~11-section webpage-format** document, so the default 450px share height would double-scroll. I set the iframe to **`height:6800px`** as a considered estimate, but **I could not load `gamma.app` from CI** (blocked by the environment's network policy) to measure it empirically. Please open the page in a browser and adjust the single `height:` value in `identity-layer.html` if there's trailing whitespace (too tall) or internal scrolling (too short).

## Constraints honored
- ✅ No changes to `index.html` or any homepage CTA
- ✅ No new top-level nav item or dropdown
- ✅ "Impersonation Latency" kept verbatim everywhere
- ✅ Terse, factual tone — no marketing copy
- ✅ Does not touch the Gamma document itself (the Jan 12 → Jan 13 date correction is handled separately in Gamma's editor; the Gamma already reads Jan 13)

## Verification
- Guards green: `validate_ci.py` (330), `check_number_drift.py` (DRIFT PASS), `check_baseline.py` (BASELINE PASS).
- Rendered in Chromium: commentary page chrome/hero, the new News card, and the new Portfolio card all display correctly. (The embedded Gamma itself can't render in CI — network-blocked — but the page structure is verified.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K6naAZodVs6Cftbq2miy1L

---
_Generated by [Claude Code](https://claude.ai/code/session_01K6naAZodVs6Cftbq2miy1L)_