### PR TITLE
Spec-maturity release: Chapter 10 Enforcement Profile + invariant tests + PolicyAction plan

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing
 1. Fork the repo
 2. Make changes
-3. Run tests: `python -m pytest tests/ -q` (330 expected)
+3. Run tests: `python -m pytest tests/ -q` (343 expected)
 4. Open a PR — big changes: open an Issue first
 Discussions: https://github.com/NHID-Clinical/NHID-Clinical/discussions

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -23,6 +23,7 @@ open, voluntary reference — not a standard, certification, or production infra
 - [ ] Guards pass: `scripts/validate_ci.py`, `scripts/check_baseline.py`, `scripts/check_number_drift.py`
 - [ ] No new claims of certification, accredited-standard, or regulatory status
 - [ ] Control names and disclaimers are unchanged (or intentionally updated with rationale below)
+- [ ] Public claims reviewed against `docs/claim-boundaries.md` and its Maintainer/Reviewer Claims Control (applies to any external-facing artifact: site copy, blog post, abstract, deck, announcement, demo page)
 
 ## Notes
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   unit-invariant:
-    name: "Unit invariant: 330 passed"
+    name: "Unit invariant: 343 passed"
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/nightly-verify.yml
+++ b/.github/workflows/nightly-verify.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Install dependencies
         run: pip install -r requirements.txt
 
-      - name: Test-count invariant (330 expected via validate_ci.py)
+      - name: Test-count invariant (343 expected via validate_ci.py)
         run: python scripts/validate_ci.py
 
       - name: Confusion-matrix baseline guard

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@
 
 <p align="center">
   <a href="https://github.com/NHID-Clinical/NHID-Clinical/actions"><img alt="CI" src="https://github.com/NHID-Clinical/NHID-Clinical/actions/workflows/ci.yml/badge.svg"></a>
-  <img alt="Python Tests" src="https://img.shields.io/badge/python%20tests-330%20passing-brightgreen?style=flat-square">
+  <img alt="Python Tests" src="https://img.shields.io/badge/python%20tests-343%20passing-brightgreen?style=flat-square">
   <img alt="Middleware Tests" src="https://img.shields.io/badge/middleware%20tests-66%20passing-brightgreen?style=flat-square">
   <img alt="Version" src="https://img.shields.io/badge/version-v1.3-0b6ebc?style=flat-square">
   <img alt="License" src="https://img.shields.io/badge/license-CC%20BY%204.0-lightgrey?style=flat-square">
@@ -84,7 +84,7 @@ For a one-page overview aimed at hospital, payer, compliance, and procurement le
 An honest maturity snapshot. NHID-Clinical is a working reference implementation, not a production-scale product.
 
 **Available today**
-- Deterministic policy engine with 330 passing tests
+- Deterministic policy engine with 343 passing tests
 - Live v1.3 conformance API — demo and vendor routes need no key; VAPI and Twilio adapters accept native call payloads
 - Tier 0 [Shadow Pilot Kit](docs/pilot-kit/README.md) — measure impersonation latency on your own call logs in 2–4 weeks
 - Conformance Test Suite and a per-call Call Authorization Score (CAS)
@@ -111,7 +111,7 @@ This is a voluntary framework — **not an accredited standard, certification, o
 | **EIT-01** | Escalation Implementation Test | Clear human handoff path, honored on request |
 
 Plus **ATR-01** (audit trail) — every call must produce a machine-readable trace.  
