### PR TITLE
Website IA sweep: 4-group nav, standardized CTAs, readability + audience row

### DIFF
--- a/about.html
+++ b/about.html
@@ -32,35 +32,42 @@
     </a>
     <div class="nav-links">
       <a href="/">Home</a>
-      <a href="/about.html">About</a>
-      <a href="/research-portfolio.html">Portfolio</a>
       <div class="nav-dropdown">
-        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Specification <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
+        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Learn <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
         <div class="nav-dropdown-menu">
           <a href="/specification.html">Specification</a>
           <a href="/technical-stack.html">Technical Stack</a>
           <a href="/regulatory-alignment.html">Regulatory Alignment</a>
+          <a href="/about.html">About</a>
         </div>
       </div>
       <div class="nav-dropdown">
-        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Implement <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
+        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Evaluate <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
+        <div class="nav-dropdown-menu">
+          <a href="/simulator.html">Simulator</a>
+          <a href="/shadow-evaluation-guide.html">Shadow Evaluation</a>
+          <a href="/evidence-pack.html">Evidence Pack</a>
+          <a href="/for-payers.html">For Payers</a>
+        </div>
+      </div>
+      <div class="nav-dropdown">
+        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Build <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
         <div class="nav-dropdown-menu">
           <a href="/developers.html">Developers</a>
           <a href="/interoperability.html">Interoperability</a>
-          <a href="/evidence-pack.html">Evidence Pack</a>
-          <a href="/shadow-evaluation-guide.html">Shadow Evaluation</a>
           <a href="/registry.html">Implementation Registry</a>
           <a href="/icon-system.html">Icon System</a>
         </div>
       </div>
       <div class="nav-dropdown">
-        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Pilot <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
+        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Community <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
         <div class="nav-dropdown-menu">
-          <a href="/for-payers.html">For Payers</a>          <a href="/roadmap.html">Roadmap</a>
           <a href="/news.html">News</a>
+          <a href="/roadmap.html">Roadmap</a>
+          <a href="/research-portfolio.html">Portfolio</a>
+          <a href="https://github.com/NHID-Clinical/NHID-Clinical">GitHub &#x2197;</a>
         </div>
       </div>
-      <a href="/simulator.html">Simulator</a>
       <a href="https://ai-governance-map.vercel.app/" target="_blank" rel="noopener noreferrer">AI Map &#x2197;</a>
     </div>
     <div class="nav-actions">
@@ -93,23 +100,26 @@
 
 <nav class="mobile-nav" id="mobile-nav" aria-label="Mobile navigation">
   <a href="/">Home</a>
-  <a href="/about.html">About</a>
-  <a href="/research-portfolio.html">Portfolio</a>
-  <a href="/simulator.html">Simulator</a>
-  <strong class="mobile-nav-group">Specification</strong>
+  <strong class="mobile-nav-group">Learn</strong>
   <a href="/specification.html">Specification</a>
   <a href="/technical-stack.html">Technical Stack</a>
   <a href="/regulatory-alignment.html">Regulatory Alignment</a>
-  <strong class="mobile-nav-group">Implement</strong>
+  <a href="/about.html">About</a>
+  <strong class="mobile-nav-group">Evaluate</strong>
+  <a href="/simulator.html">Simulator</a>
+  <a href="/shadow-evaluation-guide.html">Shadow Evaluation</a>
+  <a href="/evidence-pack.html">Evidence Pack</a>
+  <a href="/for-payers.html">For Payers</a>
+  <strong class="mobile-nav-group">Build</strong>
   <a href="/developers.html">Developers</a>
   <a href="/interoperability.html">Interoperability</a>
-  <a href="/evidence-pack.html">Evidence Pack</a>
-  <a href="/shadow-evaluation-guide.html">Shadow Evaluation</a>
   <a href="/registry.html">Implementation Registry</a>
   <a href="/icon-system.html">Icon System</a>
-  <strong class="mobile-nav-group">Pilot</strong>
-  <a href="/for-payers.html">For Payers</a>  <a href="/roadmap.html">Roadmap</a>
+  <strong class="mobile-nav-group">Community</strong>
   <a href="/news.html">News</a>
+  <a href="/roadmap.html">Roadmap</a>
+  <a href="/research-portfolio.html">Portfolio</a>
+  <a href="https://github.com/NHID-Clinical/NHID-Clinical" target="_blank" rel="noopener noreferrer">GitHub &#x2197;</a>
   <a href="https://ai-governance-map.vercel.app/" target="_blank" rel="noopener noreferrer">AI Map &#x2197;</a>
   <div class="mobile-nav-footer">
     <button class="theme-toggle mobile-theme-toggle" type="button" aria-label="Toggle dark mode">
@@ -119,6 +129,7 @@
     </button>
   </div>
 </nav>
+
 <div class="nav-backdrop" id="nav-backdrop"></div>
 
 <main>
@@ -165,6 +176,18 @@
 
 
 
+<section class="page-cta">
+  <div class="container">
+    <h2>Where to go next</h2>
+    <p>Four ways into NHID-Clinical, whatever you came to do.</p>
+    <div class="page-cta-grid">
+      <a class="page-cta-card" href="/specification.html"><b>Read the Specification <span class="arr">&rarr;</span></b><span>The v1.3 controls, in full.</span></a>
+      <a class="page-cta-card" href="/simulator.html"><b>Try the Simulator <span class="arr">&rarr;</span></b><span>Run the controls on call scenarios.</span></a>
+      <a class="page-cta-card" href="/evidence-pack.html"><b>Review the Evidence Pack <span class="arr">&rarr;</span></b><span>Guarantees, a failure trace, the audit model.</span></a>
+      <a class="page-cta-card" href="https://github.com/NHID-Clinical/NHID-Clinical/discussions" target="_blank" rel="noopener noreferrer"><b>Join the Community <span class="arr">&#x2197;</span></b><span>Questions and feedback on GitHub.</span></a>
+    </div>
+  </div>
+</section>
 <footer id="contact" class="site-footer">
   <div class="container footer-inner">
     <p>© 2026 Brianna Baynard | NIST-2025-0035-0026 | CC BY 4.0</p>

--- a/demo.html
+++ b/demo.html
@@ -33,35 +33,42 @@
     </a>
     <div class="nav-links">
       <a href="/">Home</a>
-      <a href="/about.html">About</a>
-      <a href="/research-portfolio.html">Portfolio</a>
       <div class="nav-dropdown">
-        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Specification <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
+        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Learn <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
         <div class="nav-dropdown-menu">
           <a href="/specification.html">Specification</a>
           <a href="/technical-stack.html">Technical Stack</a>
           <a href="/regulatory-alignment.html">Regulatory Alignment</a>
+          <a href="/about.html">About</a>
         </div>
       </div>
       <div class="nav-dropdown">
-        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Implement <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
+        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Evaluate <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
+        <div class="nav-dropdown-menu">
+          <a href="/simulator.html">Simulator</a>
+          <a href="/shadow-evaluation-guide.html">Shadow Evaluation</a>
+          <a href="/evidence-pack.html">Evidence Pack</a>
+          <a href="/for-payers.html">For Payers</a>
+        </div>
+      </div>
+      <div class="nav-dropdown">
+        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Build <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
         <div class="nav-dropdown-menu">
           <a href="/developers.html">Developers</a>
           <a href="/interoperability.html">Interoperability</a>
-          <a href="/evidence-pack.html">Evidence Pack</a>
-          <a href="/shadow-evaluation-guide.html">Shadow Evaluation</a>
           <a href="/registry.html">Implementation Registry</a>
           <a href="/icon-system.html">Icon System</a>
         </div>
       </div>
       <div class="nav-dropdown">
-        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Pilot <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
+        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Community <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
         <div class="nav-dropdown-menu">
-          <a href="/for-payers.html">For Payers</a>          <a href="/roadmap.html">Roadmap</a>
           <a href="/news.html">News</a>
+          <a href="/roadmap.html">Roadmap</a>
+          <a href="/research-portfolio.html">Portfolio</a>
+          <a href="https://github.com/NHID-Clinical/NHID-Clinical">GitHub &#x2197;</a>
         </div>
       </div>
-      <a href="/simulator.html">Simulator</a>
       <a href="https://ai-governance-map.vercel.app/" target="_blank" rel="noopener noreferrer">AI Map &#x2197;</a>
     </div>
     <div class="nav-actions">
@@ -94,23 +101,26 @@
 
 <nav class="mobile-nav" id="mobile-nav" aria-label="Mobile navigation">
   <a href="/">Home</a>
-  <a href="/about.html">About</a>
-  <a href="/research-portfolio.html">Portfolio</a>
-  <a href="/simulator.html">Simulator</a>
-  <strong class="mobile-nav-group">Specification</strong>
+  <strong class="mobile-nav-group">Learn</strong>
   <a href="/specification.html">Specification</a>
   <a href="/technical-stack.html">Technical Stack</a>
   <a href="/regulatory-alignment.html">Regulatory Alignment</a>
-  <strong class="mobile-nav-group">Implement</strong>
+  <a href="/about.html">About</a>
+  <strong class="mobile-nav-group">Evaluate</strong>
+  <a href="/simulator.html">Simulator</a>
+  <a href="/shadow-evaluation-guide.html">Shadow Evaluation</a>
+  <a href="/evidence-pack.html">Evidence Pack</a>
+  <a href="/for-payers.html">For Payers</a>
+  <strong class="mobile-nav-group">Build</strong>
   <a href="/developers.html">Developers</a>
   <a href="/interoperability.html">Interoperability</a>
-  <a href="/evidence-pack.html">Evidence Pack</a>
-  <a href="/shadow-evaluation-guide.html">Shadow Evaluation</a>
   <a href="/registry.html">Implementation Registry</a>
   <a href="/icon-system.html">Icon System</a>
-  <strong class="mobile-nav-group">Pilot</strong>
-  <a href="/for-payers.html">For Payers</a>  <a href="/roadmap.html">Roadmap</a>
+  <strong class="mobile-nav-group">Community</strong>
   <a href="/news.html">News</a>
+  <a href="/roadmap.html">Roadmap</a>
+  <a href="/research-portfolio.html">Portfolio</a>
+  <a href="https://github.com/NHID-Clinical/NHID-Clinical" target="_blank" rel="noopener noreferrer">GitHub &#x2197;</a>
   <a href="https://ai-governance-map.vercel.app/" target="_blank" rel="noopener noreferrer">AI Map &#x2197;</a>
   <div class="mobile-nav-footer">
     <button class="theme-toggle mobile-theme-toggle" type="button" aria-label="Toggle dark mode">
@@ -120,6 +130,7 @@
     </button>
   </div>
 </nav>
+
 <div class="nav-backdrop" id="nav-backdrop"></div>
 
 <main>
@@ -176,6 +187,18 @@
   </section>
 </main>
 
+<section class="page-cta">
+  <div class="container">
+    <h2>Where to go next</h2>
+    <p>Four ways into NHID-Clinical, whatever you came to do.</p>
+    <div class="page-cta-grid">
+      <a class="page-cta-card" href="/specification.html"><b>Read the Specification <span class="arr">&rarr;</span></b><span>The v1.3 controls, in full.</span></a>
+      <a class="page-cta-card" href="/simulator.html"><b>Try the Simulator <span class="arr">&rarr;</span></b><span>Run the controls on call scenarios.</span></a>
+      <a class="page-cta-card" href="/evidence-pack.html"><b>Review the Evidence Pack <span class="arr">&rarr;</span></b><span>Guarantees, a failure trace, the audit model.</span></a>
+      <a class="page-cta-card" href="https://github.com/NHID-Clinical/NHID-Clinical/discussions" target="_blank" rel="noopener noreferrer"><b>Join the Community <span class="arr">&#x2197;</span></b><span>Questions and feedback on GitHub.</span></a>
+    </div>
+  </div>
+</section>
 <footer id="contact" class="site-footer">
   <div class="container footer-inner">
     <p>© 2026 Brianna Baynard | NIST-2025-0035-0026 | CC BY 4.0<br/><span class="footer-demo-line"><strong>Reference demonstration line</strong> — <a href="tel:+17176706772">+1 (717) 670-6772</a> <span class="footer-demo-note">(website demo, not personal contact)</span></span></p>

--- a/developers.html
+++ b/developers.html
@@ -33,35 +33,42 @@
     </a>
     <div class="nav-links">
       <a href="/">Home</a>
-      <a href="/about.html">About</a>
-      <a href="/research-portfolio.html">Portfolio</a>
       <div class="nav-dropdown">
-        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Specification <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
+        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Learn <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
         <div class="nav-dropdown-menu">
           <a href="/specification.html">Specification</a>
           <a href="/technical-stack.html">Technical Stack</a>
           <a href="/regulatory-alignment.html">Regulatory Alignment</a>
+          <a href="/about.html">About</a>
         </div>
       </div>
       <div class="nav-dropdown">
-        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Implement <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
+        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Evaluate <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
+        <div class="nav-dropdown-menu">
+          <a href="/simulator.html">Simulator</a>
+          <a href="/shadow-evaluation-guide.html">Shadow Evaluation</a>
+          <a href="/evidence-pack.html">Evidence Pack</a>
+          <a href="/for-payers.html">For Payers</a>
+        </div>
+      </div>
+      <div class="nav-dropdown">
+        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Build <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
         <div class="nav-dropdown-menu">
           <a href="/developers.html">Developers</a>
           <a href="/interoperability.html">Interoperability</a>
-          <a href="/evidence-pack.html">Evidence Pack</a>
-          <a href="/shadow-evaluation-guide.html">Shadow Evaluation</a>
           <a href="/registry.html">Implementation Registry</a>
           <a href="/icon-system.html">Icon System</a>
         </div>
       </div>
       <div class="nav-dropdown">
-        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Pilot <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
+        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Community <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
         <div class="nav-dropdown-menu">
-          <a href="/for-payers.html">For Payers</a>          <a href="/roadmap.html">Roadmap</a>
           <a href="/news.html">News</a>
+          <a href="/roadmap.html">Roadmap</a>
+          <a href="/research-portfolio.html">Portfolio</a>
+          <a href="https://github.com/NHID-Clinical/NHID-Clinical">GitHub &#x2197;</a>
         </div>
       </div>
-      <a href="/simulator.html">Simulator</a>
       <a href="https://ai-governance-map.vercel.app/" target="_blank" rel="noopener noreferrer">AI Map &#x2197;</a>
     </div>
     <div class="nav-actions">
@@ -94,23 +101,26 @@
 
 <nav class="mobile-nav" id="mobile-nav" aria-label="Mobile navigation">
   <a href="/">Home</a>
-  <a href="/about.html">About</a>
-  <a href="/research-portfolio.html">Portfolio</a>
-  <a href="/simulator.html">Simulator</a>
-  <strong class="mobile-nav-group">Specification</strong>
+  <strong class="mobile-nav-group">Learn</strong>
   <a href="/specification.html">Specification</a>
   <a href="/technical-stack.html">Technical Stack</a>
   <a href="/regulatory-alignment.html">Regulatory Alignment</a>
-  <strong class="mobile-nav-group">Implement</strong>
+  <a href="/about.html">About</a>
+  <strong class="mobile-nav-group">Evaluate</strong>
+  <a href="/simulator.html">Simulator</a>
+  <a href="/shadow-evaluation-guide.html">Shadow Evaluation</a>
+  <a href="/evidence-pack.html">Evidence Pack</a>
+  <a href="/for-payers.html">For Payers</a>
+  <strong class="mobile-nav-group">Build</strong>
   <a href="/developers.html">Developers</a>
   <a href="/interoperability.html">Interoperability</a>
-  <a href="/evidence-pack.html">Evidence Pack</a>
-  <a href="/shadow-evaluation-guide.html">Shadow Evaluation</a>
   <a href="/registry.html">Implementation Registry</a>
   <a href="/icon-system.html">Icon System</a>
-  <strong class="mobile-nav-group">Pilot</strong>
-  <a href="/for-payers.html">For Payers</a>  <a href="/roadmap.html">Roadmap</a>
+  <strong class="mobile-nav-group">Community</strong>
   <a href="/news.html">News</a>
+  <a href="/roadmap.html">Roadmap</a>
+  <a href="/research-portfolio.html">Portfolio</a>
+  <a href="https://github.com/NHID-Clinical/NHID-Clinical" target="_blank" rel="noopener noreferrer">GitHub &#x2197;</a>
   <a href="https://ai-governance-map.vercel.app/" target="_blank" rel="noopener noreferrer">AI Map &#x2197;</a>
   <div class="mobile-nav-footer">
     <button class="theme-toggle mobile-theme-toggle" type="button" aria-label="Toggle dark mode">
@@ -120,6 +130,7 @@
     </button>
   </div>
 </nav>
+
 <div class="nav-backdrop" id="nav-backdrop"></div>
 
 <main>
@@ -383,6 +394,18 @@ python tests/trace_generator.py --offline</pre>
       <h3>Architecture, visualized</h3>
       <p>The interactive five-layer trust stack on the homepage shows where adapters, the policy engine, NHID-Auth v2, and the audit ledger sit relative to each other.</p>
       <a href="/#trust-stack">View the Trust Stack →</a>&nbsp;&nbsp; <a href="/simulator.html?scenario=idg-01">Deep-link a scenario: /simulator.html?scenario=idg-01 →</a>&nbsp;&nbsp;
+    </div>
+  </div>
+</section>
+<section class="page-cta">
+  <div class="container">
+    <h2>Where to go next</h2>
+    <p>Four ways into NHID-Clinical, whatever you came to do.</p>
+    <div class="page-cta-grid">
+      <a class="page-cta-card" href="/specification.html"><b>Read the Specification <span class="arr">&rarr;</span></b><span>The v1.3 controls, in full.</span></a>
+      <a class="page-cta-card" href="/simulator.html"><b>Try the Simulator <span class="arr">&rarr;</span></b><span>Run the controls on call scenarios.</span></a>
+      <a class="page-cta-card" href="/evidence-pack.html"><b>Review the Evidence Pack <span class="arr">&rarr;</span></b><span>Guarantees, a failure trace, the audit model.</span></a>
+      <a class="page-cta-card" href="https://github.com/NHID-Clinical/NHID-Clinical/discussions" target="_blank" rel="noopener noreferrer"><b>Join the Community <span class="arr">&#x2197;</span></b><span>Questions and feedback on GitHub.</span></a>
     </div>
   </div>
 </section>

