### PR TITLE
README: rename identity section to "Creator & Project Lead"

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,14 +340,14 @@ We are seeking the first **shadow evaluation partners** — 90 days, observe-onl
 
 [**For Payers →**](https://nhid-clinical.org/for-payers.html) · [GitHub Discussions](https://github.com/NHID-Clinical/NHID-Clinical/discussions) · [contact@nhid-clinical.org](mailto:contact@nhid-clinical.org)
 
-## Maintainer
+## Creator & Project Lead
 
 <img src="assets/maintainer/brianna-baynard.jpg" width="120" align="left" alt="Brianna Baynard" />
 
 **Brianna Baynard**
 AI Governance & Security Researcher · AIGP · ISC² CC · WGU Cybersecurity
 
-Creator and maintainer of NHID-Clinical. Background in healthcare payer operations, identity-verification workflows, and regulated-data environments. NHID-Clinical grew out of direct experience observing operational gaps in healthcare AI voice workflows, and is maintained as an open reference implementation for technical review — feedback and criticism are welcome.
+Creator and project lead for NHID-Clinical. Background in healthcare payer operations, identity-verification workflows, and regulated-data environments. NHID-Clinical grew out of direct experience observing operational gaps in healthcare AI voice workflows, and is maintained as an open reference implementation for technical review — feedback and criticism are welcome.
 
 [LinkedIn](https://linkedin.com/in/brianna-baynard) · [GitHub](https://github.com/NHID-Clinical/NHID-Clinical) · [Project website](https://nhid-clinical.org)
 


### PR DESCRIPTION
## Summary
Small README polish before external outreach — retitles the maintainer identity block to better reflect the role. **Presentation only — no architecture, control, claim, or number changes.**

## Changes (`README.md`)
- `## Maintainer` → **`## Creator & Project Lead`**.
- Bio opener: "Creator and maintainer of NHID-Clinical." → **"Creator and project lead for NHID-Clinical."**

Rationale: "maintainer" framed the role as repo administration; "Creator & Project Lead" reflects responsibility for the research direction, specifications, reference implementation, and coordination of external review — without implying a company, foundation, or standards-body role. Credential line, photo, bio body, and links are unchanged.

## Verification
- Guards green: `validate_ci.py` (343), `check_number_drift.py` (DRIFT PASS).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K6naAZodVs6Cftbq2miy1L

---
_Generated by [Claude Code](https://claude.ai/code/session_01K6naAZodVs6Cftbq2miy1L)_