-18-case CTS suite · same inputs → identical output · **330** Python tests passing (+ 66 TypeScript middleware tests)
+18-case CTS suite · same inputs → identical output · **343** Python tests passing (+ 66 TypeScript middleware tests)
 
 [**Try the Governance Simulator →**](https://nhid-clinical.org/simulator.html)
 
@@ -226,7 +226,7 @@ pip install -r requirements.txt
 python -m pytest tests/ -v
 ```
 
-Expected: **330 passing** in ~1.4s (~18 skip without a running server). Live demos and full docs on [nhid-clinical.org](https://nhid-clinical.org).
+Expected: **343 passing** in ~1.4s (~18 skip without a running server). Live demos and full docs on [nhid-clinical.org](https://nhid-clinical.org).
 
 <details>
 <summary><b>Repository structure</b></summary>
@@ -282,7 +282,7 @@ python examples/issue_and_verify.py
 | `src/` | Packaged Python modules used by the engine and tests (e.g. agent identity). |
 | `adapters/` | Vendor call-payload adapters (VAPI, Twilio). |
 | `middleware/` | TypeScript middleware and its test suite. |
-| `tests/` | The Python conformance and invariant tests (330 passing). |
+| `tests/` | The Python conformance and invariant tests (343 passing). |
 | `scripts/` | CI guards — `validate_ci.py`, `check_baseline.py`, `check_number_drift.py` — and tooling. |
 | `schema/` | Event and audit-trace schemas. |
 | `docs/` | Specification docs, the [Executive Brief](docs/executive-brief.md), the [Tier 0 Shadow Pilot Kit](docs/pilot-kit/README.md), and the knowledge archive. |

--- a/README.md
+++ b/README.md
@@ -65,6 +65,8 @@ NHID-Clinical sits beside the healthcare and identity stack; it replaces none of
 - **IAM platforms** — govern actors *you* provision; NHID-Clinical governs a *counterparty's* agent you never provisioned, arriving with no login step.
 - **AI governance frameworks** (NIST AI RMF, ISO/IEC 42001) — meta-frameworks NHID-Clinical maps to as evidence targets, not competitors.
 
+NHID-Clinical evaluates declared identity, authorization context, and interaction policy; it does **not** replace an underlying identity provider or cryptographic identity infrastructure.
+
 **Healthcare differentiation** — three load-bearing design choices: **NPI-anchored delegation** (the provider's NPI is the delegation trust root), **FHIR-compatible audit evidence**, and a **risk model validated against payer–provider operational workflows**.
 
 The governance gap is well documented; large-scale production evidence is still limited. The strongest next step for most organizations is a focused shadow pilot on their own traffic — the [**Tier 0 Shadow Pilot Kit**](docs/pilot-kit/README.md) makes that a 2–4 week exercise.
@@ -139,7 +141,7 @@ Plus **ATR-01** (audit trail) — every call must produce a machine-readable tra
   <img alt="Contrast between unverified caller path and NHID-Clinical verified pathway" src="assets/images/3d-svg/latency-split.svg" width="760">
 
   <br>
-  <sub><em>Without a standard: disclosure after PHI moves, no audit trail. With v1.3: early disclosure, verification checkpoint, human escalation, sealed audit.</em></sub>
+  <sub><em>Without a baseline: disclosure after PHI moves, no audit trail. With v1.3: early disclosure, verification checkpoint, human escalation, sealed audit.</em></sub>
 </p>
 
 ## Conformance Flow

--- a/about.html
+++ b/about.html
@@ -162,7 +162,7 @@
           <h3 style="font-size:1.1rem">Related Tools</h3>
           <p style="font-size:0.95rem;line-height:1.6">
             NHID-Clinical is also featured in the <a href="https://ai-governance-map.vercel.app/" target="_blank" style="color:var(--blue);font-weight:600">AI Governance Map</a> 
-            — an interactive maturity radar for tracking compliance across major frameworks like NIST RMF, EU AI Act, and ISO 42001.
+            — an interactive maturity radar for tracking alignment across major frameworks like NIST RMF, EU AI Act, and ISO 42001.
           </p>
       </div>
 

--- a/docs/MASTER-KNOWLEDGE-ARCHIVE.md
+++ b/docs/MASTER-KNOWLEDGE-ARCHIVE.md
@@ -950,7 +950,7 @@ NHID-Clinical/
 │   │   ├── vapi_compliant.json
 │   │   ├── twilio_compliant.json
 │   │   └── twilio_noncompliant.json
-│   └── test_*.py                      # 330 passing unit tests
+│   └── test_*.py                      # 343 passing unit tests
 ├── traces/                            # 10 pre-generated failure traces
 ├── agents/
 │   └── beacon_system_prompt.md        # Reference voice agent
@@ -1125,11 +1125,12 @@ All items from the original 7-gap enterprise production readiness plan:
 | + Fabricate Battle-Test Corpus adapter | 303 | `test_fabricate_adapter.py` |
 | + DBC-01 corpus-mined phrase expansion (additive) | 306 | `test_dbc01_heuristics.py` (+3) |
 | + DBC-01 human-review routing + queue store | 327 | `test_dbc01_review_routing.py`, `test_dbc01_review_queue_store.py`, `test_handler_human_review.py` (+21) |
-| + CodeRabbit review fixes (idempotency + handler regression tests) | **330** | `test_dbc01_review_queue_store.py`, `test_handler_human_review.py` (+3) |
+| + CodeRabbit review fixes (idempotency + handler regression tests) | 330 | `test_dbc01_review_queue_store.py`, `test_handler_human_review.py` (+3) |
+| + Enforcement Profile invariants (spec-maturity release; no behavior change) | **343** | `test_enforcement_profile.py` (+13) |
 
-**Current invariant:** `UNIT_EXPECTED = 330` in `scripts/validate_ci.py`
+**Current invariant:** `UNIT_EXPECTED = 343` in `scripts/validate_ci.py`
 
-**Total suite:** 396 passing (330 Python + 66 TypeScript middleware)
+**Total suite:** 409 passing (343 Python + 66 TypeScript middleware)
 
 ### 7.3 Near-Term Roadmap
 
@@ -1200,7 +1201,7 @@ git clone https://github.com/NHID-Clinical/NHID-Clinical.git
 cd NHID-Clinical
 pip install -r requirements.txt
 python -m pytest tests/ -v
-# Expected: 330 passed (18 skipped when no server running = integration tests)
+# Expected: 343 passed (18 skipped when no server running = integration tests)
 ```
 
 ### 8.2 Key Dependencies
@@ -1220,11 +1221,11 @@ PyJWT>=2.8.0
 
 ### 8.3 CI Invariant
 
-The CI pipeline enforces exactly `UNIT_EXPECTED = 330` passing tests with 0 failures:
+The CI pipeline enforces exactly `UNIT_EXPECTED = 343` passing tests with 0 failures:
 
 ```python
 # scripts/validate_ci.py
-UNIT_EXPECTED = 330
+UNIT_EXPECTED = 343
 INTEGRATION_EXPECTED = 18  # acceptable skip count (integration tests)
 ```
 
@@ -1358,7 +1359,7 @@ git push -u origin claude/my-feature-branch
 
 When Claude Code or any LLM is working on this repository:
 
-1. **All existing tests must pass.** The CI invariant (`UNIT_EXPECTED = 330`) must hold after
+1. **All existing tests must pass.** The CI invariant (`UNIT_EXPECTED = 343`) must hold after
    every change. Run `python scripts/validate_ci.py` before committing.
 
 2. **"Impersonation Latency" is the permanent canonical term.** It must never be renamed,
@@ -1424,8 +1425,8 @@ When Claude Code or any LLM is working on this repository:
 When resuming a Claude Code session after context limit:
 
 > "Continue from where you left off. The plan file is at
-> `/root/.claude/plans/did-i-make-an-fluffy-quiche.md`. Current UNIT_EXPECTED is 330.
-> All 330 tests pass. The most recent completed task was [X]. The next task is [Y]."
+> `/root/.claude/plans/did-i-make-an-fluffy-quiche.md`. Current UNIT_EXPECTED is 343.
+> All 343 tests pass. The most recent completed task was [X]. The next task is [Y]."
 
 ---
 
@@ -2321,7 +2322,7 @@ It addresses the disclosure and audit trail aspects of AI voice interactions.
 # From src/nhid_policy_engine_v1.py
 POLICY_ENGINE_VERSION = "1.0.0"
 NHID_SPEC_VERSION = "1.3"
-UNIT_EXPECTED = 330  # scripts/validate_ci.py
+UNIT_EXPECTED = 343  # scripts/validate_ci.py
 
 # Live API
 API_BASE = "https://gfvq4swdtf.execute-api.us-east-1.amazonaws.com/prod"
@@ -2365,7 +2366,7 @@ NPI_PATTERN = r"^\d{10}$"
 | `test_dbc01_review_queue_store.py` | 12 | `dbc01_review_queue` table CRUD (enqueue/list/get/resolve, incl. idempotency) |
 | `test_dbc01_review_routing.py` | 8 | `should_route_to_review()` DBC-01/CAS routing logic |
 | `test_handler_human_review.py` | 4 | Handler-level `human_review` block + queue side effect |
-| **Total** | **330 passed, 18 skipped** | All Python unit tests |
+| **Total** | **343 passed, 18 skipped** | All Python unit tests |
 
 ### 23.4 Pre-Generated Failure Traces
 

--- a/docs/claim-boundaries.md
+++ b/docs/claim-boundaries.md
@@ -58,7 +58,7 @@ question.
 | "A non-human-actor identity and delegated-authorization protocol (reference implementation)." | "A universal identity layer." / "Trust infrastructure." / "A control plane." |
 | "A healthcare-specific delegation scheme aligned with emerging authenticated-delegation approaches, composable with SPIFFE/OAuth-style stacks." | "A profile of authenticated delegation" (implies an adopted base standard) · "We invented delegated authority / agent identity / scope attenuation." |
 | "Mapped to NIST AI RMF and ISO/IEC 42001; designed to support the transparency obligations described in EU AI Act Article 50." | "Compliant with / certified against" any of them. |
-| "A voluntary, open proposal and standards candidate." | "An emerging standard." / "The standard for AI agents in healthcare." |
+| "A voluntary open proposal with standards-oriented artifacts." | "An emerging standard." / "The standard for AI agents in healthcare." / "A standards candidate" (implies a formal standards process has started). |
 | "Reference implementation; revocation is in-memory; key custody and federation are documented but not built." | "Production-ready." / "Enterprise infrastructure." |
 | "Disclosure latency is measured on recorded traffic; the framework does not detect covert agents." | "Detects unauthorized/rogue AI callers." |
 | "Delegation makes compromise scoped and revocable rather than unbounded." | "Prevents impersonation / fraud." |
@@ -85,8 +85,9 @@ this writing; adopt by version from current materials.
 - NHID-Clinical is a **voluntary, open proposal** (CC BY 4.0), submitted as a
   **public comment** to a NIST RFI docket (**NIST-2025-0035-0026**). A public
   comment is **not** a NIST endorsement, adoption, or certification.
-- Current honest label: **standards candidate / input to a potential work
-  item** — not an emerging standard.
+- Current honest label: **a voluntary open proposal with standards-oriented
+  artifacts / input to a potential work item** — not an emerging standard, and
+  not a "standards candidate" in the sense of an opened standards-body process.
 - Gating step to strengthen the standards argument: a **second, independent
   implementation passing the conformance test suite**, plus published
   designs for registry/trust-resolution, revocation and key lifecycle, and
@@ -108,6 +109,59 @@ this writing; adopt by version from current materials.
   parallel art, and disclose the gaps first (in-memory revocation, no
   federation, no second implementation, key lifecycle unspecified). Disclosed
   immaturity is forgiven; immaturity dressed as "infrastructure" is not.
+
+---
+
+## Maintainer / Reviewer Claims Control (v1.x)
+
+This is the **authoritative pre-publish gate** for external claims — the
+operational form of the tables above. It is a project governance control, not an
+informal checklist: it exists to prevent uncontrolled external assertions.
+
+> **Reviewer test.** *Could this claim be independently verified from repository
+> artifacts (code, tests, docs) or public records (the NIST filing)?* If not, it
+> does not ship.
+
+**How to use.** Before any artifact goes out — spec, site copy, deck, comment
+letter, README, social post — every external claim it makes MUST map to an
+allowed row below (or a close paraphrase). If a claim matches a prohibited row,
+or matches nothing here, **cut it or rewrite it to the nearest allowed form.**
+When unsure, default to the weaker claim.
+
+### Allowed — with verifiable basis
+
+| Claim | Verifiable basis |
+| :-- | :-- |
+| "An open **reference implementation** and proposed **control model** for receiver-side governance of inbound healthcare AI agents." *(anchor claim)* | `src/nhid_policy_engine_v1.py` + CTS + adapters + simulator + pilot kit |
+| "**Implements receiver-side enforcement behavior.**" | `PolicyAction` + `evaluate_all()` emit the receiver action; CTS asserts `expected_policy_action` |
+| "**Separates identity disclosure, authorization evaluation, enforcement decision, and evidence capture into distinct control stages.**" | `PolicyDecision` flow (IDG/PDX → decision → Enforcement Profile → ATR-01 / FHIR); `docs/enforcement-profile.md`. This staged separation is a core strength — it is not "a disclosure banner." |
+| "A **deterministic, testable conformance model** (same inputs → identical output)." | `conformance/nhid_conformance_test_suite_v1.yaml` + `src/cts_runner.py`; passing unit suite |
+| "Five controls (IDG/PDX/DBC/EIT/ATR-01) plus a documented **Enforcement Profile — not a sixth control.**" | `docs/enforcement-profile.md`; `evaluate_all` ladder |
+| "Emits **FHIR AuditEvent** evidence for the interaction." | `src/fhir_audit_emitter.py`, `nhid_audit_export.py` |
+| "**Mapped to** NIST AI RMF and ISO/IEC 42001; **designed to support** EU AI Act Art. 50 transparency obligations." | `regulatory-alignment.html` — mapping only |
+| "Addresses an **underserved receiver-side operational gap** for inbound healthcare AI voice agents." | Narrow scope; conservative, hedged |
+| "A **voluntary open proposal with standards-oriented artifacts**; submitted a **public comment** to NIST (NIST-2025-0035-0026)." | Public comment ≠ endorsement or an opened standards process |
+| "Revocation is **checked at verification and in-memory** in the reference implementation." | `src/agent_identity.py` — not live / not cross-org |
+| "A **bot-to-bot disclosure gate** exists for agent-to-agent contexts." | `evaluate_bot_to_bot()` — disclosure only, not mutual authorization |
+
+### Prohibited — and why
+
+| Claim | Why prohibited |
+| :-- | :-- |
+| "NHID is **a standard / the standard / an emerging standard / a standards candidate.**" | No adoption body, no accreditation, no second implementation, no opened standards-body process. |
+| "**Provides authentication of AI agents.**" | Conflates identity declaration, credential verification, authorization, and enforcement. **Use instead:** *"NHID evaluates declared identity, authorization context, and interaction policy. It does not replace an underlying identity provider or cryptographic identity infrastructure."* |
+| "**Nobody** is solving receiver-side enforcement." | False — runtime enforcement is actively researched. Say *"no widely adopted, standardized receiver-side model exists."* |
+| "**Solved agent identity** / **prevents impersonation or fraud.**" | Too broad; NHID makes compromise scoped and revocable, it does not prevent it. |
+| "**Production-ready** / enterprise infrastructure / a trust or control plane." | Reference primitive; in-memory revocation, no registry, no federation, no key lifecycle. |
+| "**Compliant with / certified against** NIST / ISO / EU AI Act." | Mapping ≠ compliance ≠ certification. |
+| "**Detects** unauthorized / rogue / covert AI callers." | Measures disclosure on recorded traffic; does not detect covert agents. |
+| "A **universal identity layer** / a **healthcare AI governance framework.**" | Implies the model/bias/clinical scope NHID explicitly excludes. |
+| "**Adopted by** [any payer / provider / vendor]." | Zero production adoption today. |
+
+**Standing decision (do not reopen):** enforcement is documented as an
+Enforcement Profile over the five controls, **not** an `ENF-01` sixth control —
+the implementation already produces enforcement outcomes, so a sixth control
+would duplicate them. See `docs/enforcement-profile.md`.
 
 ---
 

--- a/docs/enforcement-profile.md
+++ b/docs/enforcement-profile.md
@@ -1,0 +1,141 @@
+# Chapter 10 — Enforcement Profile
+
+**Status:** Normative (NHID-Clinical v1.3). Documents behavior already implemented by the
+deterministic policy engine. **This chapter adds no new control.** The framework remains four
+behavioral controls (IDG-01, PDX-01, DBC-01, EIT-01) plus one audit requirement (ATR-01).
+
+**Source of truth:** `src/nhid_policy_engine_v1.py` and the Conformance Test Suite
+(`conformance/nhid_conformance_test_suite_v1.yaml`). Where this chapter and the reference
+implementation disagree, the implementation and its `expected_policy_action` assertions win;
+report the discrepancy.
+
+**RFC 2119 note.** MUST / SHOULD / MAY define a voluntary, self-imposed conformance baseline.
+They do not imply legal obligation. NHID-Clinical is a voluntary open proposal (CC BY 4.0) —
+not an accredited standard, certification, or regulatory requirement.
+
+---
+
+## 10.1 Enforcement Profile
+
+### 10.1.1 `PolicyDecision` — the output contract of control evaluation
+
+Evaluating the five controls against a single call turn produces exactly one **`PolicyDecision`**.
+It is the contract every receiver consumes. Its normative fields:
+
+| Field | Meaning |
+| :--- | :--- |
+| `action` | The single `PolicyAction` the receiver MUST execute for this turn (§10.1.2). |
+| `reason_code` | Stable machine token identifying which condition produced the action. |
+| `violations[]` | Every `BoundaryViolation` (`rule_id`, `description`, `severity`) raised by **all** controls this turn — merged, never collapsed. |
+| `next_state` | Advisory workflow state label. |
+| `policy_version` | Engine version that produced the decision. |
+
+A `PolicyDecision` carries **no score**. CAS is not a field of the decision and is computed
+separately and downstream (§10.4).
+
+### 10.1.2 `PolicyAction` vocabulary
+
+There are exactly **five** actions. A sixth action MUST NOT be introduced (a new action would be
+a sixth control in disguise). For each action:
+
+| PolicyAction | Meaning | Receiver obligation | Affects PHI exchange? | Affects workflow state? |
+| :--- | :--- | :--- | :--- | :--- |
+| **`DISCLOSE_IDENTITY`** | The agent has not disclosed non-human identity. | Receiver MUST require identity disclosure before material interaction continues; MUST NOT treat the caller as verified. | **Yes** — material interaction is withheld until disclosure. | Yes → `AWAITING_DISCLOSURE`. |
+| **`DENY_DATA`** | PHI exchange was attempted before disclosure (or an undisclosed agent-to-agent context). | Receiver MUST NOT request, accept, or release PHI on this turn. | **Yes** — PHI is blocked. | Yes → `GATE_BLOCKED`. |
+| **`ESCALATE_HUMAN`** | A human handoff is required and either not honored or unavailable. | Receiver MUST provide a functional human escalation path. | Indirect — the interaction transfers to a human; automated exchange halts. | Yes → `ESCALATING` / `ESCALATION_FAILED`. |
+| **`LOG_ONLY`** | A suggestive or evidentiary finding was raised (deceptive-behavior signal, or an audit-trail gap). | Receiver MUST record the finding; SHOULD route to human review per severity/CAS (§10.4). MUST NOT, by itself, treat this as a hard block. | **No** — not a data gate on its own. | No (state preserved / flagged, e.g. `DECEPTION_FLAGGED`). |
+| **`CONTINUE_AI`** | The evaluated control(s) passed. | None beyond proceeding; the AI agent MAY continue, subject to the other controls. | No block. | Typically → `DISCLOSED` / `DATA_EXCHANGE_AUTHORIZED` / unchanged. |
+
+> **Note (documented behavior, not a new rule):** DBC-01 emits `LOG_ONLY` for both a Tier-A
+> artifact (CRITICAL severity) and a Tier-B/C text signal (MAJOR). A deception finding is therefore
+> **recorded and routed**, not itself a PHI gate; any blocking on a deceptive turn arises from a
+> co-occurring IDG-01/PDX-01 failure, resolved by the ladder in §10.2. The CRITICAL severity still
+> propagates in `violations[]` and SHOULD drive review routing.
+
+---
+
+## 10.2 Enforcement Ladder
+
+A single turn MAY trip multiple controls at once, but the receiver needs **one unambiguous
+action**. When control outcomes conflict, the receiver MUST apply the most-protective action by
+this fixed precedence:
+
+```
+DENY_DATA  >  ESCALATE_HUMAN  >  DISCLOSE_IDENTITY  >  LOG_ONLY  >  CONTINUE_AI
+```
+
+- **Why conflict resolution exists:** enforcement acts per turn; two controls can each demand a
+  different response (e.g. PHI-before-disclosure *and* an unmet escalation request). The ladder
+  guarantees a deterministic, safety-first selection: the action that most limits data exposure
+  wins.
+- **The ladder resolves outcomes; it does not replace evaluation.** Every control still evaluates
+  independently and contributes its `violations[]`. The ladder only selects which single `action`
+  the receiver executes — it never suppresses a control's findings, and it never re-decides
+  conformance.
+
+---
+
+## 10.3 Consequence Matrix
+
+Normative mapping of control outcome → `PolicyAction` → receiver obligation. Each obligation
+attaches to an **existing** control — there is no standalone enforcement control.
+
+| Control outcome | PolicyAction | Receiver obligation (normative) |
+| :--- | :--- | :--- |
+| **IDG-01** — no non-human disclosure | `DISCLOSE_IDENTITY` | Receiver MUST require identity disclosure before material interaction. |
+| **PDX-01** — PHI attempted before disclosure | `DENY_DATA` | Receiver MUST prevent PHI exchange until disclosure is confirmed. |
+| **EIT-01** — escalation unmet / no path | `ESCALATE_HUMAN` | Receiver MUST provide a functional human escalation path. |
+| **DBC-01** — deceptive artifact or implied-human framing | `LOG_ONLY` | Receiver MUST record the finding and SHOULD route to human review per severity/CAS. |
+| **ATR-01** — required audit field missing | `LOG_ONLY` | Receiver MUST preserve evidence and record the audit-trail gap. |
+| All controls pass | `CONTINUE_AI` | Receiver MAY allow the AI agent to proceed. |
+
+---
+
+## 10.4 CAS Authority Boundary
+
+The Call Authorization Score (CAS) is a **downstream assessment and routing** mechanism. It is
+derived **after**, and **from**, the `PolicyDecision` (and audit-field completeness). It is not an
+evaluator and not an enforcer.
+
+**CAS MAY:**
+- trigger human review (reference threshold: CAS below Conditional Trust, `0.75`);
+- influence review priority and queueing.
+
+**CAS MUST NOT:**
+- override or modify a `PolicyDecision`;
+- convert `DENY_DATA` (or any restrictive action) into allowed access;
+- independently determine control compliance.
+
+### Governing invariant (normative)
+
+> The Enforcement Profile SHALL consume `PolicyDecision` outputs and SHALL NOT independently
+> evaluate control conformance or modify the outcome of the five core controls. CAS SHALL be
+> derived from, and downstream of, the `PolicyDecision`; it MAY drive review routing but SHALL NOT
+> alter the emitted `PolicyAction`. The five controls remain the sole source of conformance
+> decisions.
+
+---
+
+## Appendix 10.A — Normative vs. Reference-Implementation
+
+To keep the specification portable, the following separation is normative.
+
+**Normative (an independent implementation MUST reproduce):**
+- the five control outcomes and their pass/fail conditions;
+- the `PolicyAction` vocabulary and each action's meaning + receiver obligation (§10.1.2);
+- the Enforcement Ladder precedence (§10.2);
+- the Consequence Matrix receiver obligations (§10.3);
+- the CAS authority boundary and governing invariant (§10.4);
+- the ATR-01 required audit-field set (evidence requirement).
+
+**Reference implementation only (informative — an implementation MAY differ):**
+- the specific heuristic lexicons and their tuning (e.g. `_DBC_*` phrase lists,
+  `_ESCALATION_TRIGGERS`, PHI-speech patterns);
+- exact CAS scoring internals (NOCF/ECF weights and formula) beyond the tier thresholds;
+- TwiML / audio fallback strings and prompt wording;
+- internal `next_state` label spellings and `reason_code` string values;
+- internal-error handling and the `LOG_ONLY` safe-default.
+
+Implementers MUST NOT treat the reference lexicons or scoring internals as conformance
+requirements; conformance is defined by control outcomes, actions, precedence, obligations, and
+evidence — not by any particular phrase list or weight.

--- a/docs/policyaction-consolidation-plan.md
+++ b/docs/policyaction-consolidation-plan.md
@@ -1,0 +1,57 @@
+# PolicyAction Authority Consolidation Plan
+
+**Purpose:** designate one authoritative `PolicyAction` vocabulary and retire the divergent
+copies — a prerequisite for Chapter 10 (Enforcement Profile) to reference "PolicyAction"
+unambiguously. **This document changes no runtime behavior.** It records the current state and a
+behavior-preserving migration sequence.
+
+## Current state (verified by import audit)
+
+| Module | Vocabulary | Live consumers | Verdict |
+| :--- | :--- | :--- | :--- |
+| **`src/nhid_policy_engine_v1.py`** | `DISCLOSE_IDENTITY, ESCALATE_HUMAN, DENY_DATA, CONTINUE_AI, LOG_ONLY` | CTS runner, all adapters + their tests, `functions/handler.py` (live Lambda), Twilio/ElevenLabs handlers, `webplatform/nhid_bridge.py`, `synthetic_eval_loop`, pilot kit | **Authoritative.** It is the vocabulary the Conformance Test Suite asserts via `expected_policy_action`. |
+| `nhid_policy.py` (root) | `DISCLOSE, ESCALATE, BLOCK, ROUTE_LLM, ERROR` | `app.py`, `scripts/test_runner.py` | **Deprecate.** Divergent vocabulary. |
+| `src/nhid_policy.py` | *(byte-identical duplicate of root `nhid_policy.py`)* | — (import-compatible dup) | **Delete the redundant copy** — two identical files is pure liability. |
+| `src/voice_policy.py` | own `DisclosureState` / decision model | `nhid_api_endpoints.py` (live via `main:app`), its own tests | **Decide & document** (see Step 4). |
+
+**Live-path note:** the uvicorn entrypoint (`Procfile → main:app`) mounts *both* the legacy
+`app.py` engine (root `nhid_policy`) *and* `nhid_api_endpoints` (`voice_policy`), while the AWS
+Lambda path (`template.yaml → functions.handler`) uses the authoritative v1 engine. Three action
+vocabularies are therefore live simultaneously. This is pre-existing debt that the Enforcement
+Profile work surfaces; it does not originate here.
+
+## Target end-state
+
+Exactly one importable `PolicyAction` (the five values from `src/nhid_policy_engine_v1.py`) on
+every live path. `tests/test_enforcement_profile.py::test_policyaction_vocabulary_is_exactly_the_five_values`
+is the standing guard against regression.
+
+## Migration sequence (each step behavior-preserving; run full suite + guards after each)
+
+0. **(this release — done)** Pin the authoritative enum with a vocabulary-stability test. Publish
+   Chapter 10 naming `src/nhid_policy_engine_v1.PolicyAction` as authoritative. *No code moved.*
+1. **De-duplicate the identical pair.** Make `src/nhid_policy.py` re-export from root
+   `nhid_policy.py` (or vice-versa) so there is a single definition; confirm `app.py` and
+   `scripts/test_runner.py` imports still resolve. Byte-identical duplication is removed with zero
+   semantic change.
+2. **Adapter, not rewrite, for the legacy vocabulary.** Add an explicit, deprecated mapping from
+   the legacy actions to the authoritative ones (`BLOCK→DENY_DATA`, `ESCALATE→ESCALATE_HUMAN`,
+   `DISCLOSE→DISCLOSE_IDENTITY`, `ROUTE_LLM→CONTINUE_AI`, `ERROR→LOG_ONLY`) so `app.py` can emit the
+   authoritative vocabulary without touching control logic. Mark the legacy enum `@deprecated`.
+3. **Migrate `app.py`** to consume `evaluate_all` (preferred) or the Step-2 adapter. Decide whether
+   `app.py`'s class-based `NHIDPolicyEngine` is still a needed surface or a legacy demo that can be
+   retired behind the v1 engine.
+4. **Resolve `voice_policy.py`.** Maintainer decision required: is `nhid_api_endpoints.py` a live
+   conformance surface or a legacy/demo path? Then either (a) map its decisions onto the
+   authoritative `PolicyAction` and document the relationship, or (b) explicitly scope it as a
+   non-normative transcript-chunk pre-filter that is **not** the conformance engine.
+5. **Remove the legacy vocabulary** once no live path imports it; ship as a minor release with a
+   deprecation note. The vocabulary-stability test continues to guard the single definition.
+
+## Timing
+
+The Chapter 10 documentation and the vocabulary-stability test (Step 0) ship now and are
+independent of Steps 1–5. Steps 1–2 (de-dup + adapter) are low-risk and SHOULD precede publishing
+Chapter 10 as fully normative, so "maps to `PolicyAction`" resolves to a single definition.
+Steps 3–5 touch live entrypoints and MUST each be verified against the full suite + guards; they
+are sequenced after this spec-maturity release.

--- a/pricing.html
+++ b/pricing.html
@@ -53,7 +53,7 @@
   <div class="pricing-hero">
     <p class="section-kicker">Licensing &amp; Services</p>
     <h1>Everything is open. CC BY 4.0.</h1>
-    <p>The specification, the v1.3 policy engine, the v2 cryptographic identity layer, the conformance test suite, the adapters, and the simulator are all free and open — no license fees, no paid tiers, no gated features.</p>
+    <p>The specification, the v1.3 policy engine, the v2 cryptographic authorization layer (NHID-Auth), the conformance test suite, the adapters, and the simulator are all free and open — no license fees, no paid tiers, no gated features.</p>
   </div>
 
   <div class="pricing-grid" style="grid-template-columns:1fr;max-width:44rem;margin:0 auto">
@@ -62,7 +62,7 @@
       <ul>
         <li>Full conformance test suite (Python policy engine + TypeScript middleware)</li>
         <li>v1.3 policy engine (pure Python, zero runtime deps)</li>
-        <li>v2 cryptographic identity layer — public reference implementation</li>
+        <li>v2 cryptographic authorization layer (NHID-Auth) — public reference implementation</li>
         <li>VAPI + Twilio adapters and a live demo API (no key required)</li>
         <li>PowerShell module, OpenAPI spec, Postman collection</li>
         <li>Community support (GitHub Discussions)</li>

--- a/research-portfolio.html
+++ b/research-portfolio.html
@@ -301,7 +301,7 @@
       <div class="content-cards" style="grid-template-columns:repeat(auto-fit,minmax(16rem,1fr));margin-top:1rem">
         <div class="content-card">
           <h3>NHID-Clinical</h3>
-          <p>Non-Human Identity Disclosure standard for healthcare voice workflows &mdash; specification, reference implementation, and open repository.</p>
+          <p>Non-Human Identity Disclosure controls for healthcare voice workflows &mdash; specification, reference implementation, and open repository.</p>
           <a class="card-link" href="https://nhid-clinical.org" target="_blank" rel="noopener noreferrer">nhid-clinical.org &#x2197;</a>
         </div>
         <div class="content-card">

--- a/scripts/validate_ci.py
+++ b/scripts/validate_ci.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 import re, subprocess, sys
-UNIT_EXPECTED = 330
+UNIT_EXPECTED = 343
 INTEGRATION_EXPECTED = 18
 def run_pytest():
     result = subprocess.run([sys.executable,"-m","pytest","tests/","-q","--tb=short","--no-header"],capture_output=True,text=True)

--- a/specification.html
+++ b/specification.html
@@ -233,7 +233,7 @@ sequenceDiagram
       <p style="color:var(--body);font-size:1rem;line-height:1.85;margin-top:.75rem">This proposal applies to <strong>B2B administrative voice workflows</strong> — AI systems calling payer offices on behalf of providers, vendors, or plan administrators. It does not apply to patient-facing calls, clinical decision support, or internal tooling.</p>
 
       <h2 style="margin-top:2.5rem">What This Is Not</h2>
-      <p style="color:var(--body);font-size:1rem;line-height:1.85;margin-top:.75rem">This proposal does not define a compliance program. There is no certifying body, no audit process, and no enforcement mechanism. The <a href="/registry.html" style="color:var(--teal-bright);font-weight:600">Implementation Registry</a> is self-attestation only — vendors list themselves and link their own live conformance metrics; NHID-Clinical does not verify or certify entries. The full proposal document (PDF below) contains more detail for interested practitioners.</p>
+      <p style="color:var(--body);font-size:1rem;line-height:1.85;margin-top:.75rem">This proposal does not define a compliance program. There is no certifying body, no audit process, and no enforcement mechanism. NHID-Clinical evaluates declared identity, authorization context, and interaction policy; it does not replace an underlying identity provider or cryptographic identity infrastructure. The <a href="/registry.html" style="color:var(--teal-bright);font-weight:600">Implementation Registry</a> is self-attestation only — vendors list themselves and link their own live conformance metrics; NHID-Clinical does not verify or certify entries. The full proposal document (PDF below) contains more detail for interested practitioners.</p>
 
       <h2 style="margin-top:2.5rem">Known Gaps (v1.3)</h2>
       <p style="color:var(--body);font-size:1rem;line-height:1.85;margin-top:.75rem">v1.3 addresses <em>observable behavior</em> — disclosure timing, deceptive artifacts, escalation path, audit logging. It does not address caller authorization. Because NPIs are public, a malicious AI can trivially impersonate a provider unless a cryptographic authorization handshake is enforced — <a href="/roadmap.html" style="color:var(--teal-bright);font-weight:600">NHID-Auth v2</a> (released June 2026, CC BY 4.0) addresses this with Ed25519 provider-signed agent passports and NPI binding. NHID-Clinical v1.3 tells you the caller was automated; NHID-Auth v2 tells you the caller was authorized.</p>
@@ -252,7 +252,7 @@ sequenceDiagram
         <h3 style="margin-top:1.5rem;font-size:1.1rem">Broader Context</h3>
         <p style="font-size:0.95rem;line-height:1.6;color:var(--ink)">
           NHID-Clinical is also featured in the <a href="https://ai-governance-map.vercel.app/" target="_blank" style="color:var(--teal-bright);font-weight:600">AI Governance Map</a> 
-          — an interactive maturity radar for tracking compliance across frameworks like NIST RMF, EU AI Act, and ISO 42001.
+          — an interactive maturity radar for tracking alignment across frameworks like NIST RMF, EU AI Act, and ISO 42001.
         </p>
 
         <h3 style="margin-top:1.5rem;font-size:1.1rem">Document Family</h3>
@@ -267,7 +267,7 @@ sequenceDiagram
             </thead>
             <tbody>
                 <tr style="border-bottom:1px solid var(--line)">
-                    <td style="padding:0.5rem">Governance standard</td>
+                    <td style="padding:0.5rem">Governance control model</td>
                     <td style="padding:0.5rem">NHID-Clinical v1.3</td>
                     <td style="padding:0.5rem">Current</td>
                     <td style="padding:0.5rem">Minimum disclosure baseline</td>

--- a/technical-stack.html
+++ b/technical-stack.html
@@ -200,7 +200,7 @@
   <section class="page-section" style="background:var(--mist)">
     <div class="container" style="max-width:62rem">
       <h2>The Framework at a Glance</h2>
-      <p style="margin-bottom:1.5rem;color:var(--body)">Every component of NHID-Clinical on one map — the proposal, the v1.3 controls, the technical stack, pilot tooling, regulatory alignment, and the v2 identity layer.</p>
+      <p style="margin-bottom:1.5rem;color:var(--body)">Every component of NHID-Clinical on one map — the proposal, the v1.3 controls, the technical stack, pilot tooling, regulatory alignment, and the v2 authorization layer (NHID-Auth).</p>
       <img src="/assets/diagrams/framework-mindmap.svg" alt="Mind map of the NHID-Clinical framework: the proposal, v1.3 core controls (IDG-01, PDX-01, DBC-01, EIT-01), technical stack, pilot and evaluation tooling, regulatory alignment, v2 identity layer, and community governance" style="width:100%;height:auto;border-radius:14px;border:1px solid var(--border)" loading="lazy"/>
     </div>
   </section>

--- a/tests/test_enforcement_profile.py
+++ b/tests/test_enforcement_profile.py
@@ -1,0 +1,220 @@
+"""
+Enforcement Profile invariants (spec-maturity release).
+
+These tests do NOT introduce new behavior. They pin the enforcement behavior
+that already exists in src/nhid_policy_engine_v1.py so that the newly written
+Chapter 10 (Enforcement Profile / Ladder / Consequence Matrix / CAS Authority
+Boundary) stays true to the reference implementation.
+
+Coverage:
+  1. PolicyAction vocabulary stability (guards against an accidental 6th action)
+  2. Enforcement ladder precedence
+  3. Multiple simultaneous control failures
+  4. CAS cannot override a PolicyDecision
+  5. PolicyDecision serialization contract
+"""
+from __future__ import annotations
+
+import inspect
+from dataclasses import fields, is_dataclass
+
+import pytest
+
+from src.nhid_policy_engine_v1 import (
+    PolicyAction,
+    PolicyDecision,
+    evaluate_all,
+)
+from src.nhid_cas import compute_cas, compute_nocf, NOCFInputs
+
+EXPECTED_VOCABULARY = {
+    "DISCLOSE_IDENTITY",
+    "ESCALATE_HUMAN",
+    "DENY_DATA",
+    "CONTINUE_AI",
+    "LOG_ONLY",
+}
+
+
+# ── helpers ────────────────────────────────────────────────────────────────
+
+def _audit_fields() -> dict:
+    """Full ATR-01 required field set so ATR-01 returns CONTINUE_AI and does
+    not add LOG_ONLY noise (used when we want to isolate a different control)."""
+    return {
+        "event_id": "evt-1",
+        "timestamp": "2026-07-27T15:00:00Z",
+        "session_id": "sess-1",
+        "request_id": "req-1",
+        "event_type": "turn",
+        "actor_id": "agent-1",
+        "state_before": "OPEN",
+        "state_after": "OPEN",
+        "replay_mode": False,
+        "external_calls_cached": True,
+        "execution_context": {
+            "pipeline_version": "1.0.0",
+            "policy_engine_version": "1.0.0",
+            "nhid_schema_version": "1.0",
+        },
+    }
+
+
+def _event(*, governance: dict, speech: str = "", counterparty: str = "human_operator",
+           with_audit: bool = True) -> dict:
+    ev: dict = {
+        "counterparty_type": counterparty,
+        "healthcare_governance": governance,
+        "input_payload": {"speech_text": speech},
+    }
+    if with_audit:
+        ev.update(_audit_fields())
+    return ev
+
+
+# ── 1. PolicyAction vocabulary stability ───────────────────────────────────
+
+def test_policyaction_vocabulary_is_exactly_the_five_values():
+    """A sixth action must never appear silently — that would be a 6th control
+    in disguise. This is the tripwire for the five-control invariant."""
+    assert {a.value for a in PolicyAction} == EXPECTED_VOCABULARY
+    assert len(PolicyAction) == 5
+
+
+def test_policyaction_values_are_stable_uppercase_strings():
+    for action in PolicyAction:
+        assert isinstance(action.value, str)
+        assert action.value == action.name  # value mirrors name, no drift
+
+
+# ── 2. Enforcement ladder precedence ───────────────────────────────────────
+
+def test_ladder_deny_data_dominates_escalate_human():
+    # PDX-01 fail (PHI in fields, no disclosure) + EIT-01 fail (escalation, no path)
+    gov = {"disclosure_timestamp": None, "phi_accessed": ["member_id"],
+           "escalation_path_available": False}
+    ev = _event(governance=gov, speech="I need to speak to a human")
+    session = {"escalation_path_available": False, "turn_count": 1}
+    decision = evaluate_all(session, ev)
+    assert decision.action == PolicyAction.DENY_DATA
+
+
+def test_ladder_escalate_human_dominates_disclose_identity():
+    # IDG-01 fail (no disclosure) + EIT-01 fail (escalation, no path), NO PHI
+    gov = {"disclosure_timestamp": None, "phi_accessed": []}
+    ev = _event(governance=gov, speech="please transfer me to a representative")
+    session = {"escalation_path_available": False, "turn_count": 1}
+    decision = evaluate_all(session, ev)
+    assert decision.action == PolicyAction.ESCALATE_HUMAN
+
+
+def test_ladder_disclose_identity_dominates_log_only():
+    # IDG-01 fail (DISCLOSE_IDENTITY) + ATR-01 fail (LOG_ONLY, audit omitted)
+    gov = {"disclosure_timestamp": None, "phi_accessed": []}
+    ev = _event(governance=gov, speech="hello", with_audit=False)
+    session = {"turn_count": 0}
+    decision = evaluate_all(session, ev)
+    assert decision.action == PolicyAction.DISCLOSE_IDENTITY
+
+
+def test_ladder_log_only_dominates_continue_ai():
+    # Clean disclosure (IDG/PDX/EIT continue) + ATR-01 fail (LOG_ONLY)
+    gov = {"disclosure_timestamp": "2026-07-27T15:00:00Z",
+           "identity_assertion_text": "I am an automated system.",
+           "phi_accessed": []}
+    ev = _event(governance=gov, speech="thanks", with_audit=False)
+    session = {"turn_count": 1}
+    decision = evaluate_all(session, ev)
+    assert decision.action == PolicyAction.LOG_ONLY
+
+
+# ── 3. Multiple simultaneous control failures ──────────────────────────────
+
+def test_multiple_simultaneous_failures_merge_all_violations():
+    gov = {"disclosure_timestamp": None, "phi_accessed": ["member_id"],
+           "escalation_path_available": False}
+    ev = _event(governance=gov, speech="I need to speak to a human")
+    session = {"escalation_path_available": False, "turn_count": 1}
+    decision = evaluate_all(session, ev)
+    rule_ids = {v.rule_id for v in decision.violations}
+    # IDG-01 (undisclosed), PDX-01 (PHI pre-disclosure), EIT-01 (no escalation path)
+    assert {"IDG-01", "PDX-01", "EIT-01"}.issubset(rule_ids)
+    # Composite action is still the single most-restrictive one, not a merge
+    assert decision.action == PolicyAction.DENY_DATA
+
+
+def test_composite_action_is_one_of_the_vocabulary():
+    gov = {"disclosure_timestamp": None, "phi_accessed": ["npi"]}
+    ev = _event(governance=gov, speech="member id please")
+    decision = evaluate_all({"turn_count": 1}, ev)
+    assert decision.action in set(PolicyAction)
+
+
+# ── 4. CAS cannot override a PolicyDecision ────────────────────────────────
+
+def test_evaluate_all_does_not_consume_cas():
+    """Structural proof: the decision authority cannot read CAS, so CAS can
+    never influence the emitted PolicyAction."""
+    params = set(inspect.signature(evaluate_all).parameters)
+    assert params == {"session", "event"}
+
+
+def test_cas_result_is_score_only_and_carries_no_action():
+    nocf = compute_nocf(NOCFInputs(
+        entity_match_rate=0.9, intent_accuracy=0.9, domain_hit_rate=0.9,
+        successful_actions=8, attempted_actions=10,
+        call_drop_rate=0.0, audio_corruption_rate=0.0, tool_failure_rate=0.0,
+        latency_ms=800.0,
+        hallucination_risk=0.1, pii_leakage_risk=0.1, identity_ambiguity_risk=0.1,
+    ))
+    cas = compute_cas(iaf=True, nocf_result=nocf, trace={})
+    assert "cas" in cas and "tier" in cas
+    # CAS is a measurement: it must not carry any enforcement action.
+    assert "action" not in cas
+    assert not any(str(v) in EXPECTED_VOCABULARY for v in cas.values())
+
+
+def test_low_cas_does_not_downgrade_a_deny_decision():
+    """A DENY_DATA decision stays DENY_DATA regardless of any CAS value — the
+    decision is computed by the controls, not by the score."""
+    gov = {"disclosure_timestamp": None, "phi_accessed": ["member_id"]}
+    ev = _event(governance=gov, speech="member id please")
+    decision = evaluate_all({"turn_count": 1}, ev)
+    assert decision.action == PolicyAction.DENY_DATA
+    # A deliberately low CAS exists independently and does not touch the action.
+    low_nocf = compute_nocf(NOCFInputs(
+        entity_match_rate=0.1, intent_accuracy=0.1, domain_hit_rate=0.1,
+        successful_actions=1, attempted_actions=10,
+        call_drop_rate=0.5, audio_corruption_rate=0.3, tool_failure_rate=0.3,
+        latency_ms=2400.0,
+        hallucination_risk=0.9, pii_leakage_risk=0.9, identity_ambiguity_risk=0.9,
+    ))
+    low_cas = compute_cas(iaf=False, nocf_result=low_nocf, trace={})
+    assert low_cas["cas"] < 0.5  # low, review/deny tier
+    assert decision.action == PolicyAction.DENY_DATA  # unchanged
+
+
+# ── 5. PolicyDecision serialization contract ───────────────────────────────
+
+def test_policydecision_serialization_contract():
+    gov = {"disclosure_timestamp": None, "phi_accessed": []}
+    decision = evaluate_all({"turn_count": 0}, _event(governance=gov))
+    assert is_dataclass(decision)
+    field_names = {f.name for f in fields(PolicyDecision)}
+    required = {"action", "reason_code", "policy_version", "violations",
+                "next_state", "twiml_fallback", "gather_speech"}
+    assert required.issubset(field_names)
+    # The public wire form uses action.value + reason_code.
+    assert isinstance(decision.action.value, str)
+    assert isinstance(decision.reason_code, str) and decision.reason_code
+    assert isinstance(decision.next_state, str)
+
+
+def test_policydecision_violations_are_structured():
+    gov = {"disclosure_timestamp": None, "phi_accessed": ["member_id"]}
+    decision = evaluate_all({"turn_count": 1}, _event(governance=gov, speech="member id"))
+    assert decision.violations, "expected at least one violation"
+    for v in decision.violations:
+        assert v.rule_id and isinstance(v.rule_id, str)
+        assert v.description and isinstance(v.description, str)
+        assert v.severity.value in {"critical", "major", "minor"}


### PR DESCRIPTION
## Summary
Formalizes the enforcement behavior the deterministic policy engine **already implements** into normative specification language. **No sixth control. No new behavior. No engine/control code changed.** The five-control architecture, CTS behavior, `PolicyDecision` flow, CAS separation, and ATR-01 evidence boundary are all preserved.

## Phase 1 — Chapter 10 (`docs/enforcement-profile.md`, normative)
- **10.1 Enforcement Profile** — `PolicyDecision` as the output contract; the five-value `PolicyAction` vocabulary with, for each action, its meaning / receiver obligation / whether it affects PHI exchange / whether it affects workflow state.
- **10.2 Enforcement Ladder** — documents the existing precedence `DENY_DATA > ESCALATE_HUMAN > DISCLOSE_IDENTITY > LOG_ONLY > CONTINUE_AI`, why conflict resolution exists, and that it **resolves** simultaneous outcomes without **replacing** control evaluation.
- **10.3 Consequence Matrix** — normative control-outcome → action → receiver-obligation table.
- **10.4 CAS Authority Boundary** — CAS MAY trigger/priority review; MUST NOT override a `PolicyDecision`, convert `DENY_DATA` into access, or determine conformance. Includes the governing invariant sentence.
- **Appendix 10.A** — the normative vs reference-implementation split (Phase 4).

## Phase 2 — PolicyAction consolidation plan (`docs/policyaction-consolidation-plan.md`)
Designates `src/nhid_policy_engine_v1.PolicyAction` authoritative (it's what the CTS asserts and the whole live path imports). Documents the divergent copies — the byte-identical `nhid_policy.py`/`src/nhid_policy.py` duplicate and `voice_policy.py` — and gives a sequenced, **behavior-preserving** migration. **No runtime changes in this PR.**

## Phase 3 — Invariant tests (`tests/test_enforcement_profile.py`, 13 tests)
Pin the existing behavior: PolicyAction vocabulary stability (tripwire against a 6th action), ladder precedence, multi-control merge, **CAS cannot override a decision**, and the `PolicyDecision` serialization contract.

## Count invariant
Adding 13 tests moves the unit invariant **330 → 343**, propagated atomically across every guard-watched surface (`validate_ci.py` `UNIT_EXPECTED`, `ci.yml` + nightly job names, `CONTRIBUTING`, README badges/prose) plus the archive LIVE rows. Dated historical rows left intact.

## Verification
- Guards green: `validate_ci.py` (**CI PASS: 343 passed**), `check_number_drift.py` (**DRIFT PASS** at 343), `check_baseline.py` (**BASELINE PASS**).
- Confirmed **no engine/control files touched** — only docs, the new test file, and count surfaces.

## Final question — A or B?
**B: an existing deterministic enforcement implementation being formalized into a portable specification.** The audit showed enforcement is already live and tested (`evaluate_all` emits actions, the ladder resolves conflicts, the CTS asserts `expected_policy_action`, CAS is downstream). This PR turns that implicit behavior into normative language and pins it with tests — it does not create a capability. The only non-documentation follow-up is collapsing the three live `PolicyAction` vocabularies to one, which is planned, not performed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K6naAZodVs6Cftbq2miy1L

---
_Generated by [Claude Code](https://claude.ai/code/session_01K6naAZodVs6Cftbq2miy1L)_