--- a/evidence-pack.html
+++ b/evidence-pack.html
@@ -50,35 +50,42 @@
     </a>
     <div class="nav-links">
       <a href="/">Home</a>
-      <a href="/about.html">About</a>
-      <a href="/research-portfolio.html">Portfolio</a>
       <div class="nav-dropdown">
-        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Specification <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
+        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Learn <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
         <div class="nav-dropdown-menu">
           <a href="/specification.html">Specification</a>
           <a href="/technical-stack.html">Technical Stack</a>
           <a href="/regulatory-alignment.html">Regulatory Alignment</a>
+          <a href="/about.html">About</a>
         </div>
       </div>
       <div class="nav-dropdown">
-        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Implement <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
+        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Evaluate <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
+        <div class="nav-dropdown-menu">
+          <a href="/simulator.html">Simulator</a>
+          <a href="/shadow-evaluation-guide.html">Shadow Evaluation</a>
+          <a href="/evidence-pack.html">Evidence Pack</a>
+          <a href="/for-payers.html">For Payers</a>
+        </div>
+      </div>
+      <div class="nav-dropdown">
+        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Build <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
         <div class="nav-dropdown-menu">
           <a href="/developers.html">Developers</a>
           <a href="/interoperability.html">Interoperability</a>
-          <a href="/evidence-pack.html">Evidence Pack</a>
-          <a href="/shadow-evaluation-guide.html">Shadow Evaluation</a>
           <a href="/registry.html">Implementation Registry</a>
           <a href="/icon-system.html">Icon System</a>
         </div>
       </div>
       <div class="nav-dropdown">
-        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Pilot <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
+        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Community <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
         <div class="nav-dropdown-menu">
-          <a href="/for-payers.html">For Payers</a>          <a href="/roadmap.html">Roadmap</a>
           <a href="/news.html">News</a>
+          <a href="/roadmap.html">Roadmap</a>
+          <a href="/research-portfolio.html">Portfolio</a>
+          <a href="https://github.com/NHID-Clinical/NHID-Clinical">GitHub &#x2197;</a>
         </div>
       </div>
-      <a href="/simulator.html">Simulator</a>
       <a href="https://ai-governance-map.vercel.app/" target="_blank" rel="noopener noreferrer">AI Map &#x2197;</a>
     </div>
     <div class="nav-actions">
@@ -111,23 +118,26 @@
 
 <nav class="mobile-nav" id="mobile-nav" aria-label="Mobile navigation">
   <a href="/">Home</a>
-  <a href="/about.html">About</a>
-  <a href="/research-portfolio.html">Portfolio</a>
-  <a href="/simulator.html">Simulator</a>
-  <strong class="mobile-nav-group">Specification</strong>
+  <strong class="mobile-nav-group">Learn</strong>
   <a href="/specification.html">Specification</a>
   <a href="/technical-stack.html">Technical Stack</a>
   <a href="/regulatory-alignment.html">Regulatory Alignment</a>
-  <strong class="mobile-nav-group">Implement</strong>
+  <a href="/about.html">About</a>
+  <strong class="mobile-nav-group">Evaluate</strong>
+  <a href="/simulator.html">Simulator</a>
+  <a href="/shadow-evaluation-guide.html">Shadow Evaluation</a>
+  <a href="/evidence-pack.html">Evidence Pack</a>
+  <a href="/for-payers.html">For Payers</a>
+  <strong class="mobile-nav-group">Build</strong>
   <a href="/developers.html">Developers</a>
   <a href="/interoperability.html">Interoperability</a>
-  <a href="/evidence-pack.html">Evidence Pack</a>
-  <a href="/shadow-evaluation-guide.html">Shadow Evaluation</a>
   <a href="/registry.html">Implementation Registry</a>
   <a href="/icon-system.html">Icon System</a>
-  <strong class="mobile-nav-group">Pilot</strong>
-  <a href="/for-payers.html">For Payers</a>  <a href="/roadmap.html">Roadmap</a>
+  <strong class="mobile-nav-group">Community</strong>
   <a href="/news.html">News</a>
+  <a href="/roadmap.html">Roadmap</a>
+  <a href="/research-portfolio.html">Portfolio</a>
+  <a href="https://github.com/NHID-Clinical/NHID-Clinical" target="_blank" rel="noopener noreferrer">GitHub &#x2197;</a>
   <a href="https://ai-governance-map.vercel.app/" target="_blank" rel="noopener noreferrer">AI Map &#x2197;</a>
   <div class="mobile-nav-footer">
     <button class="theme-toggle mobile-theme-toggle" type="button" aria-label="Toggle dark mode">
@@ -137,6 +147,7 @@
     </button>
   </div>
 </nav>
+
 <div class="nav-backdrop" id="nav-backdrop"></div>
 
 <main>
@@ -424,6 +435,18 @@ t=00:00.152  PERSIST    Event written — disclosure_timestamp set</pre>
   </section>
 </main>
 
+<section class="page-cta">
+  <div class="container">
+    <h2>Where to go next</h2>
+    <p>Four ways into NHID-Clinical, whatever you came to do.</p>
+    <div class="page-cta-grid">
+      <a class="page-cta-card" href="/specification.html"><b>Read the Specification <span class="arr">&rarr;</span></b><span>The v1.3 controls, in full.</span></a>
+      <a class="page-cta-card" href="/simulator.html"><b>Try the Simulator <span class="arr">&rarr;</span></b><span>Run the controls on call scenarios.</span></a>
+      <a class="page-cta-card" href="/evidence-pack.html"><b>Review the Evidence Pack <span class="arr">&rarr;</span></b><span>Guarantees, a failure trace, the audit model.</span></a>
+      <a class="page-cta-card" href="https://github.com/NHID-Clinical/NHID-Clinical/discussions" target="_blank" rel="noopener noreferrer"><b>Join the Community <span class="arr">&#x2197;</span></b><span>Questions and feedback on GitHub.</span></a>
+    </div>
+  </div>
+</section>
 <footer id="contact" class="site-footer">
   <div class="container footer-inner">
     <p>© 2026 Brianna Baynard | NIST-2025-0035-0026 | CC BY 4.0</p>

--- a/faq.html
+++ b/faq.html
@@ -32,35 +32,42 @@
     </a>
     <div class="nav-links">
       <a href="/">Home</a>
-      <a href="/about.html">About</a>
-      <a href="/research-portfolio.html">Portfolio</a>
       <div class="nav-dropdown">
-        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Specification <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
+        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Learn <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
         <div class="nav-dropdown-menu">
           <a href="/specification.html">Specification</a>
           <a href="/technical-stack.html">Technical Stack</a>
           <a href="/regulatory-alignment.html">Regulatory Alignment</a>
+          <a href="/about.html">About</a>
         </div>
       </div>
       <div class="nav-dropdown">
-        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Implement <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
+        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Evaluate <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
+        <div class="nav-dropdown-menu">
+          <a href="/simulator.html">Simulator</a>
+          <a href="/shadow-evaluation-guide.html">Shadow Evaluation</a>
+          <a href="/evidence-pack.html">Evidence Pack</a>
+          <a href="/for-payers.html">For Payers</a>
+        </div>
+      </div>
+      <div class="nav-dropdown">
+        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Build <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
         <div class="nav-dropdown-menu">
           <a href="/developers.html">Developers</a>
           <a href="/interoperability.html">Interoperability</a>
-          <a href="/evidence-pack.html">Evidence Pack</a>
-          <a href="/shadow-evaluation-guide.html">Shadow Evaluation</a>
           <a href="/registry.html">Implementation Registry</a>
           <a href="/icon-system.html">Icon System</a>
         </div>
       </div>
       <div class="nav-dropdown">
-        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Pilot <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
+        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Community <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
         <div class="nav-dropdown-menu">
-          <a href="/for-payers.html">For Payers</a>          <a href="/roadmap.html">Roadmap</a>
           <a href="/news.html">News</a>
+          <a href="/roadmap.html">Roadmap</a>
+          <a href="/research-portfolio.html">Portfolio</a>
+          <a href="https://github.com/NHID-Clinical/NHID-Clinical">GitHub &#x2197;</a>
         </div>
       </div>
-      <a href="/simulator.html">Simulator</a>
       <a href="https://ai-governance-map.vercel.app/" target="_blank" rel="noopener noreferrer">AI Map &#x2197;</a>
     </div>
     <div class="nav-actions">
@@ -93,23 +100,26 @@
 
 <nav class="mobile-nav" id="mobile-nav" aria-label="Mobile navigation">
   <a href="/">Home</a>
-  <a href="/about.html">About</a>
-  <a href="/research-portfolio.html">Portfolio</a>
-  <a href="/simulator.html">Simulator</a>
-  <strong class="mobile-nav-group">Specification</strong>
+  <strong class="mobile-nav-group">Learn</strong>
   <a href="/specification.html">Specification</a>
   <a href="/technical-stack.html">Technical Stack</a>
   <a href="/regulatory-alignment.html">Regulatory Alignment</a>
-  <strong class="mobile-nav-group">Implement</strong>
+  <a href="/about.html">About</a>
+  <strong class="mobile-nav-group">Evaluate</strong>
+  <a href="/simulator.html">Simulator</a>
+  <a href="/shadow-evaluation-guide.html">Shadow Evaluation</a>
+  <a href="/evidence-pack.html">Evidence Pack</a>
+  <a href="/for-payers.html">For Payers</a>
+  <strong class="mobile-nav-group">Build</strong>
   <a href="/developers.html">Developers</a>
   <a href="/interoperability.html">Interoperability</a>
-  <a href="/evidence-pack.html">Evidence Pack</a>
-  <a href="/shadow-evaluation-guide.html">Shadow Evaluation</a>
   <a href="/registry.html">Implementation Registry</a>
   <a href="/icon-system.html">Icon System</a>
-  <strong class="mobile-nav-group">Pilot</strong>
-  <a href="/for-payers.html">For Payers</a>  <a href="/roadmap.html">Roadmap</a>
+  <strong class="mobile-nav-group">Community</strong>
   <a href="/news.html">News</a>
+  <a href="/roadmap.html">Roadmap</a>
+  <a href="/research-portfolio.html">Portfolio</a>
+  <a href="https://github.com/NHID-Clinical/NHID-Clinical" target="_blank" rel="noopener noreferrer">GitHub &#x2197;</a>
   <a href="https://ai-governance-map.vercel.app/" target="_blank" rel="noopener noreferrer">AI Map &#x2197;</a>
   <div class="mobile-nav-footer">
     <button class="theme-toggle mobile-theme-toggle" type="button" aria-label="Toggle dark mode">
@@ -119,6 +129,7 @@
     </button>
   </div>
 </nav>
+
 <div class="nav-backdrop" id="nav-backdrop"></div>
 
 <main>
@@ -212,6 +223,18 @@ GitHub:  github.com/NHID-Clinical/NHID-Clinical/discussions</pre>
   </section>
 </main>
 
+<section class="page-cta">
+  <div class="container">
+    <h2>Where to go next</h2>
+    <p>Four ways into NHID-Clinical, whatever you came to do.</p>
+    <div class="page-cta-grid">
+      <a class="page-cta-card" href="/specification.html"><b>Read the Specification <span class="arr">&rarr;</span></b><span>The v1.3 controls, in full.</span></a>
+      <a class="page-cta-card" href="/simulator.html"><b>Try the Simulator <span class="arr">&rarr;</span></b><span>Run the controls on call scenarios.</span></a>
+      <a class="page-cta-card" href="/evidence-pack.html"><b>Review the Evidence Pack <span class="arr">&rarr;</span></b><span>Guarantees, a failure trace, the audit model.</span></a>
+      <a class="page-cta-card" href="https://github.com/NHID-Clinical/NHID-Clinical/discussions" target="_blank" rel="noopener noreferrer"><b>Join the Community <span class="arr">&#x2197;</span></b><span>Questions and feedback on GitHub.</span></a>
+    </div>
+  </div>
+</section>
 <footer id="contact" class="site-footer">
   <div class="container footer-inner">
     <p>© 2026 Brianna Baynard | NIST-2025-0035-0026 | CC BY 4.0</p>

--- a/for-payers.html
+++ b/for-payers.html
@@ -84,35 +84,42 @@
     </a>
     <div class="nav-links">
       <a href="/">Home</a>
-      <a href="/about.html">About</a>
-      <a href="/research-portfolio.html">Portfolio</a>
       <div class="nav-dropdown">
-        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Specification <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
+        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Learn <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
         <div class="nav-dropdown-menu">
           <a href="/specification.html">Specification</a>
           <a href="/technical-stack.html">Technical Stack</a>
           <a href="/regulatory-alignment.html">Regulatory Alignment</a>
+          <a href="/about.html">About</a>
         </div>
       </div>
       <div class="nav-dropdown">
-        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Implement <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
+        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Evaluate <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
+        <div class="nav-dropdown-menu">
+          <a href="/simulator.html">Simulator</a>
+          <a href="/shadow-evaluation-guide.html">Shadow Evaluation</a>
+          <a href="/evidence-pack.html">Evidence Pack</a>
+          <a href="/for-payers.html">For Payers</a>
+        </div>
+      </div>
+      <div class="nav-dropdown">
+        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Build <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
         <div class="nav-dropdown-menu">
           <a href="/developers.html">Developers</a>
           <a href="/interoperability.html">Interoperability</a>
-          <a href="/evidence-pack.html">Evidence Pack</a>
-          <a href="/shadow-evaluation-guide.html">Shadow Evaluation</a>
           <a href="/registry.html">Implementation Registry</a>
           <a href="/icon-system.html">Icon System</a>
         </div>
       </div>
       <div class="nav-dropdown">
-        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Pilot <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
+        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Community <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
         <div class="nav-dropdown-menu">
-          <a href="/for-payers.html">For Payers</a>          <a href="/roadmap.html">Roadmap</a>
           <a href="/news.html">News</a>
+          <a href="/roadmap.html">Roadmap</a>
+          <a href="/research-portfolio.html">Portfolio</a>
+          <a href="https://github.com/NHID-Clinical/NHID-Clinical">GitHub &#x2197;</a>
         </div>
       </div>
-      <a href="/simulator.html">Simulator</a>
       <a href="https://ai-governance-map.vercel.app/" target="_blank" rel="noopener noreferrer">AI Map &#x2197;</a>
     </div>
     <div class="nav-actions">
@@ -145,23 +152,26 @@
 
 <nav class="mobile-nav" id="mobile-nav" aria-label="Mobile navigation">
   <a href="/">Home</a>
-  <a href="/about.html">About</a>
-  <a href="/research-portfolio.html">Portfolio</a>
-  <a href="/simulator.html">Simulator</a>
-  <strong class="mobile-nav-group">Specification</strong>
+  <strong class="mobile-nav-group">Learn</strong>
   <a href="/specification.html">Specification</a>
   <a href="/technical-stack.html">Technical Stack</a>
   <a href="/regulatory-alignment.html">Regulatory Alignment</a>
-  <strong class="mobile-nav-group">Implement</strong>
+  <a href="/about.html">About</a>
+  <strong class="mobile-nav-group">Evaluate</strong>
+  <a href="/simulator.html">Simulator</a>
+  <a href="/shadow-evaluation-guide.html">Shadow Evaluation</a>
+  <a href="/evidence-pack.html">Evidence Pack</a>
+  <a href="/for-payers.html">For Payers</a>
+  <strong class="mobile-nav-group">Build</strong>
   <a href="/developers.html">Developers</a>
   <a href="/interoperability.html">Interoperability</a>
-  <a href="/evidence-pack.html">Evidence Pack</a>
-  <a href="/shadow-evaluation-guide.html">Shadow Evaluation</a>
   <a href="/registry.html">Implementation Registry</a>
   <a href="/icon-system.html">Icon System</a>
-  <strong class="mobile-nav-group">Pilot</strong>
-  <a href="/for-payers.html">For Payers</a>  <a href="/roadmap.html">Roadmap</a>
+  <strong class="mobile-nav-group">Community</strong>
   <a href="/news.html">News</a>
+  <a href="/roadmap.html">Roadmap</a>
+  <a href="/research-portfolio.html">Portfolio</a>
+  <a href="https://github.com/NHID-Clinical/NHID-Clinical" target="_blank" rel="noopener noreferrer">GitHub &#x2197;</a>
   <a href="https://ai-governance-map.vercel.app/" target="_blank" rel="noopener noreferrer">AI Map &#x2197;</a>
   <div class="mobile-nav-footer">
     <button class="theme-toggle mobile-theme-toggle" type="button" aria-label="Toggle dark mode">
@@ -171,6 +181,7 @@
     </button>
   </div>
 </nav>
+
 <div class="nav-backdrop" id="nav-backdrop"></div>
 
 <main>
@@ -350,6 +361,18 @@
       <p>Shadow evaluation checklist: (1) pick one call type, (2) mirror transcripts to the conformance API, (3) review the evidence bundle with compliance. No production risk.</p>
       <a href="/shadow-evaluation-guide.html">Shadow Evaluation Guide →</a>&nbsp;&nbsp;
       <a href="/specs/NHID-Clinical-Operational-Blueprint-v1.3.pdf">Operational Blueprint (PDF) →</a>
+    </div>
+  </div>
+</section>
+<section class="page-cta">
+  <div class="container">
+    <h2>Where to go next</h2>
+    <p>Four ways into NHID-Clinical, whatever you came to do.</p>
+    <div class="page-cta-grid">
+      <a class="page-cta-card" href="/specification.html"><b>Read the Specification <span class="arr">&rarr;</span></b><span>The v1.3 controls, in full.</span></a>
+      <a class="page-cta-card" href="/simulator.html"><b>Try the Simulator <span class="arr">&rarr;</span></b><span>Run the controls on call scenarios.</span></a>
+      <a class="page-cta-card" href="/evidence-pack.html"><b>Review the Evidence Pack <span class="arr">&rarr;</span></b><span>Guarantees, a failure trace, the audit model.</span></a>
+      <a class="page-cta-card" href="https://github.com/NHID-Clinical/NHID-Clinical/discussions" target="_blank" rel="noopener noreferrer"><b>Join the Community <span class="arr">&#x2197;</span></b><span>Questions and feedback on GitHub.</span></a>
     </div>
   </div>
 </section>

--- a/governance-simulator.html
+++ b/governance-simulator.html
@@ -342,35 +342,42 @@
     </a>
     <div class="nav-links">
       <a href="/">Home</a>
-      <a href="/about.html">About</a>
-      <a href="/research-portfolio.html">Portfolio</a>
       <div class="nav-dropdown">
-        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Specification <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
+        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Learn <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
         <div class="nav-dropdown-menu">
           <a href="/specification.html">Specification</a>
           <a href="/technical-stack.html">Technical Stack</a>
           <a href="/regulatory-alignment.html">Regulatory Alignment</a>
+          <a href="/about.html">About</a>
         </div>
       </div>
       <div class="nav-dropdown">
-        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Implement <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
+        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Evaluate <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
+        <div class="nav-dropdown-menu">
+          <a href="/simulator.html">Simulator</a>
+          <a href="/shadow-evaluation-guide.html">Shadow Evaluation</a>
+          <a href="/evidence-pack.html">Evidence Pack</a>
+          <a href="/for-payers.html">For Payers</a>
+        </div>
+      </div>
+      <div class="nav-dropdown">
+        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Build <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
         <div class="nav-dropdown-menu">
           <a href="/developers.html">Developers</a>
           <a href="/interoperability.html">Interoperability</a>
-          <a href="/evidence-pack.html">Evidence Pack</a>
-          <a href="/shadow-evaluation-guide.html">Shadow Evaluation</a>
           <a href="/registry.html">Implementation Registry</a>
           <a href="/icon-system.html">Icon System</a>
         </div>
       </div>
       <div class="nav-dropdown">
-        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Pilot <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
+        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Community <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
         <div class="nav-dropdown-menu">
-          <a href="/for-payers.html">For Payers</a>          <a href="/roadmap.html">Roadmap</a>
           <a href="/news.html">News</a>
+          <a href="/roadmap.html">Roadmap</a>
+          <a href="/research-portfolio.html">Portfolio</a>
+          <a href="https://github.com/NHID-Clinical/NHID-Clinical">GitHub &#x2197;</a>
         </div>
       </div>
-      <a href="/simulator.html">Simulator</a>
       <a href="https://ai-governance-map.vercel.app/" target="_blank" rel="noopener noreferrer">AI Map &#x2197;</a>
     </div>
     <div class="nav-actions">
@@ -403,23 +410,26 @@
 
 <nav class="mobile-nav" id="mobile-nav" aria-label="Mobile navigation">
   <a href="/">Home</a>
-  <a href="/about.html">About</a>
-  <a href="/research-portfolio.html">Portfolio</a>
-  <a href="/simulator.html">Simulator</a>
-  <strong class="mobile-nav-group">Specification</strong>
+  <strong class="mobile-nav-group">Learn</strong>
   <a href="/specification.html">Specification</a>
   <a href="/technical-stack.html">Technical Stack</a>
   <a href="/regulatory-alignment.html">Regulatory Alignment</a>
-  <strong class="mobile-nav-group">Implement</strong>
+  <a href="/about.html">About</a>
+  <strong class="mobile-nav-group">Evaluate</strong>
+  <a href="/simulator.html">Simulator</a>
+  <a href="/shadow-evaluation-guide.html">Shadow Evaluation</a>
+  <a href="/evidence-pack.html">Evidence Pack</a>
+  <a href="/for-payers.html">For Payers</a>
+  <strong class="mobile-nav-group">Build</strong>
   <a href="/developers.html">Developers</a>
   <a href="/interoperability.html">Interoperability</a>
-  <a href="/evidence-pack.html">Evidence Pack</a>
-  <a href="/shadow-evaluation-guide.html">Shadow Evaluation</a>
   <a href="/registry.html">Implementation Registry</a>
   <a href="/icon-system.html">Icon System</a>
-  <strong class="mobile-nav-group">Pilot</strong>
-  <a href="/for-payers.html">For Payers</a>  <a href="/roadmap.html">Roadmap</a>
+  <strong class="mobile-nav-group">Community</strong>
   <a href="/news.html">News</a>
+  <a href="/roadmap.html">Roadmap</a>
+  <a href="/research-portfolio.html">Portfolio</a>
+  <a href="https://github.com/NHID-Clinical/NHID-Clinical" target="_blank" rel="noopener noreferrer">GitHub &#x2197;</a>
   <a href="https://ai-governance-map.vercel.app/" target="_blank" rel="noopener noreferrer">AI Map &#x2197;</a>
   <div class="mobile-nav-footer">
     <button class="theme-toggle mobile-theme-toggle" type="button" aria-label="Toggle dark mode">
@@ -429,6 +439,7 @@
     </button>
   </div>
 </nav>
+
 <div class="nav-backdrop" id="nav-backdrop"></div>
 
 <!-- ── Simulator ─────────────────────────────────────────────── -->

--- a/icon-system.html
+++ b/icon-system.html
@@ -32,35 +32,42 @@
     </a>
     <div class="nav-links">
       <a href="/">Home</a>
-      <a href="/about.html">About</a>
-      <a href="/research-portfolio.html">Portfolio</a>
       <div class="nav-dropdown">
-        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Specification <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
+        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Learn <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
         <div class="nav-dropdown-menu">
           <a href="/specification.html">Specification</a>
           <a href="/technical-stack.html">Technical Stack</a>
           <a href="/regulatory-alignment.html">Regulatory Alignment</a>
+          <a href="/about.html">About</a>
         </div>
       </div>
       <div class="nav-dropdown">
-        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Implement <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
+        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Evaluate <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
+        <div class="nav-dropdown-menu">
+          <a href="/simulator.html">Simulator</a>
+          <a href="/shadow-evaluation-guide.html">Shadow Evaluation</a>
+          <a href="/evidence-pack.html">Evidence Pack</a>
+          <a href="/for-payers.html">For Payers</a>
+        </div>
+      </div>
+      <div class="nav-dropdown">
+        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Build <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
         <div class="nav-dropdown-menu">
           <a href="/developers.html">Developers</a>
           <a href="/interoperability.html">Interoperability</a>
-          <a href="/evidence-pack.html">Evidence Pack</a>
-          <a href="/shadow-evaluation-guide.html">Shadow Evaluation</a>
           <a href="/registry.html">Implementation Registry</a>
           <a href="/icon-system.html">Icon System</a>
         </div>
       </div>
       <div class="nav-dropdown">
-        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Pilot <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
+        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Community <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
         <div class="nav-dropdown-menu">
-          <a href="/for-payers.html">For Payers</a>          <a href="/roadmap.html">Roadmap</a>
           <a href="/news.html">News</a>
+          <a href="/roadmap.html">Roadmap</a>
+          <a href="/research-portfolio.html">Portfolio</a>
+          <a href="https://github.com/NHID-Clinical/NHID-Clinical">GitHub &#x2197;</a>
         </div>
       </div>
-      <a href="/simulator.html">Simulator</a>
       <a href="https://ai-governance-map.vercel.app/" target="_blank" rel="noopener noreferrer">AI Map &#x2197;</a>
     </div>
     <div class="nav-actions">
@@ -93,23 +100,26 @@
 
 <nav class="mobile-nav" id="mobile-nav" aria-label="Mobile navigation">
   <a href="/">Home</a>
-  <a href="/about.html">About</a>
-  <a href="/research-portfolio.html">Portfolio</a>
-  <a href="/simulator.html">Simulator</a>
-  <strong class="mobile-nav-group">Specification</strong>
+  <strong class="mobile-nav-group">Learn</strong>
   <a href="/specification.html">Specification</a>
   <a href="/technical-stack.html">Technical Stack</a>
   <a href="/regulatory-alignment.html">Regulatory Alignment</a>
-  <strong class="mobile-nav-group">Implement</strong>
+  <a href="/about.html">About</a>
+  <strong class="mobile-nav-group">Evaluate</strong>
+  <a href="/simulator.html">Simulator</a>
+  <a href="/shadow-evaluation-guide.html">Shadow Evaluation</a>
+  <a href="/evidence-pack.html">Evidence Pack</a>
+  <a href="/for-payers.html">For Payers</a>
+  <strong class="mobile-nav-group">Build</strong>
   <a href="/developers.html">Developers</a>
   <a href="/interoperability.html">Interoperability</a>
-  <a href="/evidence-pack.html">Evidence Pack</a>
-  <a href="/shadow-evaluation-guide.html">Shadow Evaluation</a>
   <a href="/registry.html">Implementation Registry</a>
   <a href="/icon-system.html">Icon System</a>
-  <strong class="mobile-nav-group">Pilot</strong>
-  <a href="/for-payers.html">For Payers</a>  <a href="/roadmap.html">Roadmap</a>
+  <strong class="mobile-nav-group">Community</strong>
   <a href="/news.html">News</a>
+  <a href="/roadmap.html">Roadmap</a>
+  <a href="/research-portfolio.html">Portfolio</a>
+  <a href="https://github.com/NHID-Clinical/NHID-Clinical" target="_blank" rel="noopener noreferrer">GitHub &#x2197;</a>
   <a href="https://ai-governance-map.vercel.app/" target="_blank" rel="noopener noreferrer">AI Map &#x2197;</a>
   <div class="mobile-nav-footer">
     <button class="theme-toggle mobile-theme-toggle" type="button" aria-label="Toggle dark mode">
@@ -119,6 +129,7 @@
     </button>
   </div>
 </nav>
+
 <div class="nav-backdrop" id="nav-backdrop"></div>
 
 <main>
@@ -407,6 +418,18 @@
   </section>
 </main>
 
+<section class="page-cta">
+  <div class="container">
+    <h2>Where to go next</h2>
+    <p>Four ways into NHID-Clinical, whatever you came to do.</p>
+    <div class="page-cta-grid">
+      <a class="page-cta-card" href="/specification.html"><b>Read the Specification <span class="arr">&rarr;</span></b><span>The v1.3 controls, in full.</span></a>
+      <a class="page-cta-card" href="/simulator.html"><b>Try the Simulator <span class="arr">&rarr;</span></b><span>Run the controls on call scenarios.</span></a>
+      <a class="page-cta-card" href="/evidence-pack.html"><b>Review the Evidence Pack <span class="arr">&rarr;</span></b><span>Guarantees, a failure trace, the audit model.</span></a>
+      <a class="page-cta-card" href="https://github.com/NHID-Clinical/NHID-Clinical/discussions" target="_blank" rel="noopener noreferrer"><b>Join the Community <span class="arr">&#x2197;</span></b><span>Questions and feedback on GitHub.</span></a>
+    </div>
+  </div>
+</section>
 <footer id="contact" class="site-footer">
   <div class="container footer-inner">
     <p>&copy; 2026 Brianna Baynard | NIST-2025-0035-0026 | CC BY 4.0</p>

--- a/identity-layer.html
+++ b/identity-layer.html
@@ -32,35 +32,42 @@
     </a>
                 <div class="nav-links">
       <a href="/">Home</a>
-      <a href="/about.html">About</a>
-      <a href="/research-portfolio.html">Portfolio</a>
       <div class="nav-dropdown">
-        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Specification <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
+        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Learn <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
         <div class="nav-dropdown-menu">
           <a href="/specification.html">Specification</a>
           <a href="/technical-stack.html">Technical Stack</a>
           <a href="/regulatory-alignment.html">Regulatory Alignment</a>
+          <a href="/about.html">About</a>
         </div>
       </div>
       <div class="nav-dropdown">
-        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Implement <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
+        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Evaluate <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
+        <div class="nav-dropdown-menu">
+          <a href="/simulator.html">Simulator</a>
+          <a href="/shadow-evaluation-guide.html">Shadow Evaluation</a>
+          <a href="/evidence-pack.html">Evidence Pack</a>
+          <a href="/for-payers.html">For Payers</a>
+        </div>
+      </div>
+      <div class="nav-dropdown">
+        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Build <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
         <div class="nav-dropdown-menu">
           <a href="/developers.html">Developers</a>
           <a href="/interoperability.html">Interoperability</a>
-          <a href="/evidence-pack.html">Evidence Pack</a>
-          <a href="/shadow-evaluation-guide.html">Shadow Evaluation</a>
           <a href="/registry.html">Implementation Registry</a>
           <a href="/icon-system.html">Icon System</a>
         </div>
       </div>
       <div class="nav-dropdown">
-        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Pilot <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
+        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Community <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
         <div class="nav-dropdown-menu">
-          <a href="/for-payers.html">For Payers</a>          <a href="/roadmap.html">Roadmap</a>
           <a href="/news.html">News</a>
+          <a href="/roadmap.html">Roadmap</a>
+          <a href="/research-portfolio.html">Portfolio</a>
+          <a href="https://github.com/NHID-Clinical/NHID-Clinical">GitHub &#x2197;</a>
         </div>
       </div>
-      <a href="/simulator.html">Simulator</a>
       <a href="https://ai-governance-map.vercel.app/" target="_blank" rel="noopener noreferrer">AI Map &#x2197;</a>
     </div>
     <div class="nav-actions">
@@ -93,23 +100,26 @@
 
 <nav class="mobile-nav" id="mobile-nav" aria-label="Mobile navigation">
   <a href="/">Home</a>
-  <a href="/about.html">About</a>
-  <a href="/research-portfolio.html">Portfolio</a>
-  <a href="/simulator.html">Simulator</a>
-  <strong class="mobile-nav-group">Specification</strong>
+  <strong class="mobile-nav-group">Learn</strong>
   <a href="/specification.html">Specification</a>
   <a href="/technical-stack.html">Technical Stack</a>
   <a href="/regulatory-alignment.html">Regulatory Alignment</a>
-  <strong class="mobile-nav-group">Implement</strong>
+  <a href="/about.html">About</a>
+  <strong class="mobile-nav-group">Evaluate</strong>
+  <a href="/simulator.html">Simulator</a>
+  <a href="/shadow-evaluation-guide.html">Shadow Evaluation</a>
+  <a href="/evidence-pack.html">Evidence Pack</a>
+  <a href="/for-payers.html">For Payers</a>
+  <strong class="mobile-nav-group">Build</strong>
   <a href="/developers.html">Developers</a>
   <a href="/interoperability.html">Interoperability</a>
-  <a href="/evidence-pack.html">Evidence Pack</a>
-  <a href="/shadow-evaluation-guide.html">Shadow Evaluation</a>
   <a href="/registry.html">Implementation Registry</a>
   <a href="/icon-system.html">Icon System</a>
-  <strong class="mobile-nav-group">Pilot</strong>
-  <a href="/for-payers.html">For Payers</a>  <a href="/roadmap.html">Roadmap</a>
+  <strong class="mobile-nav-group">Community</strong>
   <a href="/news.html">News</a>
+  <a href="/roadmap.html">Roadmap</a>
+  <a href="/research-portfolio.html">Portfolio</a>
+  <a href="https://github.com/NHID-Clinical/NHID-Clinical" target="_blank" rel="noopener noreferrer">GitHub &#x2197;</a>
   <a href="https://ai-governance-map.vercel.app/" target="_blank" rel="noopener noreferrer">AI Map &#x2197;</a>
   <div class="mobile-nav-footer">
     <button class="theme-toggle mobile-theme-toggle" type="button" aria-label="Toggle dark mode">
@@ -119,6 +129,7 @@
     </button>
   </div>
 </nav>
+
 <div class="nav-backdrop" id="nav-backdrop"></div>
 
 <main>
@@ -141,6 +152,18 @@
   </section>
 </main>
 
+<section class="page-cta">
+  <div class="container">
+    <h2>Where to go next</h2>
+    <p>Four ways into NHID-Clinical, whatever you came to do.</p>
+    <div class="page-cta-grid">
+      <a class="page-cta-card" href="/specification.html"><b>Read the Specification <span class="arr">&rarr;</span></b><span>The v1.3 controls, in full.</span></a>
+      <a class="page-cta-card" href="/simulator.html"><b>Try the Simulator <span class="arr">&rarr;</span></b><span>Run the controls on call scenarios.</span></a>
+      <a class="page-cta-card" href="/evidence-pack.html"><b>Review the Evidence Pack <span class="arr">&rarr;</span></b><span>Guarantees, a failure trace, the audit model.</span></a>
+      <a class="page-cta-card" href="https://github.com/NHID-Clinical/NHID-Clinical/discussions" target="_blank" rel="noopener noreferrer"><b>Join the Community <span class="arr">&#x2197;</span></b><span>Questions and feedback on GitHub.</span></a>
+    </div>
+  </div>
+</section>
 <footer id="contact" class="site-footer">
   <div class="container footer-inner">
     <p>© 2026 Brianna Baynard | NIST-2025-0035-0026 | CC BY 4.0</p>

--- a/implementation-review.html
+++ b/implementation-review.html
@@ -32,35 +32,42 @@
     </a>
     <div class="nav-links">
       <a href="/">Home</a>
-      <a href="/about.html">About</a>
-      <a href="/research-portfolio.html">Portfolio</a>
       <div class="nav-dropdown">
-        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Specification <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
+        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Learn <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
         <div class="nav-dropdown-menu">
           <a href="/specification.html">Specification</a>
           <a href="/technical-stack.html">Technical Stack</a>
           <a href="/regulatory-alignment.html">Regulatory Alignment</a>
+          <a href="/about.html">About</a>
         </div>
       </div>
       <div class="nav-dropdown">
-        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Implement <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
+        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Evaluate <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
+        <div class="nav-dropdown-menu">
+          <a href="/simulator.html">Simulator</a>
+          <a href="/shadow-evaluation-guide.html">Shadow Evaluation</a>
+          <a href="/evidence-pack.html">Evidence Pack</a>
+          <a href="/for-payers.html">For Payers</a>
+        </div>
+      </div>
+      <div class="nav-dropdown">
+        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Build <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
         <div class="nav-dropdown-menu">
           <a href="/developers.html">Developers</a>
           <a href="/interoperability.html">Interoperability</a>
-          <a href="/evidence-pack.html">Evidence Pack</a>
-          <a href="/shadow-evaluation-guide.html">Shadow Evaluation</a>
           <a href="/registry.html">Implementation Registry</a>
           <a href="/icon-system.html">Icon System</a>
         </div>
       </div>
       <div class="nav-dropdown">
-        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Pilot <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
+        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Community <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
         <div class="nav-dropdown-menu">
-          <a href="/for-payers.html">For Payers</a>          <a href="/roadmap.html">Roadmap</a>
           <a href="/news.html">News</a>
+          <a href="/roadmap.html">Roadmap</a>
+          <a href="/research-portfolio.html">Portfolio</a>
+          <a href="https://github.com/NHID-Clinical/NHID-Clinical">GitHub &#x2197;</a>
         </div>
       </div>
-      <a href="/simulator.html">Simulator</a>
       <a href="https://ai-governance-map.vercel.app/" target="_blank" rel="noopener noreferrer">AI Map &#x2197;</a>
     </div>
     <div class="nav-actions">
@@ -93,23 +100,26 @@
 
 <nav class="mobile-nav" id="mobile-nav" aria-label="Mobile navigation">
   <a href="/">Home</a>
-  <a href="/about.html">About</a>
-  <a href="/research-portfolio.html">Portfolio</a>
-  <a href="/simulator.html">Simulator</a>
-  <strong class="mobile-nav-group">Specification</strong>
+  <strong class="mobile-nav-group">Learn</strong>
   <a href="/specification.html">Specification</a>
   <a href="/technical-stack.html">Technical Stack</a>
   <a href="/regulatory-alignment.html">Regulatory Alignment</a>
-  <strong class="mobile-nav-group">Implement</strong>
+  <a href="/about.html">About</a>
+  <strong class="mobile-nav-group">Evaluate</strong>
+  <a href="/simulator.html">Simulator</a>
+  <a href="/shadow-evaluation-guide.html">Shadow Evaluation</a>
+  <a href="/evidence-pack.html">Evidence Pack</a>
+  <a href="/for-payers.html">For Payers</a>
+  <strong class="mobile-nav-group">Build</strong>
   <a href="/developers.html">Developers</a>
   <a href="/interoperability.html">Interoperability</a>
-  <a href="/evidence-pack.html">Evidence Pack</a>
-  <a href="/shadow-evaluation-guide.html">Shadow Evaluation</a>
   <a href="/registry.html">Implementation Registry</a>
   <a href="/icon-system.html">Icon System</a>
-  <strong class="mobile-nav-group">Pilot</strong>
-  <a href="/for-payers.html">For Payers</a>  <a href="/roadmap.html">Roadmap</a>
+  <strong class="mobile-nav-group">Community</strong>
   <a href="/news.html">News</a>
+  <a href="/roadmap.html">Roadmap</a>
+  <a href="/research-portfolio.html">Portfolio</a>
+  <a href="https://github.com/NHID-Clinical/NHID-Clinical" target="_blank" rel="noopener noreferrer">GitHub &#x2197;</a>
   <a href="https://ai-governance-map.vercel.app/" target="_blank" rel="noopener noreferrer">AI Map &#x2197;</a>
   <div class="mobile-nav-footer">
     <button class="theme-toggle mobile-theme-toggle" type="button" aria-label="Toggle dark mode">
@@ -119,6 +129,7 @@
     </button>
   </div>
 </nav>
+
 <div class="nav-backdrop" id="nav-backdrop"></div>
 
 <main>
@@ -148,6 +159,18 @@
   </section>
 </main>
 
+<section class="page-cta">
+  <div class="container">
+    <h2>Where to go next</h2>
+    <p>Four ways into NHID-Clinical, whatever you came to do.</p>
+    <div class="page-cta-grid">
+      <a class="page-cta-card" href="/specification.html"><b>Read the Specification <span class="arr">&rarr;</span></b><span>The v1.3 controls, in full.</span></a>
+      <a class="page-cta-card" href="/simulator.html"><b>Try the Simulator <span class="arr">&rarr;</span></b><span>Run the controls on call scenarios.</span></a>
+      <a class="page-cta-card" href="/evidence-pack.html"><b>Review the Evidence Pack <span class="arr">&rarr;</span></b><span>Guarantees, a failure trace, the audit model.</span></a>
+      <a class="page-cta-card" href="https://github.com/NHID-Clinical/NHID-Clinical/discussions" target="_blank" rel="noopener noreferrer"><b>Join the Community <span class="arr">&#x2197;</span></b><span>Questions and feedback on GitHub.</span></a>
+    </div>
+  </div>
+</section>
 <footer id="contact" class="site-footer">
   <div class="container footer-inner">
     <p>© 2026 Brianna Baynard | NIST-2025-0035-0026 | CC BY 4.0</p>

--- a/index.html
+++ b/index.html
@@ -33,35 +33,42 @@
     </a>
     <div class="nav-links">
       <a href="/">Home</a>
-      <a href="/about.html">About</a>
-      <a href="/research-portfolio.html">Portfolio</a>
       <div class="nav-dropdown">
-        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Specification <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
+        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Learn <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
         <div class="nav-dropdown-menu">
           <a href="/specification.html">Specification</a>
           <a href="/technical-stack.html">Technical Stack</a>
           <a href="/regulatory-alignment.html">Regulatory Alignment</a>
+          <a href="/about.html">About</a>
         </div>
       </div>
       <div class="nav-dropdown">
-        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Implement <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
+        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Evaluate <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
+        <div class="nav-dropdown-menu">
+          <a href="/simulator.html">Simulator</a>
+          <a href="/shadow-evaluation-guide.html">Shadow Evaluation</a>
+          <a href="/evidence-pack.html">Evidence Pack</a>
+          <a href="/for-payers.html">For Payers</a>
+        </div>
+      </div>
+      <div class="nav-dropdown">
+        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Build <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
         <div class="nav-dropdown-menu">
           <a href="/developers.html">Developers</a>
           <a href="/interoperability.html">Interoperability</a>
-          <a href="/evidence-pack.html">Evidence Pack</a>
-          <a href="/shadow-evaluation-guide.html">Shadow Evaluation</a>
           <a href="/registry.html">Implementation Registry</a>
           <a href="/icon-system.html">Icon System</a>
         </div>
       </div>
       <div class="nav-dropdown">
-        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Pilot <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
+        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Community <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
         <div class="nav-dropdown-menu">
-          <a href="/for-payers.html">For Payers</a>          <a href="/roadmap.html">Roadmap</a>
           <a href="/news.html">News</a>
+          <a href="/roadmap.html">Roadmap</a>
+          <a href="/research-portfolio.html">Portfolio</a>
+          <a href="https://github.com/NHID-Clinical/NHID-Clinical">GitHub &#x2197;</a>
         </div>
       </div>
-      <a href="/simulator.html">Simulator</a>
       <a href="https://ai-governance-map.vercel.app/" target="_blank" rel="noopener noreferrer">AI Map &#x2197;</a>
     </div>
     <div class="nav-actions">
@@ -94,23 +101,26 @@
 
 <nav class="mobile-nav" id="mobile-nav" aria-label="Mobile navigation">
   <a href="/">Home</a>
-  <a href="/about.html">About</a>
-  <a href="/research-portfolio.html">Portfolio</a>
-  <a href="/simulator.html">Simulator</a>
-  <strong class="mobile-nav-group">Specification</strong>
+  <strong class="mobile-nav-group">Learn</strong>
   <a href="/specification.html">Specification</a>
   <a href="/technical-stack.html">Technical Stack</a>
   <a href="/regulatory-alignment.html">Regulatory Alignment</a>
-  <strong class="mobile-nav-group">Implement</strong>
+  <a href="/about.html">About</a>
+  <strong class="mobile-nav-group">Evaluate</strong>
+  <a href="/simulator.html">Simulator</a>
+  <a href="/shadow-evaluation-guide.html">Shadow Evaluation</a>
+  <a href="/evidence-pack.html">Evidence Pack</a>
+  <a href="/for-payers.html">For Payers</a>
+  <strong class="mobile-nav-group">Build</strong>
   <a href="/developers.html">Developers</a>
   <a href="/interoperability.html">Interoperability</a>
-  <a href="/evidence-pack.html">Evidence Pack</a>
-  <a href="/shadow-evaluation-guide.html">Shadow Evaluation</a>
   <a href="/registry.html">Implementation Registry</a>
   <a href="/icon-system.html">Icon System</a>
-  <strong class="mobile-nav-group">Pilot</strong>
-  <a href="/for-payers.html">For Payers</a>  <a href="/roadmap.html">Roadmap</a>
+  <strong class="mobile-nav-group">Community</strong>
   <a href="/news.html">News</a>
+  <a href="/roadmap.html">Roadmap</a>
+  <a href="/research-portfolio.html">Portfolio</a>
+  <a href="https://github.com/NHID-Clinical/NHID-Clinical" target="_blank" rel="noopener noreferrer">GitHub &#x2197;</a>
   <a href="https://ai-governance-map.vercel.app/" target="_blank" rel="noopener noreferrer">AI Map &#x2197;</a>
   <div class="mobile-nav-footer">
     <button class="theme-toggle mobile-theme-toggle" type="button" aria-label="Toggle dark mode">
@@ -120,6 +130,7 @@
     </button>
   </div>
 </nav>
+
 <div class="nav-backdrop" id="nav-backdrop"></div>
 
 <main>
@@ -154,6 +165,18 @@
         <b>FHIR R4<small>AuditEvent evidence</small></b>
         <b>STIR/SHAKEN<small>Carrier authentication</small></b>
       </div>
+    </div>
+  </section>
+
+  <!-- ── Who is this for? ──────────────────────────────────────────────────── -->
+  <section class="page-section" style="padding-block:1rem 1.75rem">
+    <div class="container audience-row reveal">
+      <span class="audience-label">Who it's for</span>
+      <span class="audience-chip"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round"><path d="M3 21h18M4 21V10l8-5 8 5v11M9 21v-6h6v6"/></svg>Payers</span>
+      <span class="audience-chip"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round"><path d="M6 3v5a4 4 0 0 0 8 0V3"/><path d="M10 16a5 5 0 0 0 5-5"/><circle cx="18" cy="9.5" r="2"/></svg>Providers</span>
+      <span class="audience-chip"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round"><path d="m8 8-4 4 4 4M16 8l4 4-4 4"/></svg>AI vendors</span>
+      <span class="audience-chip"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3v18M5 7h14M7 7l-3 6h6zM17 7l-3 6h6z"/></svg>Regulators</span>
+      <span class="audience-chip"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round"><path d="M9 3h6M10 3v6l-5 9a2 2 0 0 0 2 3h10a2 2 0 0 0 2-3l-5-9V3"/></svg>Researchers</span>
     </div>
   </section>
 

--- a/interoperability.html
+++ b/interoperability.html
@@ -31,35 +31,42 @@
     </a>
     <div class="nav-links">
       <a href="/">Home</a>
-      <a href="/about.html">About</a>
-      <a href="/research-portfolio.html">Portfolio</a>
       <div class="nav-dropdown">
-        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Specification <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
+        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Learn <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
         <div class="nav-dropdown-menu">
           <a href="/specification.html">Specification</a>
           <a href="/technical-stack.html">Technical Stack</a>
           <a href="/regulatory-alignment.html">Regulatory Alignment</a>
+          <a href="/about.html">About</a>
         </div>
       </div>
       <div class="nav-dropdown">
-        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Implement <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
+        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Evaluate <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
+        <div class="nav-dropdown-menu">
+          <a href="/simulator.html">Simulator</a>
+          <a href="/shadow-evaluation-guide.html">Shadow Evaluation</a>
+          <a href="/evidence-pack.html">Evidence Pack</a>
+          <a href="/for-payers.html">For Payers</a>
+        </div>
+      </div>
+      <div class="nav-dropdown">
+        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Build <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
         <div class="nav-dropdown-menu">
           <a href="/developers.html">Developers</a>
           <a href="/interoperability.html">Interoperability</a>
-          <a href="/evidence-pack.html">Evidence Pack</a>
-          <a href="/shadow-evaluation-guide.html">Shadow Evaluation</a>
           <a href="/registry.html">Implementation Registry</a>
           <a href="/icon-system.html">Icon System</a>
         </div>
       </div>
       <div class="nav-dropdown">
-        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Pilot <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
+        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Community <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
         <div class="nav-dropdown-menu">
-          <a href="/for-payers.html">For Payers</a>          <a href="/roadmap.html">Roadmap</a>
           <a href="/news.html">News</a>
+          <a href="/roadmap.html">Roadmap</a>
+          <a href="/research-portfolio.html">Portfolio</a>
+          <a href="https://github.com/NHID-Clinical/NHID-Clinical">GitHub &#x2197;</a>
         </div>
       </div>
-      <a href="/simulator.html">Simulator</a>
       <a href="https://ai-governance-map.vercel.app/" target="_blank" rel="noopener noreferrer">AI Map &#x2197;</a>
     </div>
     <div class="nav-actions">
@@ -92,23 +99,26 @@
 
 <nav class="mobile-nav" id="mobile-nav" aria-label="Mobile navigation">
   <a href="/">Home</a>
-  <a href="/about.html">About</a>
-  <a href="/research-portfolio.html">Portfolio</a>
-  <a href="/simulator.html">Simulator</a>
-  <strong class="mobile-nav-group">Specification</strong>
+  <strong class="mobile-nav-group">Learn</strong>
   <a href="/specification.html">Specification</a>
   <a href="/technical-stack.html">Technical Stack</a>
   <a href="/regulatory-alignment.html">Regulatory Alignment</a>
-  <strong class="mobile-nav-group">Implement</strong>
+  <a href="/about.html">About</a>
+  <strong class="mobile-nav-group">Evaluate</strong>
+  <a href="/simulator.html">Simulator</a>
+  <a href="/shadow-evaluation-guide.html">Shadow Evaluation</a>
+  <a href="/evidence-pack.html">Evidence Pack</a>
+  <a href="/for-payers.html">For Payers</a>
+  <strong class="mobile-nav-group">Build</strong>
   <a href="/developers.html">Developers</a>
   <a href="/interoperability.html">Interoperability</a>
-  <a href="/evidence-pack.html">Evidence Pack</a>
-  <a href="/shadow-evaluation-guide.html">Shadow Evaluation</a>
   <a href="/registry.html">Implementation Registry</a>
   <a href="/icon-system.html">Icon System</a>
-  <strong class="mobile-nav-group">Pilot</strong>
-  <a href="/for-payers.html">For Payers</a>  <a href="/roadmap.html">Roadmap</a>
+  <strong class="mobile-nav-group">Community</strong>
   <a href="/news.html">News</a>
+  <a href="/roadmap.html">Roadmap</a>
+  <a href="/research-portfolio.html">Portfolio</a>
+  <a href="https://github.com/NHID-Clinical/NHID-Clinical" target="_blank" rel="noopener noreferrer">GitHub &#x2197;</a>
   <a href="https://ai-governance-map.vercel.app/" target="_blank" rel="noopener noreferrer">AI Map &#x2197;</a>
   <div class="mobile-nav-footer">
     <button class="theme-toggle mobile-theme-toggle" type="button" aria-label="Toggle dark mode">
@@ -118,6 +128,7 @@
     </button>
   </div>
 </nav>
+
 <div class="nav-backdrop" id="nav-backdrop"></div>
 
 <main>
@@ -243,6 +254,18 @@ python -m pytest tests/ -v</pre>
   </section>
 </main>
 
+<section class="page-cta">
+  <div class="container">
+    <h2>Where to go next</h2>
+    <p>Four ways into NHID-Clinical, whatever you came to do.</p>
+    <div class="page-cta-grid">
+      <a class="page-cta-card" href="/specification.html"><b>Read the Specification <span class="arr">&rarr;</span></b><span>The v1.3 controls, in full.</span></a>
+      <a class="page-cta-card" href="/simulator.html"><b>Try the Simulator <span class="arr">&rarr;</span></b><span>Run the controls on call scenarios.</span></a>
+      <a class="page-cta-card" href="/evidence-pack.html"><b>Review the Evidence Pack <span class="arr">&rarr;</span></b><span>Guarantees, a failure trace, the audit model.</span></a>
+      <a class="page-cta-card" href="https://github.com/NHID-Clinical/NHID-Clinical/discussions" target="_blank" rel="noopener noreferrer"><b>Join the Community <span class="arr">&#x2197;</span></b><span>Questions and feedback on GitHub.</span></a>
+    </div>
+  </div>
+</section>
 <footer id="contact" class="site-footer">
   <div class="container footer-inner">
     <p>© 2026 Brianna Baynard | NIST-2025-0035-0026 | CC BY 4.0</p>

--- a/news.html
+++ b/news.html
@@ -32,35 +32,42 @@
     </a>
                 <div class="nav-links">
       <a href="/">Home</a>
-      <a href="/about.html">About</a>
-      <a href="/research-portfolio.html">Portfolio</a>
       <div class="nav-dropdown">
-        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Specification <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
+        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Learn <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
         <div class="nav-dropdown-menu">
           <a href="/specification.html">Specification</a>
           <a href="/technical-stack.html">Technical Stack</a>
           <a href="/regulatory-alignment.html">Regulatory Alignment</a>
+          <a href="/about.html">About</a>
         </div>
       </div>
       <div class="nav-dropdown">
-        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Implement <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
+        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Evaluate <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
+        <div class="nav-dropdown-menu">
+          <a href="/simulator.html">Simulator</a>
+          <a href="/shadow-evaluation-guide.html">Shadow Evaluation</a>
+          <a href="/evidence-pack.html">Evidence Pack</a>
+          <a href="/for-payers.html">For Payers</a>
+        </div>
+      </div>
+      <div class="nav-dropdown">
+        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Build <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
         <div class="nav-dropdown-menu">
           <a href="/developers.html">Developers</a>
           <a href="/interoperability.html">Interoperability</a>
-          <a href="/evidence-pack.html">Evidence Pack</a>
-          <a href="/shadow-evaluation-guide.html">Shadow Evaluation</a>
           <a href="/registry.html">Implementation Registry</a>
           <a href="/icon-system.html">Icon System</a>
         </div>
       </div>
       <div class="nav-dropdown">
-        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Pilot <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
+        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Community <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
         <div class="nav-dropdown-menu">
-          <a href="/for-payers.html">For Payers</a>          <a href="/roadmap.html">Roadmap</a>
           <a href="/news.html">News</a>
+          <a href="/roadmap.html">Roadmap</a>
+          <a href="/research-portfolio.html">Portfolio</a>
+          <a href="https://github.com/NHID-Clinical/NHID-Clinical">GitHub &#x2197;</a>
         </div>
       </div>
-      <a href="/simulator.html">Simulator</a>
       <a href="https://ai-governance-map.vercel.app/" target="_blank" rel="noopener noreferrer">AI Map &#x2197;</a>
     </div>
     <div class="nav-actions">
@@ -93,23 +100,26 @@
 
 <nav class="mobile-nav" id="mobile-nav" aria-label="Mobile navigation">
   <a href="/">Home</a>
-  <a href="/about.html">About</a>
-  <a href="/research-portfolio.html">Portfolio</a>
-  <a href="/simulator.html">Simulator</a>
-  <strong class="mobile-nav-group">Specification</strong>
+  <strong class="mobile-nav-group">Learn</strong>
   <a href="/specification.html">Specification</a>
   <a href="/technical-stack.html">Technical Stack</a>
   <a href="/regulatory-alignment.html">Regulatory Alignment</a>
-  <strong class="mobile-nav-group">Implement</strong>
+  <a href="/about.html">About</a>
+  <strong class="mobile-nav-group">Evaluate</strong>
+  <a href="/simulator.html">Simulator</a>
+  <a href="/shadow-evaluation-guide.html">Shadow Evaluation</a>
+  <a href="/evidence-pack.html">Evidence Pack</a>
+  <a href="/for-payers.html">For Payers</a>
+  <strong class="mobile-nav-group">Build</strong>
   <a href="/developers.html">Developers</a>
   <a href="/interoperability.html">Interoperability</a>
-  <a href="/evidence-pack.html">Evidence Pack</a>
-  <a href="/shadow-evaluation-guide.html">Shadow Evaluation</a>
   <a href="/registry.html">Implementation Registry</a>
   <a href="/icon-system.html">Icon System</a>
-  <strong class="mobile-nav-group">Pilot</strong>
-  <a href="/for-payers.html">For Payers</a>  <a href="/roadmap.html">Roadmap</a>
+  <strong class="mobile-nav-group">Community</strong>
   <a href="/news.html">News</a>
+  <a href="/roadmap.html">Roadmap</a>
+  <a href="/research-portfolio.html">Portfolio</a>
+  <a href="https://github.com/NHID-Clinical/NHID-Clinical" target="_blank" rel="noopener noreferrer">GitHub &#x2197;</a>
   <a href="https://ai-governance-map.vercel.app/" target="_blank" rel="noopener noreferrer">AI Map &#x2197;</a>
   <div class="mobile-nav-footer">
     <button class="theme-toggle mobile-theme-toggle" type="button" aria-label="Toggle dark mode">
@@ -119,6 +129,7 @@
     </button>
   </div>
 </nav>
+
 <div class="nav-backdrop" id="nav-backdrop"></div>
 
 <main>
@@ -271,6 +282,18 @@
   </section>
 </main>
 
+<section class="page-cta">
+  <div class="container">
+    <h2>Where to go next</h2>
+    <p>Four ways into NHID-Clinical, whatever you came to do.</p>
+    <div class="page-cta-grid">
+      <a class="page-cta-card" href="/specification.html"><b>Read the Specification <span class="arr">&rarr;</span></b><span>The v1.3 controls, in full.</span></a>
+      <a class="page-cta-card" href="/simulator.html"><b>Try the Simulator <span class="arr">&rarr;</span></b><span>Run the controls on call scenarios.</span></a>
+      <a class="page-cta-card" href="/evidence-pack.html"><b>Review the Evidence Pack <span class="arr">&rarr;</span></b><span>Guarantees, a failure trace, the audit model.</span></a>
+      <a class="page-cta-card" href="https://github.com/NHID-Clinical/NHID-Clinical/discussions" target="_blank" rel="noopener noreferrer"><b>Join the Community <span class="arr">&#x2197;</span></b><span>Questions and feedback on GitHub.</span></a>
+    </div>
+  </div>
+</section>
 <footer id="contact" class="site-footer">
   <div class="container footer-inner">
     <p>© 2026 Brianna Baynard | NIST-2025-0035-0026 | CC BY 4.0</p>

--- a/nhid-clinical-ui.css
+++ b/nhid-clinical-ui.css
@@ -3305,3 +3305,72 @@ h2 { font-weight: 700; }
 .mock-row { display: flex; align-items: center; justify-content: space-between; padding: .58rem 0; border-top: 1px solid var(--line); font-size: .9rem; color: var(--ink-soft); }
 .mock-row .ok { color: var(--teal-bright); font-weight: 800; }
 .mock-tag { margin-top: 1rem; font-size: .72rem; color: var(--body); font-style: italic; }
+
+/* ═══════════════════════════════════════════════════════════════════════
+   Readability & information-architecture layer (2026-07)
+   Executive-scan patterns: status badge, 2-min summary, audience row,
+   standardized page CTA, comfortable reading measure.
+   ═══════════════════════════════════════════════════════════════════════ */
+
+.readable { max-width: 44rem; margin-inline: auto; }
+main p { line-height: 1.75; }
+
+/* Compact status badge — the single, consistent disclaimer chip */
+.status-badge {
+  display: inline-flex; flex-wrap: wrap; align-items: center; gap: .55rem;
+  font-size: .74rem; font-weight: 600; letter-spacing: .01em;
+  color: var(--body); background: var(--mist);
+  border: 1px solid var(--line); border-radius: 999px;
+  padding: .38rem .9rem; line-height: 1;
+}
+.status-badge b { color: var(--ink); font-weight: 700; }
+.status-badge .sep { color: var(--teal-bright); font-weight: 700; }
+
+/* "2-minute summary" — executive scan block: Problem / Solution / Evidence / Next */
+.exec-summary {
+  border: 1px solid var(--line); border-left: 4px solid var(--teal-bright);
+  background: var(--paper); border-radius: 14px;
+  padding: 1.5rem 1.7rem; margin: 1.75rem 0 0;
+}
+.exec-summary .exec-kicker {
+  font-size: .72rem; letter-spacing: .14em; text-transform: uppercase;
+  font-weight: 700; color: var(--teal-bright); margin: 0 0 .9rem;
+}
+.exec-summary dl { margin: 0; display: grid; gap: .7rem; }
+.exec-summary dt {
+  font-family: var(--display); font-weight: 700; font-size: .8rem;
+  letter-spacing: .02em; color: var(--ink); text-transform: uppercase;
+}
+.exec-summary dd { margin: .1rem 0 0; color: var(--body); font-size: .98rem; line-height: 1.6; }
+@media (min-width: 620px) {
+  .exec-summary dl { grid-template-columns: 7rem 1fr; gap: .55rem 1.2rem; align-items: baseline; }
+  .exec-summary dt { text-align: right; }
+}
+.exec-summary .more { display: inline-block; margin-top: 1.1rem; font-weight: 600; font-size: .92rem; color: var(--teal-bright); }
+
+/* "Who is this for?" audience chips */
+.audience-row { display: flex; flex-wrap: wrap; gap: .6rem; align-items: center; }
+.audience-label { font-size: .72rem; letter-spacing: .12em; text-transform: uppercase; font-weight: 700; color: var(--body); margin-right: .2rem; }
+.audience-chip {
+  display: inline-flex; align-items: center; gap: .45rem;
+  font-size: .86rem; font-weight: 600; color: var(--ink-soft);
+  background: var(--teal-soft); border: 1px solid rgba(20,184,166,.26);
+  border-radius: 999px; padding: .4rem .85rem;
+}
+.audience-chip svg { width: 16px; height: 16px; color: var(--teal-bright); flex-shrink: 0; }
+
+/* Standardized bottom-of-page call to action (consistent across every page) */
+.page-cta { border-top: 1px solid var(--line); padding-block: clamp(2.5rem, 5vw, 4rem); }
+.page-cta h2 { font-size: clamp(1.4rem, 2.4vw, 1.9rem); margin: 0 0 .3rem; }
+.page-cta > .container > p { color: var(--body); margin: 0 0 1.5rem; }
+.page-cta-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(13rem, 1fr)); gap: 1rem; }
+.page-cta-card {
+  display: flex; flex-direction: column; gap: .3rem;
+  border: 1px solid var(--line); border-radius: 14px; background: var(--paper);
+  padding: 1.15rem 1.25rem; text-decoration: none; color: var(--ink);
+  transition: transform .28s ease, box-shadow .28s ease, border-color .28s ease;
+}
+.page-cta-card:hover { transform: translateY(-4px); box-shadow: 0 18px 42px -24px rgba(15,23,42,.30); border-color: rgba(20,184,166,.45); }
+.page-cta-card b { font-family: var(--display); font-weight: 700; font-size: 1rem; }
+.page-cta-card span { font-size: .85rem; color: var(--body); line-height: 1.5; }
+.page-cta-card .arr { color: var(--teal-bright); font-weight: 800; }

--- a/privacy.html
+++ b/privacy.html
@@ -31,35 +31,42 @@
     </a>
     <div class="nav-links">
       <a href="/">Home</a>
-      <a href="/about.html">About</a>
-      <a href="/research-portfolio.html">Portfolio</a>
       <div class="nav-dropdown">
-        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Specification <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
+        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Learn <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
         <div class="nav-dropdown-menu">
           <a href="/specification.html">Specification</a>
           <a href="/technical-stack.html">Technical Stack</a>
           <a href="/regulatory-alignment.html">Regulatory Alignment</a>
+          <a href="/about.html">About</a>
         </div>
       </div>
       <div class="nav-dropdown">
-        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Implement <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
+        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Evaluate <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
+        <div class="nav-dropdown-menu">
+          <a href="/simulator.html">Simulator</a>
+          <a href="/shadow-evaluation-guide.html">Shadow Evaluation</a>
+          <a href="/evidence-pack.html">Evidence Pack</a>
+          <a href="/for-payers.html">For Payers</a>
+        </div>
+      </div>
+      <div class="nav-dropdown">
+        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Build <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
         <div class="nav-dropdown-menu">
           <a href="/developers.html">Developers</a>
           <a href="/interoperability.html">Interoperability</a>
-          <a href="/evidence-pack.html">Evidence Pack</a>
-          <a href="/shadow-evaluation-guide.html">Shadow Evaluation</a>
           <a href="/registry.html">Implementation Registry</a>
           <a href="/icon-system.html">Icon System</a>
         </div>
       </div>
       <div class="nav-dropdown">
-        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Pilot <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
+        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Community <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
         <div class="nav-dropdown-menu">
-          <a href="/for-payers.html">For Payers</a>          <a href="/roadmap.html">Roadmap</a>
           <a href="/news.html">News</a>
+          <a href="/roadmap.html">Roadmap</a>
+          <a href="/research-portfolio.html">Portfolio</a>
+          <a href="https://github.com/NHID-Clinical/NHID-Clinical">GitHub &#x2197;</a>
         </div>
       </div>
-      <a href="/simulator.html">Simulator</a>
       <a href="https://ai-governance-map.vercel.app/" target="_blank" rel="noopener noreferrer">AI Map &#x2197;</a>
     </div>
     <div class="nav-actions">
@@ -92,23 +99,26 @@
 
 <nav class="mobile-nav" id="mobile-nav" aria-label="Mobile navigation">
   <a href="/">Home</a>
-  <a href="/about.html">About</a>
-  <a href="/research-portfolio.html">Portfolio</a>
-  <a href="/simulator.html">Simulator</a>
-  <strong class="mobile-nav-group">Specification</strong>
+  <strong class="mobile-nav-group">Learn</strong>
   <a href="/specification.html">Specification</a>
   <a href="/technical-stack.html">Technical Stack</a>
   <a href="/regulatory-alignment.html">Regulatory Alignment</a>
-  <strong class="mobile-nav-group">Implement</strong>
+  <a href="/about.html">About</a>
+  <strong class="mobile-nav-group">Evaluate</strong>
+  <a href="/simulator.html">Simulator</a>
+  <a href="/shadow-evaluation-guide.html">Shadow Evaluation</a>
+  <a href="/evidence-pack.html">Evidence Pack</a>
+  <a href="/for-payers.html">For Payers</a>
+  <strong class="mobile-nav-group">Build</strong>
   <a href="/developers.html">Developers</a>
   <a href="/interoperability.html">Interoperability</a>
-  <a href="/evidence-pack.html">Evidence Pack</a>
-  <a href="/shadow-evaluation-guide.html">Shadow Evaluation</a>
   <a href="/registry.html">Implementation Registry</a>
   <a href="/icon-system.html">Icon System</a>
-  <strong class="mobile-nav-group">Pilot</strong>
-  <a href="/for-payers.html">For Payers</a>  <a href="/roadmap.html">Roadmap</a>
+  <strong class="mobile-nav-group">Community</strong>
   <a href="/news.html">News</a>
+  <a href="/roadmap.html">Roadmap</a>
+  <a href="/research-portfolio.html">Portfolio</a>
+  <a href="https://github.com/NHID-Clinical/NHID-Clinical" target="_blank" rel="noopener noreferrer">GitHub &#x2197;</a>
   <a href="https://ai-governance-map.vercel.app/" target="_blank" rel="noopener noreferrer">AI Map &#x2197;</a>
   <div class="mobile-nav-footer">
     <button class="theme-toggle mobile-theme-toggle" type="button" aria-label="Toggle dark mode">
@@ -118,6 +128,7 @@
     </button>
   </div>
 </nav>
+
 <div class="nav-backdrop" id="nav-backdrop"></div>
 
 <main>

--- a/proof.html
+++ b/proof.html
@@ -32,35 +32,42 @@
     </a>
     <div class="nav-links">
       <a href="/">Home</a>
-      <a href="/about.html">About</a>
-      <a href="/research-portfolio.html">Portfolio</a>
       <div class="nav-dropdown">
-        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Specification <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
+        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Learn <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
         <div class="nav-dropdown-menu">
           <a href="/specification.html">Specification</a>
           <a href="/technical-stack.html">Technical Stack</a>
           <a href="/regulatory-alignment.html">Regulatory Alignment</a>
+          <a href="/about.html">About</a>
         </div>
       </div>
       <div class="nav-dropdown">
-        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Implement <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
+        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Evaluate <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
+        <div class="nav-dropdown-menu">
+          <a href="/simulator.html">Simulator</a>
+          <a href="/shadow-evaluation-guide.html">Shadow Evaluation</a>
+          <a href="/evidence-pack.html">Evidence Pack</a>
+          <a href="/for-payers.html">For Payers</a>
+        </div>
+      </div>
+      <div class="nav-dropdown">
+        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Build <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
         <div class="nav-dropdown-menu">
           <a href="/developers.html">Developers</a>
           <a href="/interoperability.html">Interoperability</a>
-          <a href="/evidence-pack.html">Evidence Pack</a>
-          <a href="/shadow-evaluation-guide.html">Shadow Evaluation</a>
           <a href="/registry.html">Implementation Registry</a>
           <a href="/icon-system.html">Icon System</a>
         </div>
       </div>
       <div class="nav-dropdown">
-        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Pilot <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
+        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Community <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
         <div class="nav-dropdown-menu">
-          <a href="/for-payers.html">For Payers</a>          <a href="/roadmap.html">Roadmap</a>
           <a href="/news.html">News</a>
+          <a href="/roadmap.html">Roadmap</a>
+          <a href="/research-portfolio.html">Portfolio</a>
+          <a href="https://github.com/NHID-Clinical/NHID-Clinical">GitHub &#x2197;</a>
         </div>
       </div>
-      <a href="/simulator.html">Simulator</a>
       <a href="https://ai-governance-map.vercel.app/" target="_blank" rel="noopener noreferrer">AI Map &#x2197;</a>
     </div>
     <div class="nav-actions">
@@ -93,23 +100,26 @@
 
 <nav class="mobile-nav" id="mobile-nav" aria-label="Mobile navigation">
   <a href="/">Home</a>
-  <a href="/about.html">About</a>
-  <a href="/research-portfolio.html">Portfolio</a>
-  <a href="/simulator.html">Simulator</a>
-  <strong class="mobile-nav-group">Specification</strong>
+  <strong class="mobile-nav-group">Learn</strong>
   <a href="/specification.html">Specification</a>
   <a href="/technical-stack.html">Technical Stack</a>
   <a href="/regulatory-alignment.html">Regulatory Alignment</a>
-  <strong class="mobile-nav-group">Implement</strong>
+  <a href="/about.html">About</a>
+  <strong class="mobile-nav-group">Evaluate</strong>
+  <a href="/simulator.html">Simulator</a>
+  <a href="/shadow-evaluation-guide.html">Shadow Evaluation</a>
+  <a href="/evidence-pack.html">Evidence Pack</a>
+  <a href="/for-payers.html">For Payers</a>
+  <strong class="mobile-nav-group">Build</strong>
   <a href="/developers.html">Developers</a>
   <a href="/interoperability.html">Interoperability</a>
-  <a href="/evidence-pack.html">Evidence Pack</a>
-  <a href="/shadow-evaluation-guide.html">Shadow Evaluation</a>
   <a href="/registry.html">Implementation Registry</a>
   <a href="/icon-system.html">Icon System</a>
-  <strong class="mobile-nav-group">Pilot</strong>
-  <a href="/for-payers.html">For Payers</a>  <a href="/roadmap.html">Roadmap</a>
+  <strong class="mobile-nav-group">Community</strong>
   <a href="/news.html">News</a>
+  <a href="/roadmap.html">Roadmap</a>
+  <a href="/research-portfolio.html">Portfolio</a>
+  <a href="https://github.com/NHID-Clinical/NHID-Clinical" target="_blank" rel="noopener noreferrer">GitHub &#x2197;</a>
   <a href="https://ai-governance-map.vercel.app/" target="_blank" rel="noopener noreferrer">AI Map &#x2197;</a>
   <div class="mobile-nav-footer">
     <button class="theme-toggle mobile-theme-toggle" type="button" aria-label="Toggle dark mode">
@@ -119,6 +129,7 @@
     </button>
   </div>
 </nav>
+
 <div class="nav-backdrop" id="nav-backdrop"></div>
 
 <main>
@@ -322,6 +333,18 @@ t=00:00.152  PERSIST    Event written — disclosure_timestamp set</pre>
   </section>
 </main>
 
+<section class="page-cta">
+  <div class="container">
+    <h2>Where to go next</h2>
+    <p>Four ways into NHID-Clinical, whatever you came to do.</p>
+    <div class="page-cta-grid">
+      <a class="page-cta-card" href="/specification.html"><b>Read the Specification <span class="arr">&rarr;</span></b><span>The v1.3 controls, in full.</span></a>
+      <a class="page-cta-card" href="/simulator.html"><b>Try the Simulator <span class="arr">&rarr;</span></b><span>Run the controls on call scenarios.</span></a>
+      <a class="page-cta-card" href="/evidence-pack.html"><b>Review the Evidence Pack <span class="arr">&rarr;</span></b><span>Guarantees, a failure trace, the audit model.</span></a>
+      <a class="page-cta-card" href="https://github.com/NHID-Clinical/NHID-Clinical/discussions" target="_blank" rel="noopener noreferrer"><b>Join the Community <span class="arr">&#x2197;</span></b><span>Questions and feedback on GitHub.</span></a>
+    </div>
+  </div>
+</section>
 <footer id="contact" class="site-footer">
   <div class="container footer-inner">
     <p>© 2026 Brianna Baynard | NIST-2025-0035-0026 | CC BY 4.0</p>

--- a/registry.html
+++ b/registry.html
@@ -31,35 +31,42 @@
     </a>
     <div class="nav-links">
       <a href="/">Home</a>
-      <a href="/about.html">About</a>
-      <a href="/research-portfolio.html">Portfolio</a>
       <div class="nav-dropdown">
-        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Specification <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
+        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Learn <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
         <div class="nav-dropdown-menu">
           <a href="/specification.html">Specification</a>
           <a href="/technical-stack.html">Technical Stack</a>
           <a href="/regulatory-alignment.html">Regulatory Alignment</a>
+          <a href="/about.html">About</a>
         </div>
       </div>
       <div class="nav-dropdown">
-        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Implement <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
+        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Evaluate <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
+        <div class="nav-dropdown-menu">
+          <a href="/simulator.html">Simulator</a>
+          <a href="/shadow-evaluation-guide.html">Shadow Evaluation</a>
+          <a href="/evidence-pack.html">Evidence Pack</a>
+          <a href="/for-payers.html">For Payers</a>
+        </div>
+      </div>
+      <div class="nav-dropdown">
+        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Build <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
         <div class="nav-dropdown-menu">
           <a href="/developers.html">Developers</a>
           <a href="/interoperability.html">Interoperability</a>
-          <a href="/evidence-pack.html">Evidence Pack</a>
-          <a href="/shadow-evaluation-guide.html">Shadow Evaluation</a>
           <a href="/registry.html">Implementation Registry</a>
           <a href="/icon-system.html">Icon System</a>
         </div>
       </div>
       <div class="nav-dropdown">
-        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Pilot <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
+        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Community <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
         <div class="nav-dropdown-menu">
-          <a href="/for-payers.html">For Payers</a>          <a href="/roadmap.html">Roadmap</a>
           <a href="/news.html">News</a>
+          <a href="/roadmap.html">Roadmap</a>
+          <a href="/research-portfolio.html">Portfolio</a>
+          <a href="https://github.com/NHID-Clinical/NHID-Clinical">GitHub &#x2197;</a>
         </div>
       </div>
-      <a href="/simulator.html">Simulator</a>
       <a href="https://ai-governance-map.vercel.app/" target="_blank" rel="noopener noreferrer">AI Map &#x2197;</a>
     </div>
     <div class="nav-actions">
@@ -92,23 +99,26 @@
 
 <nav class="mobile-nav" id="mobile-nav" aria-label="Mobile navigation">
   <a href="/">Home</a>
-  <a href="/about.html">About</a>
-  <a href="/research-portfolio.html">Portfolio</a>
-  <a href="/simulator.html">Simulator</a>
-  <strong class="mobile-nav-group">Specification</strong>
+  <strong class="mobile-nav-group">Learn</strong>
   <a href="/specification.html">Specification</a>
   <a href="/technical-stack.html">Technical Stack</a>
   <a href="/regulatory-alignment.html">Regulatory Alignment</a>
-  <strong class="mobile-nav-group">Implement</strong>
+  <a href="/about.html">About</a>
+  <strong class="mobile-nav-group">Evaluate</strong>
+  <a href="/simulator.html">Simulator</a>
+  <a href="/shadow-evaluation-guide.html">Shadow Evaluation</a>
+  <a href="/evidence-pack.html">Evidence Pack</a>
+  <a href="/for-payers.html">For Payers</a>
+  <strong class="mobile-nav-group">Build</strong>
   <a href="/developers.html">Developers</a>
   <a href="/interoperability.html">Interoperability</a>
-  <a href="/evidence-pack.html">Evidence Pack</a>
-  <a href="/shadow-evaluation-guide.html">Shadow Evaluation</a>
   <a href="/registry.html">Implementation Registry</a>
   <a href="/icon-system.html">Icon System</a>
-  <strong class="mobile-nav-group">Pilot</strong>
-  <a href="/for-payers.html">For Payers</a>  <a href="/roadmap.html">Roadmap</a>
+  <strong class="mobile-nav-group">Community</strong>
   <a href="/news.html">News</a>
+  <a href="/roadmap.html">Roadmap</a>
+  <a href="/research-portfolio.html">Portfolio</a>
+  <a href="https://github.com/NHID-Clinical/NHID-Clinical" target="_blank" rel="noopener noreferrer">GitHub &#x2197;</a>
   <a href="https://ai-governance-map.vercel.app/" target="_blank" rel="noopener noreferrer">AI Map &#x2197;</a>
   <div class="mobile-nav-footer">
     <button class="theme-toggle mobile-theme-toggle" type="button" aria-label="Toggle dark mode">
@@ -118,6 +128,7 @@
     </button>
   </div>
 </nav>
+
 <div class="nav-backdrop" id="nav-backdrop"></div>
 
 <main>
@@ -168,6 +179,18 @@
   </section>
 </main>
 
+<section class="page-cta">
+  <div class="container">
+    <h2>Where to go next</h2>
+    <p>Four ways into NHID-Clinical, whatever you came to do.</p>
+    <div class="page-cta-grid">
+      <a class="page-cta-card" href="/specification.html"><b>Read the Specification <span class="arr">&rarr;</span></b><span>The v1.3 controls, in full.</span></a>
+      <a class="page-cta-card" href="/simulator.html"><b>Try the Simulator <span class="arr">&rarr;</span></b><span>Run the controls on call scenarios.</span></a>
+      <a class="page-cta-card" href="/evidence-pack.html"><b>Review the Evidence Pack <span class="arr">&rarr;</span></b><span>Guarantees, a failure trace, the audit model.</span></a>
+      <a class="page-cta-card" href="https://github.com/NHID-Clinical/NHID-Clinical/discussions" target="_blank" rel="noopener noreferrer"><b>Join the Community <span class="arr">&#x2197;</span></b><span>Questions and feedback on GitHub.</span></a>
+    </div>
+  </div>
+</section>
 <footer id="contact" class="site-footer">
   <div class="container footer-inner">
     <p>&copy; 2026 Brianna Baynard | NIST-2025-0035-0026 | CC BY 4.0</p>

--- a/regulatory-alignment.html
+++ b/regulatory-alignment.html
@@ -32,35 +32,42 @@
     </a>
     <div class="nav-links">
       <a href="/">Home</a>
-      <a href="/about.html">About</a>
-      <a href="/research-portfolio.html">Portfolio</a>
       <div class="nav-dropdown">
-        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Specification <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
+        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Learn <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
         <div class="nav-dropdown-menu">
           <a href="/specification.html">Specification</a>
           <a href="/technical-stack.html">Technical Stack</a>
           <a href="/regulatory-alignment.html">Regulatory Alignment</a>
+          <a href="/about.html">About</a>
         </div>
       </div>
       <div class="nav-dropdown">
-        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Implement <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
+        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Evaluate <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
+        <div class="nav-dropdown-menu">
+          <a href="/simulator.html">Simulator</a>
+          <a href="/shadow-evaluation-guide.html">Shadow Evaluation</a>
+          <a href="/evidence-pack.html">Evidence Pack</a>
+          <a href="/for-payers.html">For Payers</a>
+        </div>
+      </div>
+      <div class="nav-dropdown">
+        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Build <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
         <div class="nav-dropdown-menu">
           <a href="/developers.html">Developers</a>
           <a href="/interoperability.html">Interoperability</a>
-          <a href="/evidence-pack.html">Evidence Pack</a>
-          <a href="/shadow-evaluation-guide.html">Shadow Evaluation</a>
           <a href="/registry.html">Implementation Registry</a>
           <a href="/icon-system.html">Icon System</a>
         </div>
       </div>
       <div class="nav-dropdown">
-        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Pilot <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
+        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Community <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
         <div class="nav-dropdown-menu">
-          <a href="/for-payers.html">For Payers</a>          <a href="/roadmap.html">Roadmap</a>
           <a href="/news.html">News</a>
+          <a href="/roadmap.html">Roadmap</a>
+          <a href="/research-portfolio.html">Portfolio</a>
+          <a href="https://github.com/NHID-Clinical/NHID-Clinical">GitHub &#x2197;</a>
         </div>
       </div>
-      <a href="/simulator.html">Simulator</a>
       <a href="https://ai-governance-map.vercel.app/" target="_blank" rel="noopener noreferrer">AI Map &#x2197;</a>
     </div>
     <div class="nav-actions">
@@ -93,23 +100,26 @@
 
 <nav class="mobile-nav" id="mobile-nav" aria-label="Mobile navigation">
   <a href="/">Home</a>
-  <a href="/about.html">About</a>
-  <a href="/research-portfolio.html">Portfolio</a>
-  <a href="/simulator.html">Simulator</a>
-  <strong class="mobile-nav-group">Specification</strong>
+  <strong class="mobile-nav-group">Learn</strong>
   <a href="/specification.html">Specification</a>
   <a href="/technical-stack.html">Technical Stack</a>
   <a href="/regulatory-alignment.html">Regulatory Alignment</a>
-  <strong class="mobile-nav-group">Implement</strong>
+  <a href="/about.html">About</a>
+  <strong class="mobile-nav-group">Evaluate</strong>
+  <a href="/simulator.html">Simulator</a>
+  <a href="/shadow-evaluation-guide.html">Shadow Evaluation</a>
+  <a href="/evidence-pack.html">Evidence Pack</a>
+  <a href="/for-payers.html">For Payers</a>
+  <strong class="mobile-nav-group">Build</strong>
   <a href="/developers.html">Developers</a>
   <a href="/interoperability.html">Interoperability</a>
-  <a href="/evidence-pack.html">Evidence Pack</a>
-  <a href="/shadow-evaluation-guide.html">Shadow Evaluation</a>
   <a href="/registry.html">Implementation Registry</a>
   <a href="/icon-system.html">Icon System</a>
-  <strong class="mobile-nav-group">Pilot</strong>
-  <a href="/for-payers.html">For Payers</a>  <a href="/roadmap.html">Roadmap</a>
+  <strong class="mobile-nav-group">Community</strong>
   <a href="/news.html">News</a>
+  <a href="/roadmap.html">Roadmap</a>
+  <a href="/research-portfolio.html">Portfolio</a>
+  <a href="https://github.com/NHID-Clinical/NHID-Clinical" target="_blank" rel="noopener noreferrer">GitHub &#x2197;</a>
   <a href="https://ai-governance-map.vercel.app/" target="_blank" rel="noopener noreferrer">AI Map &#x2197;</a>
   <div class="mobile-nav-footer">
     <button class="theme-toggle mobile-theme-toggle" type="button" aria-label="Toggle dark mode">
@@ -119,6 +129,7 @@
     </button>
   </div>
 </nav>
+
 <div class="nav-backdrop" id="nav-backdrop"></div>
 
 <main>
@@ -226,6 +237,18 @@
       <h3>NHID v1.3 in full multi-framework context</h3>
       <p>See how the proposal sits alongside CCM, NIST, ISO, and the EU AI Act — including the gaps it aims to close.</p>
       <a href="https://ai-governance-map.vercel.app/">Open the AI Governance Map →</a>&nbsp;&nbsp;
+    </div>
+  </div>
+</section>
+<section class="page-cta">
+  <div class="container">
+    <h2>Where to go next</h2>
+    <p>Four ways into NHID-Clinical, whatever you came to do.</p>
+    <div class="page-cta-grid">
+      <a class="page-cta-card" href="/specification.html"><b>Read the Specification <span class="arr">&rarr;</span></b><span>The v1.3 controls, in full.</span></a>
+      <a class="page-cta-card" href="/simulator.html"><b>Try the Simulator <span class="arr">&rarr;</span></b><span>Run the controls on call scenarios.</span></a>
+      <a class="page-cta-card" href="/evidence-pack.html"><b>Review the Evidence Pack <span class="arr">&rarr;</span></b><span>Guarantees, a failure trace, the audit model.</span></a>
+      <a class="page-cta-card" href="https://github.com/NHID-Clinical/NHID-Clinical/discussions" target="_blank" rel="noopener noreferrer"><b>Join the Community <span class="arr">&#x2197;</span></b><span>Questions and feedback on GitHub.</span></a>
     </div>
   </div>
 </section>

--- a/research-portfolio.html
+++ b/research-portfolio.html
@@ -32,35 +32,42 @@
     </a>
     <div class="nav-links">
       <a href="/">Home</a>
-      <a href="/about.html">About</a>
-      <a href="/research-portfolio.html">Portfolio</a>
       <div class="nav-dropdown">
-        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Specification <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
+        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Learn <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
         <div class="nav-dropdown-menu">
           <a href="/specification.html">Specification</a>
           <a href="/technical-stack.html">Technical Stack</a>
           <a href="/regulatory-alignment.html">Regulatory Alignment</a>
+          <a href="/about.html">About</a>
         </div>
       </div>
       <div class="nav-dropdown">
-        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Implement <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
+        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Evaluate <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
+        <div class="nav-dropdown-menu">
+          <a href="/simulator.html">Simulator</a>
+          <a href="/shadow-evaluation-guide.html">Shadow Evaluation</a>
+          <a href="/evidence-pack.html">Evidence Pack</a>
+          <a href="/for-payers.html">For Payers</a>
+        </div>
+      </div>
+      <div class="nav-dropdown">
+        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Build <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
         <div class="nav-dropdown-menu">
           <a href="/developers.html">Developers</a>
           <a href="/interoperability.html">Interoperability</a>
-          <a href="/evidence-pack.html">Evidence Pack</a>
-          <a href="/shadow-evaluation-guide.html">Shadow Evaluation</a>
           <a href="/registry.html">Implementation Registry</a>
           <a href="/icon-system.html">Icon System</a>
         </div>
       </div>
       <div class="nav-dropdown">
-        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Pilot <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
+        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Community <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
         <div class="nav-dropdown-menu">
-          <a href="/for-payers.html">For Payers</a>          <a href="/roadmap.html">Roadmap</a>
           <a href="/news.html">News</a>
+          <a href="/roadmap.html">Roadmap</a>
+          <a href="/research-portfolio.html">Portfolio</a>
+          <a href="https://github.com/NHID-Clinical/NHID-Clinical">GitHub &#x2197;</a>
         </div>
       </div>
-      <a href="/simulator.html">Simulator</a>
       <a href="https://ai-governance-map.vercel.app/" target="_blank" rel="noopener noreferrer">AI Map &#x2197;</a>
     </div>
     <div class="nav-actions">
@@ -93,23 +100,26 @@
 
 <nav class="mobile-nav" id="mobile-nav" aria-label="Mobile navigation">
   <a href="/">Home</a>
-  <a href="/about.html">About</a>
-  <a href="/research-portfolio.html">Portfolio</a>
-  <a href="/simulator.html">Simulator</a>
-  <strong class="mobile-nav-group">Specification</strong>
+  <strong class="mobile-nav-group">Learn</strong>
   <a href="/specification.html">Specification</a>
   <a href="/technical-stack.html">Technical Stack</a>
   <a href="/regulatory-alignment.html">Regulatory Alignment</a>
-  <strong class="mobile-nav-group">Implement</strong>
+  <a href="/about.html">About</a>
+  <strong class="mobile-nav-group">Evaluate</strong>
+  <a href="/simulator.html">Simulator</a>
+  <a href="/shadow-evaluation-guide.html">Shadow Evaluation</a>
+  <a href="/evidence-pack.html">Evidence Pack</a>
+  <a href="/for-payers.html">For Payers</a>
+  <strong class="mobile-nav-group">Build</strong>
   <a href="/developers.html">Developers</a>
   <a href="/interoperability.html">Interoperability</a>
-  <a href="/evidence-pack.html">Evidence Pack</a>
-  <a href="/shadow-evaluation-guide.html">Shadow Evaluation</a>
   <a href="/registry.html">Implementation Registry</a>
   <a href="/icon-system.html">Icon System</a>
-  <strong class="mobile-nav-group">Pilot</strong>
-  <a href="/for-payers.html">For Payers</a>  <a href="/roadmap.html">Roadmap</a>
+  <strong class="mobile-nav-group">Community</strong>
   <a href="/news.html">News</a>
+  <a href="/roadmap.html">Roadmap</a>
+  <a href="/research-portfolio.html">Portfolio</a>
+  <a href="https://github.com/NHID-Clinical/NHID-Clinical" target="_blank" rel="noopener noreferrer">GitHub &#x2197;</a>
   <a href="https://ai-governance-map.vercel.app/" target="_blank" rel="noopener noreferrer">AI Map &#x2197;</a>
   <div class="mobile-nav-footer">
     <button class="theme-toggle mobile-theme-toggle" type="button" aria-label="Toggle dark mode">
@@ -119,6 +129,7 @@
     </button>
   </div>
 </nav>
+
 <div class="nav-backdrop" id="nav-backdrop"></div>
 
 <main>
@@ -326,6 +337,18 @@
 
 </main>
 
+<section class="page-cta">
+  <div class="container">
+    <h2>Where to go next</h2>
+    <p>Four ways into NHID-Clinical, whatever you came to do.</p>
+    <div class="page-cta-grid">
+      <a class="page-cta-card" href="/specification.html"><b>Read the Specification <span class="arr">&rarr;</span></b><span>The v1.3 controls, in full.</span></a>
+      <a class="page-cta-card" href="/simulator.html"><b>Try the Simulator <span class="arr">&rarr;</span></b><span>Run the controls on call scenarios.</span></a>
+      <a class="page-cta-card" href="/evidence-pack.html"><b>Review the Evidence Pack <span class="arr">&rarr;</span></b><span>Guarantees, a failure trace, the audit model.</span></a>
+      <a class="page-cta-card" href="https://github.com/NHID-Clinical/NHID-Clinical/discussions" target="_blank" rel="noopener noreferrer"><b>Join the Community <span class="arr">&#x2197;</span></b><span>Questions and feedback on GitHub.</span></a>
+    </div>
+  </div>
+</section>
 <footer id="contact" class="site-footer">
   <div class="container footer-inner">
     <p>© 2026 Brianna Baynard | NIST-2025-0035-0026 | CC BY 4.0</p>

--- a/roadmap.html
+++ b/roadmap.html
@@ -32,35 +32,42 @@
     </a>
     <div class="nav-links">
       <a href="/">Home</a>
-      <a href="/about.html">About</a>
-      <a href="/research-portfolio.html">Portfolio</a>
       <div class="nav-dropdown">
-        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Specification <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
+        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Learn <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
         <div class="nav-dropdown-menu">
           <a href="/specification.html">Specification</a>
           <a href="/technical-stack.html">Technical Stack</a>
           <a href="/regulatory-alignment.html">Regulatory Alignment</a>
+          <a href="/about.html">About</a>
         </div>
       </div>
       <div class="nav-dropdown">
-        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Implement <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
+        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Evaluate <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
+        <div class="nav-dropdown-menu">
+          <a href="/simulator.html">Simulator</a>
+          <a href="/shadow-evaluation-guide.html">Shadow Evaluation</a>
+          <a href="/evidence-pack.html">Evidence Pack</a>
+          <a href="/for-payers.html">For Payers</a>
+        </div>
+      </div>
+      <div class="nav-dropdown">
+        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Build <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
         <div class="nav-dropdown-menu">
           <a href="/developers.html">Developers</a>
           <a href="/interoperability.html">Interoperability</a>
-          <a href="/evidence-pack.html">Evidence Pack</a>
-          <a href="/shadow-evaluation-guide.html">Shadow Evaluation</a>
           <a href="/registry.html">Implementation Registry</a>
           <a href="/icon-system.html">Icon System</a>
         </div>
       </div>
       <div class="nav-dropdown">
-        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Pilot <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
+        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Community <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
         <div class="nav-dropdown-menu">
-          <a href="/for-payers.html">For Payers</a>          <a href="/roadmap.html">Roadmap</a>
           <a href="/news.html">News</a>
+          <a href="/roadmap.html">Roadmap</a>
+          <a href="/research-portfolio.html">Portfolio</a>
+          <a href="https://github.com/NHID-Clinical/NHID-Clinical">GitHub &#x2197;</a>
         </div>
       </div>
-      <a href="/simulator.html">Simulator</a>
       <a href="https://ai-governance-map.vercel.app/" target="_blank" rel="noopener noreferrer">AI Map &#x2197;</a>
     </div>
     <div class="nav-actions">
@@ -93,23 +100,26 @@
 
 <nav class="mobile-nav" id="mobile-nav" aria-label="Mobile navigation">
   <a href="/">Home</a>
-  <a href="/about.html">About</a>
-  <a href="/research-portfolio.html">Portfolio</a>
-  <a href="/simulator.html">Simulator</a>
-  <strong class="mobile-nav-group">Specification</strong>
+  <strong class="mobile-nav-group">Learn</strong>
   <a href="/specification.html">Specification</a>
   <a href="/technical-stack.html">Technical Stack</a>
   <a href="/regulatory-alignment.html">Regulatory Alignment</a>
-  <strong class="mobile-nav-group">Implement</strong>
+  <a href="/about.html">About</a>
+  <strong class="mobile-nav-group">Evaluate</strong>
+  <a href="/simulator.html">Simulator</a>
+  <a href="/shadow-evaluation-guide.html">Shadow Evaluation</a>
+  <a href="/evidence-pack.html">Evidence Pack</a>
+  <a href="/for-payers.html">For Payers</a>
+  <strong class="mobile-nav-group">Build</strong>
   <a href="/developers.html">Developers</a>
   <a href="/interoperability.html">Interoperability</a>
-  <a href="/evidence-pack.html">Evidence Pack</a>
-  <a href="/shadow-evaluation-guide.html">Shadow Evaluation</a>
   <a href="/registry.html">Implementation Registry</a>
   <a href="/icon-system.html">Icon System</a>
-  <strong class="mobile-nav-group">Pilot</strong>
-  <a href="/for-payers.html">For Payers</a>  <a href="/roadmap.html">Roadmap</a>
+  <strong class="mobile-nav-group">Community</strong>
   <a href="/news.html">News</a>
+  <a href="/roadmap.html">Roadmap</a>
+  <a href="/research-portfolio.html">Portfolio</a>
+  <a href="https://github.com/NHID-Clinical/NHID-Clinical" target="_blank" rel="noopener noreferrer">GitHub &#x2197;</a>
   <a href="https://ai-governance-map.vercel.app/" target="_blank" rel="noopener noreferrer">AI Map &#x2197;</a>
   <div class="mobile-nav-footer">
     <button class="theme-toggle mobile-theme-toggle" type="button" aria-label="Toggle dark mode">
@@ -119,6 +129,7 @@
     </button>
   </div>
 </nav>
+
 <div class="nav-backdrop" id="nav-backdrop"></div>
 
 <main>
@@ -261,6 +272,18 @@ python examples/issue_and_verify.py          # end-to-end credential walkthrough
       <h3>Where this is heading</h3>
       <p>Milestones are commitments to the open proposal, not product promises. Pilot results directly shape v2.</p>
       <a href="/for-payers.html">Become a shadow-evaluation partner →</a>&nbsp;&nbsp;
+    </div>
+  </div>
+</section>
+<section class="page-cta">
+  <div class="container">
+    <h2>Where to go next</h2>
+    <p>Four ways into NHID-Clinical, whatever you came to do.</p>
+    <div class="page-cta-grid">
+      <a class="page-cta-card" href="/specification.html"><b>Read the Specification <span class="arr">&rarr;</span></b><span>The v1.3 controls, in full.</span></a>
+      <a class="page-cta-card" href="/simulator.html"><b>Try the Simulator <span class="arr">&rarr;</span></b><span>Run the controls on call scenarios.</span></a>
+      <a class="page-cta-card" href="/evidence-pack.html"><b>Review the Evidence Pack <span class="arr">&rarr;</span></b><span>Guarantees, a failure trace, the audit model.</span></a>
+      <a class="page-cta-card" href="https://github.com/NHID-Clinical/NHID-Clinical/discussions" target="_blank" rel="noopener noreferrer"><b>Join the Community <span class="arr">&#x2197;</span></b><span>Questions and feedback on GitHub.</span></a>
     </div>
   </div>
 </section>

--- a/script-examples.html
+++ b/script-examples.html
@@ -32,35 +32,42 @@
     </a>
     <div class="nav-links">
       <a href="/">Home</a>
-      <a href="/about.html">About</a>
-      <a href="/research-portfolio.html">Portfolio</a>
       <div class="nav-dropdown">
-        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Specification <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
+        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Learn <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
         <div class="nav-dropdown-menu">
           <a href="/specification.html">Specification</a>
           <a href="/technical-stack.html">Technical Stack</a>
           <a href="/regulatory-alignment.html">Regulatory Alignment</a>
+          <a href="/about.html">About</a>
         </div>
       </div>
       <div class="nav-dropdown">
-        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Implement <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
+        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Evaluate <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
+        <div class="nav-dropdown-menu">
+          <a href="/simulator.html">Simulator</a>
+          <a href="/shadow-evaluation-guide.html">Shadow Evaluation</a>
+          <a href="/evidence-pack.html">Evidence Pack</a>
+          <a href="/for-payers.html">For Payers</a>
+        </div>
+      </div>
+      <div class="nav-dropdown">
+        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Build <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
         <div class="nav-dropdown-menu">
           <a href="/developers.html">Developers</a>
           <a href="/interoperability.html">Interoperability</a>
-          <a href="/evidence-pack.html">Evidence Pack</a>
-          <a href="/shadow-evaluation-guide.html">Shadow Evaluation</a>
           <a href="/registry.html">Implementation Registry</a>
           <a href="/icon-system.html">Icon System</a>
         </div>
       </div>
       <div class="nav-dropdown">
-        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Pilot <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
+        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Community <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
         <div class="nav-dropdown-menu">
-          <a href="/for-payers.html">For Payers</a>          <a href="/roadmap.html">Roadmap</a>
           <a href="/news.html">News</a>
+          <a href="/roadmap.html">Roadmap</a>
+          <a href="/research-portfolio.html">Portfolio</a>
+          <a href="https://github.com/NHID-Clinical/NHID-Clinical">GitHub &#x2197;</a>
         </div>
       </div>
-      <a href="/simulator.html">Simulator</a>
       <a href="https://ai-governance-map.vercel.app/" target="_blank" rel="noopener noreferrer">AI Map &#x2197;</a>
     </div>
     <div class="nav-actions">
@@ -93,23 +100,26 @@
 
 <nav class="mobile-nav" id="mobile-nav" aria-label="Mobile navigation">
   <a href="/">Home</a>
-  <a href="/about.html">About</a>
-  <a href="/research-portfolio.html">Portfolio</a>
-  <a href="/simulator.html">Simulator</a>
-  <strong class="mobile-nav-group">Specification</strong>
+  <strong class="mobile-nav-group">Learn</strong>
   <a href="/specification.html">Specification</a>
   <a href="/technical-stack.html">Technical Stack</a>
   <a href="/regulatory-alignment.html">Regulatory Alignment</a>
-  <strong class="mobile-nav-group">Implement</strong>
+  <a href="/about.html">About</a>
+  <strong class="mobile-nav-group">Evaluate</strong>
+  <a href="/simulator.html">Simulator</a>
+  <a href="/shadow-evaluation-guide.html">Shadow Evaluation</a>
+  <a href="/evidence-pack.html">Evidence Pack</a>
+  <a href="/for-payers.html">For Payers</a>
+  <strong class="mobile-nav-group">Build</strong>
   <a href="/developers.html">Developers</a>
   <a href="/interoperability.html">Interoperability</a>
-  <a href="/evidence-pack.html">Evidence Pack</a>
-  <a href="/shadow-evaluation-guide.html">Shadow Evaluation</a>
   <a href="/registry.html">Implementation Registry</a>
   <a href="/icon-system.html">Icon System</a>
-  <strong class="mobile-nav-group">Pilot</strong>
-  <a href="/for-payers.html">For Payers</a>  <a href="/roadmap.html">Roadmap</a>
+  <strong class="mobile-nav-group">Community</strong>
   <a href="/news.html">News</a>
+  <a href="/roadmap.html">Roadmap</a>
+  <a href="/research-portfolio.html">Portfolio</a>
+  <a href="https://github.com/NHID-Clinical/NHID-Clinical" target="_blank" rel="noopener noreferrer">GitHub &#x2197;</a>
   <a href="https://ai-governance-map.vercel.app/" target="_blank" rel="noopener noreferrer">AI Map &#x2197;</a>
   <div class="mobile-nav-footer">
     <button class="theme-toggle mobile-theme-toggle" type="button" aria-label="Toggle dark mode">
@@ -119,6 +129,7 @@
     </button>
   </div>
 </nav>
+
 <div class="nav-backdrop" id="nav-backdrop"></div>
 
 <main>
@@ -256,6 +267,18 @@
   </section>
 </main>
 
+<section class="page-cta">
+  <div class="container">
+    <h2>Where to go next</h2>
+    <p>Four ways into NHID-Clinical, whatever you came to do.</p>
+    <div class="page-cta-grid">
+      <a class="page-cta-card" href="/specification.html"><b>Read the Specification <span class="arr">&rarr;</span></b><span>The v1.3 controls, in full.</span></a>
+      <a class="page-cta-card" href="/simulator.html"><b>Try the Simulator <span class="arr">&rarr;</span></b><span>Run the controls on call scenarios.</span></a>
+      <a class="page-cta-card" href="/evidence-pack.html"><b>Review the Evidence Pack <span class="arr">&rarr;</span></b><span>Guarantees, a failure trace, the audit model.</span></a>
+      <a class="page-cta-card" href="https://github.com/NHID-Clinical/NHID-Clinical/discussions" target="_blank" rel="noopener noreferrer"><b>Join the Community <span class="arr">&#x2197;</span></b><span>Questions and feedback on GitHub.</span></a>
+    </div>
+  </div>
+</section>
 <footer id="contact" class="site-footer">
   <div class="container footer-inner">
     <p>© 2026 Brianna Baynard | NIST-2025-0035-0026 | CC BY 4.0</p>

--- a/shadow-evaluation-guide.html
+++ b/shadow-evaluation-guide.html
@@ -43,35 +43,42 @@
     </a>
     <div class="nav-links">
       <a href="/">Home</a>
-      <a href="/about.html">About</a>
-      <a href="/research-portfolio.html">Portfolio</a>
       <div class="nav-dropdown">
-        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Specification <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
+        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Learn <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
         <div class="nav-dropdown-menu">
           <a href="/specification.html">Specification</a>
           <a href="/technical-stack.html">Technical Stack</a>
           <a href="/regulatory-alignment.html">Regulatory Alignment</a>
+          <a href="/about.html">About</a>
         </div>
       </div>
       <div class="nav-dropdown">
-        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Implement <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
+        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Evaluate <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
+        <div class="nav-dropdown-menu">
+          <a href="/simulator.html">Simulator</a>
+          <a href="/shadow-evaluation-guide.html">Shadow Evaluation</a>
+          <a href="/evidence-pack.html">Evidence Pack</a>
+          <a href="/for-payers.html">For Payers</a>
+        </div>
+      </div>
+      <div class="nav-dropdown">
+        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Build <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
         <div class="nav-dropdown-menu">
           <a href="/developers.html">Developers</a>
           <a href="/interoperability.html">Interoperability</a>
-          <a href="/evidence-pack.html">Evidence Pack</a>
-          <a href="/shadow-evaluation-guide.html">Shadow Evaluation</a>
           <a href="/registry.html">Implementation Registry</a>
           <a href="/icon-system.html">Icon System</a>
         </div>
       </div>
       <div class="nav-dropdown">
-        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Pilot <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
+        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Community <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
         <div class="nav-dropdown-menu">
-          <a href="/for-payers.html">For Payers</a>          <a href="/roadmap.html">Roadmap</a>
           <a href="/news.html">News</a>
+          <a href="/roadmap.html">Roadmap</a>
+          <a href="/research-portfolio.html">Portfolio</a>
+          <a href="https://github.com/NHID-Clinical/NHID-Clinical">GitHub &#x2197;</a>
         </div>
       </div>
-      <a href="/simulator.html">Simulator</a>
       <a href="https://ai-governance-map.vercel.app/" target="_blank" rel="noopener noreferrer">AI Map &#x2197;</a>
     </div>
     <div class="nav-actions">
@@ -104,23 +111,26 @@
 
 <nav class="mobile-nav" id="mobile-nav" aria-label="Mobile navigation">
   <a href="/">Home</a>
-  <a href="/about.html">About</a>
-  <a href="/research-portfolio.html">Portfolio</a>
-  <a href="/simulator.html">Simulator</a>
-  <strong class="mobile-nav-group">Specification</strong>
+  <strong class="mobile-nav-group">Learn</strong>
   <a href="/specification.html">Specification</a>
   <a href="/technical-stack.html">Technical Stack</a>
   <a href="/regulatory-alignment.html">Regulatory Alignment</a>
-  <strong class="mobile-nav-group">Implement</strong>
+  <a href="/about.html">About</a>
+  <strong class="mobile-nav-group">Evaluate</strong>
+  <a href="/simulator.html">Simulator</a>
+  <a href="/shadow-evaluation-guide.html">Shadow Evaluation</a>
+  <a href="/evidence-pack.html">Evidence Pack</a>
+  <a href="/for-payers.html">For Payers</a>
+  <strong class="mobile-nav-group">Build</strong>
   <a href="/developers.html">Developers</a>
   <a href="/interoperability.html">Interoperability</a>
-  <a href="/evidence-pack.html">Evidence Pack</a>
-  <a href="/shadow-evaluation-guide.html">Shadow Evaluation</a>
   <a href="/registry.html">Implementation Registry</a>
   <a href="/icon-system.html">Icon System</a>
-  <strong class="mobile-nav-group">Pilot</strong>
-  <a href="/for-payers.html">For Payers</a>  <a href="/roadmap.html">Roadmap</a>
+  <strong class="mobile-nav-group">Community</strong>
   <a href="/news.html">News</a>
+  <a href="/roadmap.html">Roadmap</a>
+  <a href="/research-portfolio.html">Portfolio</a>
+  <a href="https://github.com/NHID-Clinical/NHID-Clinical" target="_blank" rel="noopener noreferrer">GitHub &#x2197;</a>
   <a href="https://ai-governance-map.vercel.app/" target="_blank" rel="noopener noreferrer">AI Map &#x2197;</a>
   <div class="mobile-nav-footer">
     <button class="theme-toggle mobile-theme-toggle" type="button" aria-label="Toggle dark mode">
@@ -130,6 +140,7 @@
     </button>
   </div>
 </nav>
+
 <div class="nav-backdrop" id="nav-backdrop"></div>
 
 <main>
@@ -269,6 +280,18 @@
   </section>
 </main>
 
+<section class="page-cta">
+  <div class="container">
+    <h2>Where to go next</h2>
+    <p>Four ways into NHID-Clinical, whatever you came to do.</p>
+    <div class="page-cta-grid">
+      <a class="page-cta-card" href="/specification.html"><b>Read the Specification <span class="arr">&rarr;</span></b><span>The v1.3 controls, in full.</span></a>
+      <a class="page-cta-card" href="/simulator.html"><b>Try the Simulator <span class="arr">&rarr;</span></b><span>Run the controls on call scenarios.</span></a>
+      <a class="page-cta-card" href="/evidence-pack.html"><b>Review the Evidence Pack <span class="arr">&rarr;</span></b><span>Guarantees, a failure trace, the audit model.</span></a>
+      <a class="page-cta-card" href="https://github.com/NHID-Clinical/NHID-Clinical/discussions" target="_blank" rel="noopener noreferrer"><b>Join the Community <span class="arr">&#x2197;</span></b><span>Questions and feedback on GitHub.</span></a>
+    </div>
+  </div>
+</section>
 <footer id="contact" class="site-footer">
   <div class="container footer-inner">
     <p>&copy; 2026 Brianna Baynard | NIST-2025-0035-0026 | CC BY 4.0</p>

--- a/sms-opt-in.html
+++ b/sms-opt-in.html
@@ -32,35 +32,42 @@
     </a>
     <div class="nav-links">
       <a href="/">Home</a>
-      <a href="/about.html">About</a>
-      <a href="/research-portfolio.html">Portfolio</a>
       <div class="nav-dropdown">
-        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Specification <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
+        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Learn <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
         <div class="nav-dropdown-menu">
           <a href="/specification.html">Specification</a>
           <a href="/technical-stack.html">Technical Stack</a>
           <a href="/regulatory-alignment.html">Regulatory Alignment</a>
+          <a href="/about.html">About</a>
         </div>
       </div>
       <div class="nav-dropdown">
-        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Implement <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
+        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Evaluate <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
+        <div class="nav-dropdown-menu">
+          <a href="/simulator.html">Simulator</a>
+          <a href="/shadow-evaluation-guide.html">Shadow Evaluation</a>
+          <a href="/evidence-pack.html">Evidence Pack</a>
+          <a href="/for-payers.html">For Payers</a>
+        </div>
+      </div>
+      <div class="nav-dropdown">
+        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Build <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
         <div class="nav-dropdown-menu">
           <a href="/developers.html">Developers</a>
           <a href="/interoperability.html">Interoperability</a>
-          <a href="/evidence-pack.html">Evidence Pack</a>
-          <a href="/shadow-evaluation-guide.html">Shadow Evaluation</a>
           <a href="/registry.html">Implementation Registry</a>
           <a href="/icon-system.html">Icon System</a>
         </div>
       </div>
       <div class="nav-dropdown">
-        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Pilot <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
+        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Community <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
         <div class="nav-dropdown-menu">
-          <a href="/for-payers.html">For Payers</a>          <a href="/roadmap.html">Roadmap</a>
           <a href="/news.html">News</a>
+          <a href="/roadmap.html">Roadmap</a>
+          <a href="/research-portfolio.html">Portfolio</a>
+          <a href="https://github.com/NHID-Clinical/NHID-Clinical">GitHub &#x2197;</a>
         </div>
       </div>
-      <a href="/simulator.html">Simulator</a>
       <a href="https://ai-governance-map.vercel.app/" target="_blank" rel="noopener noreferrer">AI Map &#x2197;</a>
     </div>
     <div class="nav-actions">
@@ -93,23 +100,26 @@
 
 <nav class="mobile-nav" id="mobile-nav" aria-label="Mobile navigation">
   <a href="/">Home</a>
-  <a href="/about.html">About</a>
-  <a href="/research-portfolio.html">Portfolio</a>
-  <a href="/simulator.html">Simulator</a>
-  <strong class="mobile-nav-group">Specification</strong>
+  <strong class="mobile-nav-group">Learn</strong>
   <a href="/specification.html">Specification</a>
   <a href="/technical-stack.html">Technical Stack</a>
   <a href="/regulatory-alignment.html">Regulatory Alignment</a>
-  <strong class="mobile-nav-group">Implement</strong>
+  <a href="/about.html">About</a>
+  <strong class="mobile-nav-group">Evaluate</strong>
+  <a href="/simulator.html">Simulator</a>
+  <a href="/shadow-evaluation-guide.html">Shadow Evaluation</a>
+  <a href="/evidence-pack.html">Evidence Pack</a>
+  <a href="/for-payers.html">For Payers</a>
+  <strong class="mobile-nav-group">Build</strong>
   <a href="/developers.html">Developers</a>
   <a href="/interoperability.html">Interoperability</a>
-  <a href="/evidence-pack.html">Evidence Pack</a>
-  <a href="/shadow-evaluation-guide.html">Shadow Evaluation</a>
   <a href="/registry.html">Implementation Registry</a>
   <a href="/icon-system.html">Icon System</a>
-  <strong class="mobile-nav-group">Pilot</strong>
-  <a href="/for-payers.html">For Payers</a>  <a href="/roadmap.html">Roadmap</a>
+  <strong class="mobile-nav-group">Community</strong>
   <a href="/news.html">News</a>
+  <a href="/roadmap.html">Roadmap</a>
+  <a href="/research-portfolio.html">Portfolio</a>
+  <a href="https://github.com/NHID-Clinical/NHID-Clinical" target="_blank" rel="noopener noreferrer">GitHub &#x2197;</a>
   <a href="https://ai-governance-map.vercel.app/" target="_blank" rel="noopener noreferrer">AI Map &#x2197;</a>
   <div class="mobile-nav-footer">
     <button class="theme-toggle mobile-theme-toggle" type="button" aria-label="Toggle dark mode">
@@ -119,6 +129,7 @@
     </button>
   </div>
 </nav>
+
 <div class="nav-backdrop" id="nav-backdrop"></div>
 
 <main>

--- a/specification.html
+++ b/specification.html
@@ -35,35 +35,42 @@
     </a>
     <div class="nav-links">
       <a href="/">Home</a>
-      <a href="/about.html">About</a>
-      <a href="/research-portfolio.html">Portfolio</a>
       <div class="nav-dropdown">
-        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Specification <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
+        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Learn <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
         <div class="nav-dropdown-menu">
           <a href="/specification.html">Specification</a>
           <a href="/technical-stack.html">Technical Stack</a>
           <a href="/regulatory-alignment.html">Regulatory Alignment</a>
+          <a href="/about.html">About</a>
         </div>
       </div>
       <div class="nav-dropdown">
-        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Implement <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
+        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Evaluate <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
+        <div class="nav-dropdown-menu">
+          <a href="/simulator.html">Simulator</a>
+          <a href="/shadow-evaluation-guide.html">Shadow Evaluation</a>
+          <a href="/evidence-pack.html">Evidence Pack</a>
+          <a href="/for-payers.html">For Payers</a>
+        </div>
+      </div>
+      <div class="nav-dropdown">
+        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Build <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
         <div class="nav-dropdown-menu">
           <a href="/developers.html">Developers</a>
           <a href="/interoperability.html">Interoperability</a>
-          <a href="/evidence-pack.html">Evidence Pack</a>
-          <a href="/shadow-evaluation-guide.html">Shadow Evaluation</a>
           <a href="/registry.html">Implementation Registry</a>
           <a href="/icon-system.html">Icon System</a>
         </div>
       </div>
       <div class="nav-dropdown">
-        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Pilot <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
+        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Community <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
         <div class="nav-dropdown-menu">
-          <a href="/for-payers.html">For Payers</a>          <a href="/roadmap.html">Roadmap</a>
           <a href="/news.html">News</a>
+          <a href="/roadmap.html">Roadmap</a>
+          <a href="/research-portfolio.html">Portfolio</a>
+          <a href="https://github.com/NHID-Clinical/NHID-Clinical">GitHub &#x2197;</a>
         </div>
       </div>
-      <a href="/simulator.html">Simulator</a>
       <a href="https://ai-governance-map.vercel.app/" target="_blank" rel="noopener noreferrer">AI Map &#x2197;</a>
     </div>
     <div class="nav-actions">
@@ -96,23 +103,26 @@
 
 <nav class="mobile-nav" id="mobile-nav" aria-label="Mobile navigation">
   <a href="/">Home</a>
-  <a href="/about.html">About</a>
-  <a href="/research-portfolio.html">Portfolio</a>
-  <a href="/simulator.html">Simulator</a>
-  <strong class="mobile-nav-group">Specification</strong>
+  <strong class="mobile-nav-group">Learn</strong>
   <a href="/specification.html">Specification</a>
   <a href="/technical-stack.html">Technical Stack</a>
   <a href="/regulatory-alignment.html">Regulatory Alignment</a>
-  <strong class="mobile-nav-group">Implement</strong>
+  <a href="/about.html">About</a>
+  <strong class="mobile-nav-group">Evaluate</strong>
+  <a href="/simulator.html">Simulator</a>
+  <a href="/shadow-evaluation-guide.html">Shadow Evaluation</a>
+  <a href="/evidence-pack.html">Evidence Pack</a>
+  <a href="/for-payers.html">For Payers</a>
+  <strong class="mobile-nav-group">Build</strong>
   <a href="/developers.html">Developers</a>
   <a href="/interoperability.html">Interoperability</a>
-  <a href="/evidence-pack.html">Evidence Pack</a>
-  <a href="/shadow-evaluation-guide.html">Shadow Evaluation</a>
   <a href="/registry.html">Implementation Registry</a>
   <a href="/icon-system.html">Icon System</a>
-  <strong class="mobile-nav-group">Pilot</strong>
-  <a href="/for-payers.html">For Payers</a>  <a href="/roadmap.html">Roadmap</a>
+  <strong class="mobile-nav-group">Community</strong>
   <a href="/news.html">News</a>
+  <a href="/roadmap.html">Roadmap</a>
+  <a href="/research-portfolio.html">Portfolio</a>
+  <a href="https://github.com/NHID-Clinical/NHID-Clinical" target="_blank" rel="noopener noreferrer">GitHub &#x2197;</a>
   <a href="https://ai-governance-map.vercel.app/" target="_blank" rel="noopener noreferrer">AI Map &#x2197;</a>
   <div class="mobile-nav-footer">
     <button class="theme-toggle mobile-theme-toggle" type="button" aria-label="Toggle dark mode">
@@ -122,6 +132,7 @@
     </button>
   </div>
 </nav>
+
 <div class="nav-backdrop" id="nav-backdrop"></div>
 
 <main>
@@ -299,6 +310,18 @@ sequenceDiagram
       <h3>See this specification in multi-framework context</h3>
       <p>Every v1.3 control maps into the broader governance landscape — CCM, NIST AI RMF, ISO, and the EU AI Act.</p>
       <a href="https://ai-governance-map.vercel.app/">Explore in the AI Governance Map →</a>&nbsp;&nbsp; <a href="/simulator.html">Try the controls in the Simulator →</a>&nbsp;&nbsp;
+    </div>
+  </div>
+</section>
+<section class="page-cta">
+  <div class="container">
+    <h2>Where to go next</h2>
+    <p>Four ways into NHID-Clinical, whatever you came to do.</p>
+    <div class="page-cta-grid">
+      <a class="page-cta-card" href="/specification.html"><b>Read the Specification <span class="arr">&rarr;</span></b><span>The v1.3 controls, in full.</span></a>
+      <a class="page-cta-card" href="/simulator.html"><b>Try the Simulator <span class="arr">&rarr;</span></b><span>Run the controls on call scenarios.</span></a>
+      <a class="page-cta-card" href="/evidence-pack.html"><b>Review the Evidence Pack <span class="arr">&rarr;</span></b><span>Guarantees, a failure trace, the audit model.</span></a>
+      <a class="page-cta-card" href="https://github.com/NHID-Clinical/NHID-Clinical/discussions" target="_blank" rel="noopener noreferrer"><b>Join the Community <span class="arr">&#x2197;</span></b><span>Questions and feedback on GitHub.</span></a>
     </div>
   </div>
 </section>

--- a/technical-stack.html
+++ b/technical-stack.html
@@ -32,35 +32,42 @@
     </a>
     <div class="nav-links">
       <a href="/">Home</a>
-      <a href="/about.html">About</a>
-      <a href="/research-portfolio.html">Portfolio</a>
       <div class="nav-dropdown">
-        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Specification <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
+        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Learn <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
         <div class="nav-dropdown-menu">
           <a href="/specification.html">Specification</a>
           <a href="/technical-stack.html">Technical Stack</a>
           <a href="/regulatory-alignment.html">Regulatory Alignment</a>
+          <a href="/about.html">About</a>
         </div>
       </div>
       <div class="nav-dropdown">
-        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Implement <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
+        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Evaluate <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
+        <div class="nav-dropdown-menu">
+          <a href="/simulator.html">Simulator</a>
+          <a href="/shadow-evaluation-guide.html">Shadow Evaluation</a>
+          <a href="/evidence-pack.html">Evidence Pack</a>
+          <a href="/for-payers.html">For Payers</a>
+        </div>
+      </div>
+      <div class="nav-dropdown">
+        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Build <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
         <div class="nav-dropdown-menu">
           <a href="/developers.html">Developers</a>
           <a href="/interoperability.html">Interoperability</a>
-          <a href="/evidence-pack.html">Evidence Pack</a>
-          <a href="/shadow-evaluation-guide.html">Shadow Evaluation</a>
           <a href="/registry.html">Implementation Registry</a>
           <a href="/icon-system.html">Icon System</a>
         </div>
       </div>
       <div class="nav-dropdown">
-        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Pilot <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
+        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Community <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
         <div class="nav-dropdown-menu">
-          <a href="/for-payers.html">For Payers</a>          <a href="/roadmap.html">Roadmap</a>
           <a href="/news.html">News</a>
+          <a href="/roadmap.html">Roadmap</a>
+          <a href="/research-portfolio.html">Portfolio</a>
+          <a href="https://github.com/NHID-Clinical/NHID-Clinical">GitHub &#x2197;</a>
         </div>
       </div>
-      <a href="/simulator.html">Simulator</a>
       <a href="https://ai-governance-map.vercel.app/" target="_blank" rel="noopener noreferrer">AI Map &#x2197;</a>
     </div>
     <div class="nav-actions">
@@ -93,23 +100,26 @@
 
 <nav class="mobile-nav" id="mobile-nav" aria-label="Mobile navigation">
   <a href="/">Home</a>
-  <a href="/about.html">About</a>
-  <a href="/research-portfolio.html">Portfolio</a>
-  <a href="/simulator.html">Simulator</a>
-  <strong class="mobile-nav-group">Specification</strong>
+  <strong class="mobile-nav-group">Learn</strong>
   <a href="/specification.html">Specification</a>
   <a href="/technical-stack.html">Technical Stack</a>
   <a href="/regulatory-alignment.html">Regulatory Alignment</a>
-  <strong class="mobile-nav-group">Implement</strong>
+  <a href="/about.html">About</a>
+  <strong class="mobile-nav-group">Evaluate</strong>
+  <a href="/simulator.html">Simulator</a>
+  <a href="/shadow-evaluation-guide.html">Shadow Evaluation</a>
+  <a href="/evidence-pack.html">Evidence Pack</a>
+  <a href="/for-payers.html">For Payers</a>
+  <strong class="mobile-nav-group">Build</strong>
   <a href="/developers.html">Developers</a>
   <a href="/interoperability.html">Interoperability</a>
-  <a href="/evidence-pack.html">Evidence Pack</a>
-  <a href="/shadow-evaluation-guide.html">Shadow Evaluation</a>
   <a href="/registry.html">Implementation Registry</a>
   <a href="/icon-system.html">Icon System</a>
-  <strong class="mobile-nav-group">Pilot</strong>
-  <a href="/for-payers.html">For Payers</a>  <a href="/roadmap.html">Roadmap</a>
+  <strong class="mobile-nav-group">Community</strong>
   <a href="/news.html">News</a>
+  <a href="/roadmap.html">Roadmap</a>
+  <a href="/research-portfolio.html">Portfolio</a>
+  <a href="https://github.com/NHID-Clinical/NHID-Clinical" target="_blank" rel="noopener noreferrer">GitHub &#x2197;</a>
   <a href="https://ai-governance-map.vercel.app/" target="_blank" rel="noopener noreferrer">AI Map &#x2197;</a>
   <div class="mobile-nav-footer">
     <button class="theme-toggle mobile-theme-toggle" type="button" aria-label="Toggle dark mode">
@@ -119,6 +129,7 @@
     </button>
   </div>
 </nav>
+
 <div class="nav-backdrop" id="nav-backdrop"></div>
 
 <main>
@@ -202,6 +213,18 @@
       <h3>The five-layer trust stack, visualized</h3>
       <p>The homepage now carries an interactive layer-by-layer view of the architecture this page documents.</p>
       <a href="/#trust-stack">View the Trust Stack →</a>&nbsp;&nbsp; <a href="https://ai-governance-map.vercel.app/">Explore in the AI Governance Map →</a>&nbsp;&nbsp;
+    </div>
+  </div>
+</section>
+<section class="page-cta">
+  <div class="container">
+    <h2>Where to go next</h2>
+    <p>Four ways into NHID-Clinical, whatever you came to do.</p>
+    <div class="page-cta-grid">
+      <a class="page-cta-card" href="/specification.html"><b>Read the Specification <span class="arr">&rarr;</span></b><span>The v1.3 controls, in full.</span></a>
+      <a class="page-cta-card" href="/simulator.html"><b>Try the Simulator <span class="arr">&rarr;</span></b><span>Run the controls on call scenarios.</span></a>
+      <a class="page-cta-card" href="/evidence-pack.html"><b>Review the Evidence Pack <span class="arr">&rarr;</span></b><span>Guarantees, a failure trace, the audit model.</span></a>
+      <a class="page-cta-card" href="https://github.com/NHID-Clinical/NHID-Clinical/discussions" target="_blank" rel="noopener noreferrer"><b>Join the Community <span class="arr">&#x2197;</span></b><span>Questions and feedback on GitHub.</span></a>
     </div>
   </div>
 </section>


### PR DESCRIPTION
## Summary
Information-architecture pass across the site, implementing the highest-impact items from your readability review. Content/presentation only — **no spec, engine, claims, numbers, or disclaimer text changed.**

## Changes
- **Navigation → four groups** (your #7): **Learn / Evaluate / Build / Community** replaces the old Specification/Implement/Pilot dropdowns, on **all 24 content pages** (desktop + mobile).
  - Learn: Specification · Technical Stack · Regulatory Alignment · About
  - Evaluate: Simulator · Shadow Evaluation · Evidence Pack · For Payers
  - Build: Developers · Interoperability · Implementation Registry · Icon System
  - Community: News · Roadmap · Portfolio · GitHub
- **Standardized bottom CTA** (your #10): a consistent "Where to go next" block (Specification / Simulator / Evidence Pack / Community) added to the end of **20 content pages**.
- **"Who it's for" audience row** (your #11) on the homepage — Payers, Providers, AI vendors, Regulators, Researchers, with stroke icons (no emoji, per the design principles).
- **Readability + IA CSS layer** (your #3/#5): comfortable line-height, plus reusable components — `status-badge`, `exec-summary` (2-minute summary), audience chips, and the page-CTA cards — ready to roll into pages.

## Not in this PR (follow-ups)
The per-page **~40% text cut** and 2-minute-summary blocks on each major page (your #1/#2/#6) are content-rewrite work I'd do page-by-page next, carefully preserving every claim and disclaimer. This PR lands the structural/site-wide wins first.

## Verification
- Guards green: `validate_ci.py` (330), `check_number_drift.py` (DRIFT), `check_baseline.py` (BASELINE).
- Rendered in Chromium: new nav, the standardized CTA, and the audience row all display cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K6naAZodVs6Cftbq2miy1L

---
_Generated by [Claude Code](https://claude.ai/code/session_01K6naAZodVs6Cftbq2miy1L)_