### PR TITLE
Site-wide redesign: roll the premium visual system across all pages

### DIFF
--- a/about.html
+++ b/about.html
@@ -133,16 +133,33 @@
 <div class="nav-backdrop" id="nav-backdrop"></div>
 
 <main>
+  <section class="inner-hero" style="position:relative;overflow:clip">
+    <div class="hero-glow" aria-hidden="true"></div>
+    <div class="container inner-hero-grid" style="position:relative;z-index:1">
+      <div>
+        <div class="crumbs"><a href="/">Home</a><span>/</span><span>About</span></div>
+        <p class="eyebrow">Why this exists</p>
+        <h1 class="reveal">About NHID-Clinical</h1>
+        <p class="lede reveal">An operational AI governance framework for non-human actor accountability — disclosure, delegated authority, and auditability of AI-operated interactions in healthcare AI workflows.</p>
+      </div>
+      <aside class="hero-summary-card">
+        <div class="spec-badges">
+          <span class="spec-badge">CC BY 4.0</span>
+          <span class="spec-badge">v1.3</span>
+          <span class="spec-badge spec-badge-green">Practitioner-led</span>
+        </div>
+        <p style="font-size:.88rem;color:var(--body);line-height:1.65;margin:.75rem 0 1rem">Created by <strong>Brianna Baynard</strong>, developed independently.<br>Submitted as a public comment to NIST (<a href="https://www.regulations.gov/comment/NIST-2025-0035-0026" target="_blank" rel="noopener noreferrer">NIST-2025-0035-0026</a>).<br><br>No organizations have adopted or piloted it in production yet.</p>
+        <a class="primary-pill" href="/specification.html" style="width:100%;justify-content:center">Read the Specification →</a>
+      </aside>
+    </div>
+  </section>
+
   <section class="page-section">
     <div class="container" style="max-width:52rem">
 
-      <h1>About NHID-Clinical</h1>
-
-      <p class="lede" style="margin-top:.75rem">An operational AI governance framework for non-human actor accountability — disclosure, delegated authority, and auditability of AI-operated interactions in healthcare AI workflows.</p>
-
       <p style="color:var(--body);font-size:1rem;line-height:1.8;margin-top:.75rem">NHID-Clinical was created by Brianna Baynard, who worked directly in healthcare payer operations — live eligibility, claims, and prior-authorization phone lines. She was on the receiving end of hundreds of calls from AI voice agents acting for provider offices, including agents that disclosed their automated status only after PHI had been exchanged, or not at all. NHID-Clinical documents those failure patterns and defines a testable baseline for addressing them. It is published openly under CC BY 4.0 and was submitted as a public comment to NIST (<a href="https://www.regulations.gov/comment/NIST-2025-0035-0026" target="_blank" rel="noopener noreferrer">NIST-2025-0035-0026</a>).</p>
 
-      <blockquote style="border-left:4px solid var(--blue);margin:1.5rem 0;padding:.75rem 1.25rem;color:var(--body);font-size:1rem;line-height:1.8;font-style:italic">
+      <blockquote class="reveal" style="border-left:4px solid var(--teal-bright);margin:1.5rem 0;padding:.75rem 1.25rem;color:var(--body);font-size:1rem;line-height:1.8;font-style:italic">
         "I sat in the exact seat that payer representatives are in today — receiving calls from systems that sounded human, exchanged sensitive data, and only later admitted they were automated. That firsthand experience showed how much friction, wasted time, and unnecessary risk this creates on both sides."
       </blockquote>
 
@@ -154,14 +171,14 @@
 
       <p style="color:var(--body);font-size:1rem;line-height:1.8;margin-top:.75rem">If you work in payer operations, provider offices, or voice AI platforms and see similar patterns, your feedback would be genuinely appreciated.</p>
 
-      <p style="color:var(--body);font-size:1rem;line-height:1.8;margin-top:.75rem"><a href="mailto:contact@nhid-clinical.org" style="color:var(--blue);font-weight:600">contact@nhid-clinical.org</a></p>
+      <p style="color:var(--body);font-size:1rem;line-height:1.8;margin-top:.75rem"><a href="mailto:contact@nhid-clinical.org" style="color:var(--teal-bright);font-weight:600">contact@nhid-clinical.org</a></p>
 
-      <p style="color:var(--body);font-size:1rem;line-height:1.8;margin-top:.75rem">For a one-page overview aimed at leadership and procurement teams, see the <a href="https://github.com/NHID-Clinical/NHID-Clinical/blob/main/docs/executive-brief.md" style="color:var(--blue);font-weight:600">Executive Brief</a>.</p>
+      <p style="color:var(--body);font-size:1rem;line-height:1.8;margin-top:.75rem">For a one-page overview aimed at leadership and procurement teams, see the <a href="https://github.com/NHID-Clinical/NHID-Clinical/blob/main/docs/executive-brief.md" style="color:var(--teal-bright);font-weight:600">Executive Brief</a>.</p>
 
-      <div style="border-top:1px solid var(--border);padding-top:2rem;margin-top:2rem">
+      <div class="reveal" style="border-top:1px solid var(--border);padding-top:2rem;margin-top:2rem">
           <h3 style="font-size:1.1rem">Related Tools</h3>
           <p style="font-size:0.95rem;line-height:1.6">
-            NHID-Clinical is also featured in the <a href="https://ai-governance-map.vercel.app/" target="_blank" style="color:var(--blue);font-weight:600">AI Governance Map</a> 
+            NHID-Clinical is also featured in the <a href="https://ai-governance-map.vercel.app/" target="_blank" style="color:var(--teal-bright);font-weight:600">AI Governance Map</a>
             — an interactive maturity radar for tracking alignment across major frameworks like NIST RMF, EU AI Act, and ISO 42001.
           </p>
       </div>

--- a/demo.html
+++ b/demo.html
@@ -134,12 +134,13 @@
 <div class="nav-backdrop" id="nav-backdrop"></div>
 
 <main>
-  <section class="inner-hero">
-    <div class="container">
+  <section class="inner-hero" style="position:relative;overflow:clip">
+    <div class="hero-glow" aria-hidden="true"></div>
+    <div class="container" style="position:relative;z-index:1">
       <div class="crumbs"><a href="/">Home</a><span>/</span><span>Live Demo Line</span></div>
       <p class="eyebrow"><span class="status-dot"></span> Live</p>
-      <h1>Call the demo line. Watch it pass or fail, live.</h1>
-      <p class="lede">A scripted, deterministic phone call — no AI variance — run through the exact same NHID-Clinical evaluation pipeline that production traffic goes through. Only the speech is fake.</p>
+      <h1 class="reveal">Call the demo line. Watch it pass or fail, live.</h1>
+      <p class="lede reveal">A scripted, deterministic phone call — no AI variance — run through the exact same NHID-Clinical evaluation pipeline that production traffic goes through. Only the speech is fake.</p>
     </div>
   </section>
 

--- a/developers.html
+++ b/developers.html
@@ -134,14 +134,15 @@
 <div class="nav-backdrop" id="nav-backdrop"></div>
 
 <main>
-  <section class="inner-hero">
-    <div class="container inner-hero-grid">
+  <section class="inner-hero" style="position:relative;overflow:clip">
+    <div class="hero-glow" aria-hidden="true"></div>
+    <div class="container inner-hero-grid" style="position:relative;z-index:1">
       <div>
         <div class="crumbs"><a href="/">Home</a><span>/</span><span>Developers</span></div>
         <p class="eyebrow">Technical Reference · v1.3 · Open Source</p>
-        <h1>Technical Reference</h1>
+        <h1 class="reveal">Technical Reference</h1>
         <p style="margin-top:.5rem;font-size:.85rem;color:var(--ink-soft)">Last updated: June 2026</p>
-        <p class="lede">Reference implementation artifacts for the NHID-Clinical v1.3 specification. These tools demonstrate that the specification can be implemented, replayed, and evaluated through deterministic trace artifacts and conformance testing.</p>
+        <p class="lede reveal">Reference implementation artifacts for the NHID-Clinical v1.3 specification. These tools demonstrate that the specification can be implemented, replayed, and evaluated through deterministic trace artifacts and conformance testing.</p>
       </div>
     </div>
   </section>
@@ -156,7 +157,7 @@
       <!-- ── Integration Ladder ────────────────────────────────────────── -->
 
       <h2 style="margin-bottom:1rem">Staged Integration — Stop at Any Rung</h2>
-      <p style="color:var(--body);font-size:.93rem;line-height:1.75;margin:0 0 1rem">Integration is a ladder, not an all-or-nothing commitment. Tier 0 needs nothing but <code style="font-size:.84rem;background:var(--bg-alt);padding:.1rem .3rem;border-radius:3px">curl</code>; Tier 2's cryptographic identity layer (NHID-Auth v2) is optional. Full walkthrough: <a href="https://github.com/NHID-Clinical/NHID-Clinical/blob/main/docs/v2-integration-guide.md" style="color:var(--blue)">v2-integration-guide.md</a>.</p>
+      <p style="color:var(--body);font-size:.93rem;line-height:1.75;margin:0 0 1rem">Integration is a ladder, not an all-or-nothing commitment. Tier 0 needs nothing but <code style="font-size:.84rem;background:var(--bg-alt);padding:.1rem .3rem;border-radius:3px">curl</code>; Tier 2's cryptographic identity layer (NHID-Auth v2) is optional. Full walkthrough: <a href="https://github.com/NHID-Clinical/NHID-Clinical/blob/main/docs/v2-integration-guide.md" style="color:var(--teal-bright)">v2-integration-guide.md</a>.</p>
       <img src="/assets/diagrams/integration-ladder.svg" alt="Staged integration ladder: Tier 0 paste a payload to the hosted demo endpoint in 15 minutes with no keys; Tier 1 wire one HTTP call into your end-of-call webhook in about 2 hours for continuous CAS monitoring; Tier 2 adds cryptographic agent identity via NHID-Auth v2 in about a day, with NPI-bound passports and scoped delegation" style="width:100%;height:auto;border-radius:10px;border:1px solid var(--border);margin-bottom:2.5rem" loading="lazy"/>
 
       <!-- ── Front Desk Walkthrough ────────────────────────────────────── -->
@@ -177,7 +178,7 @@
         <div style="display:flex;align-items:flex-start;gap:1rem;flex-wrap:wrap">
           <div style="flex:1;min-width:0">
             <h3 style="margin:0 0 .35rem;font-size:1.05rem">Canonical Event Schema</h3>
-            <code style="font-size:.82rem;color:var(--blue);background:var(--bg-alt);padding:.15rem .4rem;border-radius:3px;word-break:break-all">schema/nhid_trace_schema_v1.json</code>
+            <code style="font-size:.82rem;color:var(--teal-bright);background:var(--bg-alt);padding:.15rem .4rem;border-radius:3px;word-break:break-all">schema/nhid_trace_schema_v1.json</code>
             <p style="color:var(--body);font-size:.93rem;line-height:1.75;margin:.75rem 0 0">JSON Schema (Draft 2020&#8209;12) for a single NHID&#8209;Trace event. Includes schema annotations referencing disclosure, identity, and auditability considerations associated with TCPA, HIPAA, CA AB 489, and NY S7263.</p>
           </div>
         </div>
@@ -188,7 +189,7 @@
         <div style="display:flex;align-items:flex-start;gap:1rem;flex-wrap:wrap">
           <div style="flex:1;min-width:0">
             <h3 style="margin:0 0 .35rem;font-size:1.05rem">Policy Engine</h3>
-            <code style="font-size:.82rem;color:var(--blue);background:var(--bg-alt);padding:.15rem .4rem;border-radius:3px;word-break:break-all">src/nhid_policy_engine_v1.py</code>
+            <code style="font-size:.82rem;color:var(--teal-bright);background:var(--bg-alt);padding:.15rem .4rem;border-radius:3px;word-break:break-all">src/nhid_policy_engine_v1.py</code>
             <p style="color:var(--body);font-size:.93rem;line-height:1.75;margin:.75rem 0 0">Pure Python reference implementation of the four core controls plus the supplemental ATR-01 audit-trail control, and a bot&#8209;to&#8209;bot detection rule. No external dependencies; fully deterministic.</p>
           </div>
         </div>
@@ -199,7 +200,7 @@
         <div style="display:flex;align-items:flex-start;gap:1rem;flex-wrap:wrap">
           <div style="flex:1;min-width:0">
             <h3 style="margin:0 0 .35rem;font-size:1.05rem">Conformance Test Suite</h3>
-            <code style="font-size:.82rem;color:var(--blue);background:var(--bg-alt);padding:.15rem .4rem;border-radius:3px;word-break:break-all">tests/nhid_conformance_test_suite_v1.yaml</code>
+            <code style="font-size:.82rem;color:var(--teal-bright);background:var(--bg-alt);padding:.15rem .4rem;border-radius:3px;word-break:break-all">tests/nhid_conformance_test_suite_v1.yaml</code>
             <p style="color:var(--body);font-size:.93rem;line-height:1.75;margin:.75rem 0 0">18 machine&#8209;readable test cases covering every pass/fail/edge scenario in the v1.3 spec. Vendors can use this YAML file to self&#8209;validate their implementations.</p>
           </div>
         </div>
@@ -210,7 +211,7 @@
         <div style="display:flex;align-items:flex-start;gap:1rem;flex-wrap:wrap">
           <div style="flex:1;min-width:0">
             <h3 style="margin:0 0 .35rem;font-size:1.05rem">Failure Injection Harness</h3>
-            <code style="font-size:.82rem;color:var(--blue);background:var(--bg-alt);padding:.15rem .4rem;border-radius:3px;word-break:break-all">tests/failure_injection_harness.py</code>
+            <code style="font-size:.82rem;color:var(--teal-bright);background:var(--bg-alt);padding:.15rem .4rem;border-radius:3px;word-break:break-all">tests/failure_injection_harness.py</code>
             <p style="color:var(--body);font-size:.93rem;line-height:1.75;margin:.75rem 0 0">pytest&#8209;based test suite. Unit tests run with no server required. Integration tests validate a live FastAPI endpoint against malformed inputs and replay determinism.</p>
           </div>
         </div>
@@ -221,7 +222,7 @@
         <div style="display:flex;align-items:flex-start;gap:1rem;flex-wrap:wrap">
           <div style="flex:1;min-width:0">
             <h3 style="margin:0 0 .35rem;font-size:1.05rem">Trace Generator &amp; Example Traces</h3>
-            <code style="font-size:.82rem;color:var(--blue);background:var(--bg-alt);padding:.15rem .4rem;border-radius:3px;word-break:break-all">tests/trace_generator.py</code>
+            <code style="font-size:.82rem;color:var(--teal-bright);background:var(--bg-alt);padding:.15rem .4rem;border-radius:3px;word-break:break-all">tests/trace_generator.py</code>
             <p style="color:var(--body);font-size:.93rem;line-height:1.75;margin:.75rem 0 0">CLI script that produces canonical NHID&#8209;Clinical trace files. Ten pre&#8209;generated failure traces are available in the <code style="font-size:.82rem;background:var(--bg-alt);padding:.1rem .3rem;border-radius:3px">/traces</code> directory.</p>
           </div>
         </div>
@@ -232,7 +233,7 @@
         <div style="display:flex;align-items:flex-start;gap:1rem;flex-wrap:wrap">
           <div style="flex:1;min-width:0">
             <h3 style="margin:0 0 .35rem;font-size:1.05rem">Payer-Initiated Call Guidance</h3>
-            <code style="font-size:.82rem;color:var(--blue);background:var(--bg-alt);padding:.15rem .4rem;border-radius:3px;word-break:break-all">docs/payer-initiated-calls.md</code>
+            <code style="font-size:.82rem;color:var(--teal-bright);background:var(--bg-alt);padding:.15rem .4rem;border-radius:3px;word-break:break-all">docs/payer-initiated-calls.md</code>
             <p style="color:var(--body);font-size:.93rem;line-height:1.75;margin:.75rem 0 0">Policy-extension guide for the reversed call direction — a payer's AI agent calling a provider — covering how IDG&#8209;01, PDX&#8209;01, and DBC&#8209;01 apply when NHID&#8209;Clinical's controls were originally framed around inbound calls.</p>
           </div>
         </div>
@@ -243,18 +244,18 @@
         <div style="display:flex;align-items:flex-start;gap:1rem;flex-wrap:wrap">
           <div style="flex:1;min-width:0">
             <h3 style="margin:0 0 .35rem;font-size:1.05rem">SIP Header Integration Feedback</h3>
-            <code style="font-size:.82rem;color:var(--blue);background:var(--bg-alt);padding:.15rem .4rem;border-radius:3px;word-break:break-all">docs/sip-header-integration-feedback.md</code>
+            <code style="font-size:.82rem;color:var(--teal-bright);background:var(--bg-alt);padding:.15rem .4rem;border-radius:3px;word-break:break-all">docs/sip-header-integration-feedback.md</code>
             <p style="color:var(--body);font-size:.93rem;line-height:1.75;margin:.75rem 0 0">Standards-feedback position paper proposing an <code style="font-size:.8rem;background:var(--bg-alt);padding:.1rem .3rem;border-radius:3px">Identity-Disclosure</code> SIP header convention for AI voice agents, referencing the IETF AgentID Protocol draft.</p>
           </div>
         </div>
       </div>
 
       <!-- Interactive demo -->
-      <div style="border:1px solid var(--border);border-radius:8px;padding:1.5rem 1.75rem;margin-bottom:2.5rem;background:var(--paper);border-left:3px solid var(--blue)">
+      <div style="border:1px solid var(--border);border-radius:8px;padding:1.5rem 1.75rem;margin-bottom:2.5rem;background:var(--paper);border-left:3px solid var(--teal-bright)">
         <div style="flex:1;min-width:0">
           <h3 style="margin:0 0 .35rem;font-size:1.05rem">Policy Engine Playground <span style="font-size:.75rem;font-weight:500;color:var(--ink-soft);margin-left:.4rem">experimental</span></h3>
           <p style="color:var(--body);font-size:.93rem;line-height:1.75;margin:.75rem 0 .85rem">Browser-based interactive demo of the disclosure policy rules. Paste or select a canonical event JSON, run the engine, and inspect the deterministic trace output. Identical input always produces identical output.</p>
-          <a href="/simulator.html" style="display:inline-block;background:var(--blue);color:#fff;font-size:.85rem;font-weight:600;padding:.45rem 1rem;border-radius:5px;text-decoration:none">Open Playground →</a>
+          <a class="primary-pill" href="/simulator.html">Open Playground →</a>
         </div>
       </div>
 
@@ -277,15 +278,15 @@ python tests/trace_generator.py --offline</pre>
         <p style="color:var(--body);font-size:.93rem;line-height:1.75;margin:0 0 1rem">A public conformance endpoint is available for integration testing without self-hosting. Send any NHID-Clinical v1.3 event and receive a structured policy decision.</p>
         <div style="background:var(--bg-alt);border:1px solid var(--border);border-radius:6px;padding:1.1rem 1.25rem;margin-bottom:1rem">
           <p style="margin:0 0 .4rem;font-size:.8rem;font-weight:600;letter-spacing:.04em;color:var(--ink-soft);text-transform:uppercase">Endpoint</p>
-          <code style="font-size:.85rem;color:var(--blue);word-break:break-all">POST https://gfvq4swdtf.execute-api.us-east-1.amazonaws.com/prod/v1/conformance/check</code>
+          <code style="font-size:.85rem;color:var(--teal-bright);word-break:break-all">POST https://gfvq4swdtf.execute-api.us-east-1.amazonaws.com/prod/v1/conformance/check</code>
         </div>
-        <p style="color:var(--body);font-size:.88rem;line-height:1.75;margin:0 0 .75rem">Requests require an <code style="font-size:.84rem;background:var(--bg-alt);padding:.1rem .3rem;border-radius:3px">x-api-key</code> header. The <a href="/simulator.html" style="color:var(--blue)">Governance Simulator</a> uses a rate-limited demo key automatically. To obtain a key for your integration, contact <a href="mailto:contact@nhid-clinical.org" style="color:var(--blue)">contact@nhid-clinical.org</a>.</p>
+        <p style="color:var(--body);font-size:.88rem;line-height:1.75;margin:0 0 .75rem">Requests require an <code style="font-size:.84rem;background:var(--bg-alt);padding:.1rem .3rem;border-radius:3px">x-api-key</code> header. The <a href="/simulator.html" style="color:var(--teal-bright)">Governance Simulator</a> uses a rate-limited demo key automatically. To obtain a key for your integration, contact <a href="mailto:contact@nhid-clinical.org" style="color:var(--teal-bright)">contact@nhid-clinical.org</a>.</p>
         <pre style="background:var(--bg-alt);border:1px solid var(--border);border-radius:6px;padding:1.1rem 1.25rem;font-size:.82rem;line-height:1.8;overflow-x:auto;color:var(--body);margin:0">curl -s -X POST \
   https://gfvq4swdtf.execute-api.us-east-1.amazonaws.com/prod/v1/conformance/check \
   -H "x-api-key: YOUR_KEY" \
   -H "Content-Type: application/json" \
   -d '{"session":{"turn_count":1,"escalation_path_available":true},"event":{...}}'</pre>
-        <p style="color:var(--body);font-size:.85rem;line-height:1.75;margin:.85rem 0 0">Returns: <code style="font-size:.82rem;background:var(--bg-alt);padding:.1rem .3rem;border-radius:3px">{"conformant": true/false, "action": "...", "violations": [...], "next_state": "...", "cas": {"score": ..., "tier": ...}}</code>. See <a href="https://github.com/NHID-Clinical/NHID-Clinical/blob/main/tests/sample_request.json" style="color:var(--blue)">sample_request.json</a> for a complete example.</p>
+        <p style="color:var(--body);font-size:.85rem;line-height:1.75;margin:.85rem 0 0">Returns: <code style="font-size:.82rem;background:var(--bg-alt);padding:.1rem .3rem;border-radius:3px">{"conformant": true/false, "action": "...", "violations": [...], "next_state": "...", "cas": {"score": ..., "tier": ...}}</code>. See <a href="https://github.com/NHID-Clinical/NHID-Clinical/blob/main/tests/sample_request.json" style="color:var(--teal-bright)">sample_request.json</a> for a complete example.</p>
       </div>
 
       <!-- ── CAS Tiers ──────────────────────────────────────────────────────── -->
@@ -355,14 +356,14 @@ python tests/trace_generator.py --offline</pre>
       {"role": "bot",  "message": "Thanks. I am an automated system.", "secondsFromStart": 5.8}
     ]
   }'</pre>
-        <p style="color:var(--body);font-size:.85rem;line-height:1.75;margin:0">Returns <code style="font-size:.82rem;background:var(--bg-alt);padding:.1rem .3rem;border-radius:3px">"conformant": false</code> with an <code style="font-size:.82rem;background:var(--bg-alt);padding:.1rem .3rem;border-radius:3px">IDG-01</code> violation. Move the disclosure to the first message and re-run — result flips to <code style="font-size:.82rem;background:var(--bg-alt);padding:.1rem .3rem;border-radius:3px">"conformant": true</code>. See <a href="/interoperability.html" style="color:var(--blue)">interoperability demo →</a> for full examples.</p>
+        <p style="color:var(--body);font-size:.85rem;line-height:1.75;margin:0">Returns <code style="font-size:.82rem;background:var(--bg-alt);padding:.1rem .3rem;border-radius:3px">"conformant": false</code> with an <code style="font-size:.82rem;background:var(--bg-alt);padding:.1rem .3rem;border-radius:3px">IDG-01</code> violation. Move the disclosure to the first message and re-run — result flips to <code style="font-size:.82rem;background:var(--bg-alt);padding:.1rem .3rem;border-radius:3px">"conformant": true</code>. See <a href="/interoperability.html" style="color:var(--teal-bright)">interoperability demo →</a> for full examples.</p>
       </div>
 
       <!-- ── Interoperability ──────────────────────────────────────────────── -->
 
-      <div style="margin-top:2.5rem;padding:1.25rem 1.5rem;background:var(--bg-alt);border-left:3px solid var(--blue);border-radius:0 6px 6px 0">
+      <div style="margin-top:2.5rem;padding:1.25rem 1.5rem;background:var(--bg-alt);border-left:3px solid var(--teal-bright);border-radius:0 6px 6px 0">
         <p style="font-weight:700;margin:0 0 .4rem;color:var(--body)">Vendor Interoperability</p>
-        <p style="color:var(--body);font-size:.93rem;line-height:1.75;margin:0">The <code style="font-size:.82rem;background:var(--paper);padding:.1rem .3rem;border-radius:3px">adapters/</code> directory contains format adapters that convert vendor-specific call transcripts to NHID-Clinical event traces. Available: VAPI, Twilio Voice Intelligence, Vonage, Retell AI, Amazon Connect Contact Lens. See the <a href="/interoperability.html" style="color:var(--blue);font-weight:500">interoperability demo →</a></p>
+        <p style="color:var(--body);font-size:.93rem;line-height:1.75;margin:0">The <code style="font-size:.82rem;background:var(--paper);padding:.1rem .3rem;border-radius:3px">adapters/</code> directory contains format adapters that convert vendor-specific call transcripts to NHID-Clinical event traces. Available: VAPI, Twilio Voice Intelligence, Vonage, Retell AI, Amazon Connect Contact Lens. See the <a href="/interoperability.html" style="color:var(--teal-bright);font-weight:500">interoperability demo →</a></p>
       </div>
 
       <!-- ── Disclaimer ─────────────────────────────────────────────────── -->

--- a/evidence-pack.html
+++ b/evidence-pack.html
@@ -16,7 +16,7 @@
   <style>
     .guarantee-card {
       padding: 1rem 1.25rem;
-      border-left: 3px solid var(--blue);
+      border-left: 3px solid var(--teal-bright);
       background: var(--bg-alt);
       border-radius: 0 6px 6px 0;
     }
@@ -151,13 +151,14 @@
 <div class="nav-backdrop" id="nav-backdrop"></div>
 
 <main>
-  <section class="inner-hero">
-    <div class="container inner-hero-grid">
+  <section class="inner-hero" style="position:relative;overflow:clip">
+    <div class="hero-glow" aria-hidden="true"></div>
+    <div class="container inner-hero-grid" style="position:relative;z-index:1">
       <div>
       <div class="crumbs"><a href="/">Home</a><span>/</span><a href="/developers.html">Developers</a><span>/</span><span>Evidence Pack</span></div>
       <p class="eyebrow">For Enterprise &amp; Procurement Teams · v1.3</p>
-      <h1>Evidence Pack</h1>
-      <p class="lede">System behavior guarantees, a worked failure trace, and the audit readiness model — <strong>for teams evaluating adoption.</strong> Self-attested, open for community review.</p>
+      <h1 class="reveal">Evidence Pack</h1>
+      <p class="lede reveal">System behavior guarantees, a worked failure trace, and the audit readiness model — <strong>for teams evaluating adoption.</strong> Self-attested, open for community review.</p>
       <div class="payer-hero-visual" style="margin-top:1.25rem">
         <picture class="premium-3d">
           <img src="/assets/images/3d-svg/trust-stack.svg" alt="Diagram of the five-layer NHID-Clinical trust stack: STIR/SHAKEN, NHID-Clinical v1.3, NHID-Auth v2, FHIR AuditEvent R4, and OpenTelemetry, over the Layer 0 NPI gap."/>
@@ -308,7 +309,7 @@ A payer auditing this session would see:
 
       <!-- ── 3. Failure & Attack Simulation Coverage ──────────────────────── -->
       <h2 style="margin-top:2.5rem">4. Failure &amp; Attack Simulation Coverage</h2>
-      <p style="color:var(--body);font-size:.95rem;line-height:1.75;margin-top:.75rem">The <a href="/developers.html" style="color:var(--blue)">failure injection harness</a> covers the following scenarios:</p>
+      <p style="color:var(--body);font-size:.95rem;line-height:1.75;margin-top:.75rem">The <a href="/developers.html" style="color:var(--teal-bright)">failure injection harness</a> covers the following scenarios:</p>
 
       <table class="premium-metrics" style="margin-top:1rem">
         <thead>
@@ -404,9 +405,9 @@ t=00:00.152  PERSIST    Event written — disclosure_timestamp set</pre>
 
       <h2 style="margin-top:2.5rem">Related Resources</h2>
       <ul style="list-style:none;padding:0;display:grid;gap:.75rem;margin-top:1rem">
-        <li><a href="/developers.html" style="font-weight:600;color:var(--blue)">Developers reference &rarr;</a> <span style="color:var(--body)">— API, traces, test suite</span></li>
-        <li><a href="/shadow-evaluation-guide.html" style="font-weight:600;color:var(--blue)">Shadow Evaluation Guide &rarr;</a> <span style="color:var(--body)">— 90-day payer observation process</span></li>
-        <li><a href="/governance-simulator.html" style="font-weight:600;color:var(--blue)">Governance Simulator &rarr;</a> <span style="color:var(--body)">— deterministic control walkthrough</span></li>
+        <li><a href="/developers.html" style="font-weight:600;color:var(--teal-bright)">Developers reference &rarr;</a> <span style="color:var(--body)">— API, traces, test suite</span></li>
+        <li><a href="/shadow-evaluation-guide.html" style="font-weight:600;color:var(--teal-bright)">Shadow Evaluation Guide &rarr;</a> <span style="color:var(--body)">— 90-day payer observation process</span></li>
+        <li><a href="/governance-simulator.html" style="font-weight:600;color:var(--teal-bright)">Governance Simulator &rarr;</a> <span style="color:var(--body)">— deterministic control walkthrough</span></li>
       </ul>
 
     </div>

--- a/faq.html
+++ b/faq.html
@@ -133,12 +133,13 @@
 <div class="nav-backdrop" id="nav-backdrop"></div>
 
 <main>
-  <section class="inner-hero">
-    <div class="container">
+  <section class="inner-hero" style="position:relative;overflow:clip">
+    <div class="hero-glow" aria-hidden="true"></div>
+    <div class="container" style="position:relative;z-index:1">
       <div class="crumbs"><a href="/">Home</a><span>/</span><span>FAQ</span></div>
       <p class="eyebrow">Frequently Asked Questions</p>
-      <h1>NHID-Clinical FAQ</h1>
-      <p class="lede">What this proposal is, what it is not, and how to get involved.</p>
+      <h1 class="reveal">NHID-Clinical FAQ</h1>
+      <p class="lede reveal">What this proposal is, what it is not, and how to get involved.</p>
     </div>
   </section>
   <section class="page-section">
@@ -172,7 +173,7 @@
             <li>Provide a clear, easy path to a human when requested</li>
             <li>Maintain basic logs of the interaction</li>
           </ul>
-          <p style="margin-top:.75rem">The full proposal document has detailed discussion of each. <a href="/specs/NHID-Clinical-v1.3-Overview.pdf" download style="color:var(--blue);font-weight:600">Download the PDF →</a></p>
+          <p style="margin-top:.75rem">The full proposal document has detailed discussion of each. <a href="/specs/NHID-Clinical-v1.3-Overview.pdf" download style="color:var(--teal-bright);font-weight:600">Download the PDF →</a></p>
         </div>
         <div class="faq-item">
           <h3>Who is this for?</h3>
@@ -195,7 +196,7 @@
         </div>
         <div class="faq-item">
           <h3>Can I get feedback on my implementation?</h3>
-          <p>Informal peer feedback is available on a limited basis. Email <a href="mailto:contact@nhid-clinical.org" style="color:var(--blue);font-weight:600">contact@nhid-clinical.org</a> with your context. This is not certification or formal assessment.</p>
+          <p>Informal peer feedback is available on a limited basis. Email <a href="mailto:contact@nhid-clinical.org" style="color:var(--teal-bright);font-weight:600">contact@nhid-clinical.org</a> with your context. This is not certification or formal assessment.</p>
         </div>
         <div class="faq-item">
           <h3>What is the NIST connection?</h3>
@@ -206,7 +207,7 @@
           <pre class="faq-code">Email:   contact@nhid-clinical.org
 GitHub:  github.com/NHID-Clinical/NHID-Clinical/discussions</pre>
           <p>Real-world experience from payers and implementers is what this proposal most needs.</p>
-          <p><a href="/for-payers.html" style="color:var(--blue);font-weight:700">Start a pilot →</a></p>
+          <p><a href="/for-payers.html" style="color:var(--teal-bright);font-weight:700">Start a pilot →</a></p>
         </div>
       </div>
     </div>

--- a/for-payers.html
+++ b/for-payers.html
@@ -21,7 +21,7 @@
       width: 26px;
       height: 26px;
       border-radius: 50%;
-      background: var(--blue);
+      background: var(--teal-bright);
       color: #fff;
       font-size: .8rem;
       font-weight: 700;
@@ -39,7 +39,7 @@
     .pilot-card {
       padding: 1.2rem 1.5rem;
       background: var(--bg-alt);
-      border-left: 3px solid var(--blue);
+      border-left: 3px solid var(--teal-bright);
       border-radius: 0 6px 6px 0;
     }
     .pilot-card p, .pilot-card li { color: var(--body); font-size: .93rem; line-height: 1.75; }
@@ -50,7 +50,7 @@
       background: var(--paper);
       padding: .1rem .35rem;
       border-radius: 3px;
-      color: var(--blue);
+      color: var(--teal-bright);
     }
     .pilot-card pre {
       margin: .65rem 0 0;
@@ -185,13 +185,14 @@
 <div class="nav-backdrop" id="nav-backdrop"></div>
 
 <main>
-  <section class="inner-hero">
-    <div class="container inner-hero-grid">
+  <section class="inner-hero" style="position:relative;overflow:clip">
+    <div class="hero-glow" aria-hidden="true"></div>
+    <div class="container inner-hero-grid" style="position:relative;z-index:1">
       <div>
         <div class="crumbs"><a href="/">Home</a><span>/</span><span>For Payers</span></div>
         <p class="eyebrow">Shadow Evaluation · 90 Days · Observe Only</p>
-        <h1>For Payers: Shadow Evaluation Guide</h1>
-        <p class="lede">Establish a behavioral baseline for AI voice agent transparency — <strong>zero vendor changes, zero production risk.</strong> Run in parallel with live traffic; observe, collect evidence, decide what to require later.</p>
+        <h1 class="reveal">For Payers: Shadow Evaluation Guide</h1>
+        <p class="lede reveal">Establish a behavioral baseline for AI voice agent transparency — <strong>zero vendor changes, zero production risk.</strong> Run in parallel with live traffic; observe, collect evidence, decide what to require later.</p>
         <div class="payer-hero-visual">
           <picture class="premium-3d">
             <img src="/assets/images/3d-svg/latency-split.svg" alt="Diagram contrasting unverified impersonation latency with the verified NHID-Clinical trust pathway: early disclosure, pre-data checkpoint, escalation, and sealed audit."/>
@@ -233,7 +234,7 @@
           <p>You get impersonation-latency and disclosure metrics on your own traffic in a <a href="https://github.com/NHID-Clinical/NHID-Clinical/blob/main/docs/pilot-kit/pilot-report-template.md">ready-to-share report</a>. Use it to decide what to require of vendors.</p>
         </div>
       </div>
-      <p style="margin-top:1rem;font-size:.95rem"><a href="/shadow-evaluation-guide.html" style="font-weight:600;color:var(--blue)">See the full shadow-evaluation guide →</a></p>
+      <p style="margin-top:1rem;font-size:.95rem"><a href="/shadow-evaluation-guide.html" style="font-weight:600;color:var(--teal-bright)">See the full shadow-evaluation guide →</a></p>
     </div>
   </section>
 
@@ -327,16 +328,16 @@
 
       <div class="callout" role="note" style="margin-top:2.5rem">
         <strong>v1.3 vs. v2:</strong> v1.3 covers disclosure behavior and audit trails — suitable for shadow evaluations today. v2 adds cryptographic agent identity (NHID-Auth v2) for when you must verify the agent was authorized by the provider it claims to represent. NPIs are public; v1.3 alone does not prove authorization.
-        <a href="/roadmap.html" style="color:var(--blue);font-weight:600;display:inline-block;margin-top:.5rem">Read the v2 roadmap →</a>
+        <a href="/roadmap.html" style="color:var(--teal-bright);font-weight:600;display:inline-block;margin-top:.5rem">Read the v2 roadmap →</a>
       </div>
 
       <h2 style="margin-top:2.5rem">Evaluation Resources</h2>
       <ul style="list-style:none;padding:0;display:grid;gap:.75rem;margin-top:1rem">
-        <li><a href="https://github.com/NHID-Clinical/NHID-Clinical/blob/main/docs/executive-brief.md" style="font-weight:600;color:var(--blue)">Executive Brief →</a> <span style="color:var(--body)">— one-page overview for leadership and procurement</span></li>
-        <li><a href="/shadow-evaluation-guide.html" style="font-weight:600;color:var(--blue)">Shadow Evaluation Guide →</a> <span style="color:var(--body)">— full 90-day process</span></li>
-        <li><a href="/evidence-pack.html" style="font-weight:600;color:var(--blue)">Evidence Pack →</a> <span style="color:var(--body)">— guarantees, failure trace, audit model</span></li>
-        <li><a href="/regulatory-alignment.html" style="font-weight:600;color:var(--blue)">Regulatory Alignment →</a> <span style="color:var(--body)">— CMS-0057-F, MACPAC, DOJ FCA, state AI laws</span></li>
-        <li><a href="/demo.html" style="font-weight:600;color:var(--blue)">Reference demonstration line →</a> <span style="color:var(--body)">— hear the disclosure controls in a real call</span></li>
+        <li><a href="https://github.com/NHID-Clinical/NHID-Clinical/blob/main/docs/executive-brief.md" style="font-weight:600;color:var(--teal-bright)">Executive Brief →</a> <span style="color:var(--body)">— one-page overview for leadership and procurement</span></li>
+        <li><a href="/shadow-evaluation-guide.html" style="font-weight:600;color:var(--teal-bright)">Shadow Evaluation Guide →</a> <span style="color:var(--body)">— full 90-day process</span></li>
+        <li><a href="/evidence-pack.html" style="font-weight:600;color:var(--teal-bright)">Evidence Pack →</a> <span style="color:var(--body)">— guarantees, failure trace, audit model</span></li>
+        <li><a href="/regulatory-alignment.html" style="font-weight:600;color:var(--teal-bright)">Regulatory Alignment →</a> <span style="color:var(--body)">— CMS-0057-F, MACPAC, DOJ FCA, state AI laws</span></li>
+        <li><a href="/demo.html" style="font-weight:600;color:var(--teal-bright)">Reference demonstration line →</a> <span style="color:var(--body)">— hear the disclosure controls in a real call</span></li>
       </ul>
 
     </div>

--- a/gov-sim.html
+++ b/gov-sim.html
@@ -105,7 +105,7 @@ body::before{
 .brand{display:flex;align-items:center;gap:.6rem;margin-bottom:1.25rem}
 .brand-dot{
   width:8px;height:8px;border-radius:50%;
-  background:var(--blue);flex-shrink:0;
+  background:var(--teal-bright);flex-shrink:0;
   box-shadow:0 0 0 3px rgba(11,110,188,0.15);
 }
 .brand-name{font-size:13px;font-weight:600;color:var(--t1);letter-spacing:-.01em}
@@ -129,7 +129,7 @@ body::before{
   transition:border-color .15s,box-shadow .15s;
 }
 [data-theme="dark"] .sc-sel{background-color:rgba(15,23,42,0.5)}
-.sc-sel:focus{border-color:var(--blue);box-shadow:0 0 0 3px rgba(11,110,188,0.12)}
+.sc-sel:focus{border-color:var(--teal-bright);box-shadow:0 0 0 3px rgba(11,110,188,0.12)}
 .sc-meta{font-size:11px;color:var(--t3);line-height:1.6;margin-top:5px;min-height:1.4rem}
 .sb-div{border:none;border-top:1px solid var(--gb);margin:.7rem 0}
 
@@ -141,7 +141,7 @@ body::before{
 }
 .cond input[type="checkbox"]{
   width:14px;height:14px;border-radius:3px;
-  accent-color:var(--blue);cursor:pointer;flex-shrink:0;
+  accent-color:var(--teal-bright);cursor:pointer;flex-shrink:0;
 }
 
 /* Run button */
@@ -149,7 +149,7 @@ body::before{
   display:block;width:100%;
   padding:.52rem 1rem;font-size:13px;font-weight:600;
   color:#fff;
-  background:linear-gradient(135deg,var(--blue) 0%,#0a5fa8 100%);
+  background:linear-gradient(135deg,var(--teal-bright) 0%,#0a5fa8 100%);
   border:none;border-radius:var(--rs);cursor:pointer;
   box-shadow:0 2px 8px rgba(11,110,188,0.28),0 1px 2px rgba(11,110,188,0.1);
   transition:opacity .15s,box-shadow .15s,transform .1s;
@@ -167,7 +167,7 @@ body::before{
   transition:background .15s,color .15s;
 }
 [data-theme="dark"] .theme-btn{background:rgba(15,23,42,0.5)}
-.theme-btn:hover{color:var(--blue)}
+.theme-btn:hover{color:var(--teal-bright)}
 
 /* ── Main ──────────────────────────────────────────────────── */
 .main{flex:1;overflow-y:auto;padding:1.5rem;display:flex;flex-direction:column;gap:1rem}
@@ -288,7 +288,7 @@ body::before{
   border:1px solid rgba(11,110,188,0.1);
   margin-top:1rem;
 }
-.devlink a{color:var(--blue);text-decoration:none}
+.devlink a{color:var(--teal-bright);text-decoration:none}
 .devlink a:hover{text-decoration:underline}
 .devlink code{font-family:'Courier New',Courier,monospace;font-size:11px}
 

--- a/governance-simulator.html
+++ b/governance-simulator.html
@@ -451,14 +451,14 @@
       <h1 style="font-family:'Inter',sans-serif;font-size:1.35rem;font-weight:700;color:var(--ink);margin:0">Governance Simulator</h1>
       <p style="font-size:.82rem;color:var(--body);margin:.2rem 0 0">Synthetic data only · Illustrative · Not a compliance tool</p>
     </div>
-    <a href="/developers.html" style="font-size:.82rem;color:var(--blue);font-weight:600">Full technical reference →</a>
+    <a href="/developers.html" style="font-size:.82rem;color:var(--teal-bright);font-weight:600">Full technical reference →</a>
   </div>
 
   <div style="max-width:1400px;margin:0 auto 1rem;display:flex;align-items:center;justify-content:space-between;flex-wrap:wrap;gap:.75rem;padding:.7rem 1rem;border:1px solid var(--sim-gb,rgba(8,42,91,.10));border-radius:12px;background:var(--blue-soft,#eaf5fb)">
     <div style="font-size:.85rem;color:var(--ink)">
       <strong>Prefer a hands-on walkthrough?</strong> Try the interactive Zero Latency simulator — a guided, scenario-based training experience for the same NHID-Clinical controls.
     </div>
-    <a href="https://nhid-clinical.github.io/Simulator/" style="font-size:.82rem;color:var(--blue);font-weight:600;white-space:nowrap">Open the interactive simulator →</a>
+    <a href="https://nhid-clinical.github.io/Simulator/" style="font-size:.82rem;color:var(--teal-bright);font-weight:600;white-space:nowrap">Open the interactive simulator →</a>
   </div>
 
   <div class="sim-app">
@@ -486,7 +486,7 @@
             <option value="spoofed-identity">Spoofed Identity Call</option>
           </select>
           <p class="sim-sc-meta" id="sc-meta" aria-live="polite"></p>
-          <button type="button" id="try-failing-btn" style="margin-top:.5rem;background:none;border:none;cursor:pointer;font-size:.82rem;color:var(--blue);padding:0;text-decoration:underline;text-underline-offset:3px">Try a failing example (IDG-01 violation) ↓</button>
+          <button type="button" id="try-failing-btn" style="margin-top:.5rem;background:none;border:none;cursor:pointer;font-size:.82rem;color:var(--teal-bright);padding:0;text-decoration:underline;text-underline-offset:3px">Try a failing example (IDG-01 violation) ↓</button>
         </div>
 
         <hr class="sim-div">

--- a/icon-system.html
+++ b/icon-system.html
@@ -133,12 +133,13 @@
 <div class="nav-backdrop" id="nav-backdrop"></div>
 
 <main>
-  <section class="inner-hero">
-    <div class="container">
+  <section class="inner-hero" style="position:relative;overflow:clip">
+    <div class="hero-glow" aria-hidden="true"></div>
+    <div class="container" style="position:relative;z-index:1">
       <div class="crumbs"><a href="/">Home</a><span>/</span><span>Icon System</span></div>
       <p class="eyebrow">Iconography · 24 Core Icons · Voice-State Matrix</p>
-      <h1>NHID-Clinical Icon System</h1>
-      <p class="lede">A hexagon-framed icon pack for AI voice-agent identity disclosure &amp; authorization — built to read clearly across patient apps, clinical dashboards, and printed disclosure documents.</p>
+      <h1 class="reveal">NHID-Clinical Icon System</h1>
+      <p class="lede reveal">A hexagon-framed icon pack for AI voice-agent identity disclosure &amp; authorization — built to read clearly across patient apps, clinical dashboards, and printed disclosure documents.</p>
       <div style="display:flex;gap:10px;flex-wrap:wrap;margin-top:18px">
         <span class="badge-spec">24 core icons</span>
         <span class="badge-teal">20 voice states</span>

--- a/identity-layer.html
+++ b/identity-layer.html
@@ -133,12 +133,13 @@
 <div class="nav-backdrop" id="nav-backdrop"></div>
 
 <main>
-  <section class="inner-hero">
-    <div class="container">
+  <section class="inner-hero" style="position:relative;overflow:clip">
+    <div class="hero-glow" aria-hidden="true"></div>
+    <div class="container" style="position:relative;z-index:1">
       <div class="crumbs"><a href="/">Home</a><span>/</span><a href="/news.html">News</a><span>/</span><span>Commentary</span></div>
       <p class="eyebrow">Commentary</p>
-      <h1>Why Identity Is the Missing Layer of Responsible AI</h1>
-      <p class="lede">Independent commentary on Impersonation Latency and the five NHID-Clinical controls, mapped to NIST AI RMF, ISO/IEC 42001, and HIPAA.</p>
+      <h1 class="reveal">Why Identity Is the Missing Layer of Responsible AI</h1>
+      <p class="lede reveal">Independent commentary on Impersonation Latency and the five NHID-Clinical controls, mapped to NIST AI RMF, ISO/IEC 42001, and HIPAA.</p>
     </div>
   </section>
   <section class="page-section">

--- a/implementation-review.html
+++ b/implementation-review.html
@@ -133,18 +133,19 @@
 <div class="nav-backdrop" id="nav-backdrop"></div>
 
 <main>
-  <section class="inner-hero">
-    <div class="container">
+  <section class="inner-hero" style="position:relative;overflow:clip">
+    <div class="hero-glow" aria-hidden="true"></div>
+    <div class="container" style="position:relative;z-index:1">
       <div class="crumbs"><a href="/">Home</a><span>/</span><span>Implementation Review</span></div>
-      <h1>Implementation Review</h1>
-      <p class="lede">This content is available to interested parties on request.</p>
+      <h1 class="reveal">Implementation Review</h1>
+      <p class="lede reveal">This content is available to interested parties on request.</p>
     </div>
   </section>
   <section class="page-section">
     <div class="container" style="max-width:52rem">
       <p style="color:var(--body);font-size:1rem;line-height:1.8;margin-bottom:1.5rem">Detailed implementation review and peer feedback are shared directly with interested teams — payer operations staff, AI platform developers, and compliance reviewers who are actively working in this space.</p>
       <p style="color:var(--body);font-size:1rem;line-height:1.8;margin-bottom:1.5rem">To receive information about the peer feedback process, reach out and briefly describe your context.</p>
-      <p style="color:var(--body);font-size:1rem;line-height:1.8"><strong>Email:</strong> <a href="mailto:contact@nhid-clinical.org" style="color:var(--blue);font-weight:600">contact@nhid-clinical.org</a></p>
+      <p style="color:var(--body);font-size:1rem;line-height:1.8"><strong>Email:</strong> <a href="mailto:contact@nhid-clinical.org" style="color:var(--teal-bright);font-weight:600">contact@nhid-clinical.org</a></p>
     </div>
   </section>
   <section class="container closing-section">

--- a/interoperability.html
+++ b/interoperability.html
@@ -132,13 +132,14 @@
 <div class="nav-backdrop" id="nav-backdrop"></div>
 
 <main>
-  <section class="inner-hero">
-    <div class="container inner-hero-grid">
+  <section class="inner-hero" style="position:relative;overflow:clip">
+    <div class="hero-glow" aria-hidden="true"></div>
+    <div class="container inner-hero-grid" style="position:relative;z-index:1">
       <div>
         <div class="crumbs"><a href="/">Home</a><span>/</span><a href="/developers.html">Developers</a><span>/</span><span>Interoperability</span></div>
         <p class="eyebrow">Simulation · Twilio → NHID-Clinical</p>
-        <h1>Interoperability Demo</h1>
-        <p class="lede">This page shows how a real vendor's call transcript format can be mapped to an NHID-Clinical v1.3 event trace and evaluated for conformance. The adapter is open source — replace the sample input with real logs to test your own vendor.</p>
+        <h1 class="reveal">Interoperability Demo</h1>
+        <p class="lede reveal">This page shows how a real vendor's call transcript format can be mapped to an NHID-Clinical v1.3 event trace and evaluated for conformance. The adapter is open source — replace the sample input with real logs to test your own vendor.</p>
       </div>
     </div>
   </section>

--- a/news.html
+++ b/news.html
@@ -133,12 +133,13 @@
 <div class="nav-backdrop" id="nav-backdrop"></div>
 
 <main>
-  <section class="inner-hero">
-    <div class="container">
+  <section class="inner-hero" style="position:relative;overflow:clip">
+    <div class="hero-glow" aria-hidden="true"></div>
+    <div class="container" style="position:relative;z-index:1">
       <div class="crumbs"><a href="/">Home</a><span>/</span><span>News</span></div>
       <p class="eyebrow">Updates</p>
-      <h1>News &amp; Announcements</h1>
-      <p class="lede">Release notes, updates, and community milestones.</p>
+      <h1 class="reveal">News &amp; Announcements</h1>
+      <p class="lede reveal">Release notes, updates, and community milestones.</p>
     </div>
   </section>
   <section class="page-section">

--- a/privacy.html
+++ b/privacy.html
@@ -132,11 +132,12 @@
 <div class="nav-backdrop" id="nav-backdrop"></div>
 
 <main>
-  <section class="inner-hero">
-    <div class="container">
+  <section class="inner-hero" style="position:relative;overflow:clip">
+    <div class="hero-glow" aria-hidden="true"></div>
+    <div class="container" style="position:relative;z-index:1">
       <div class="crumbs"><a href="/">Home</a><span>/</span><span>Privacy Policy</span></div>
-      <h1>Privacy Policy</h1>
-      <p class="lede">How NHID-Clinical handles the limited personal information collected through this website.</p>
+      <h1 class="reveal">Privacy Policy</h1>
+      <p class="lede reveal">How NHID-Clinical handles the limited personal information collected through this website.</p>
     </div>
   </section>
 

--- a/proof.html
+++ b/proof.html
@@ -133,12 +133,13 @@
 <div class="nav-backdrop" id="nav-backdrop"></div>
 
 <main>
-  <section class="inner-hero">
-    <div class="container">
+  <section class="inner-hero" style="position:relative;overflow:clip">
+    <div class="hero-glow" aria-hidden="true"></div>
+    <div class="container" style="position:relative;z-index:1">
       <div class="crumbs"><a href="/">Home</a><span>/</span><a href="/developers.html">Developers</a><span>/</span><span>Proof Package</span></div>
       <p class="eyebrow">For Enterprise &amp; Procurement Teams · v1.3</p>
-      <h1>Technical Proof Package</h1>
-      <p class="lede">A summary of the deterministic guarantees, audit readiness model, and architectural properties of the NHID-Clinical reference implementation — for teams evaluating adoption or integration.</p>
+      <h1 class="reveal">Technical Proof Package</h1>
+      <p class="lede reveal">A summary of the deterministic guarantees, audit readiness model, and architectural properties of the NHID-Clinical reference implementation — for teams evaluating adoption or integration.</p>
     </div>
   </section>
 
@@ -153,19 +154,19 @@
       <h2 style="margin-top:0">1. System Behavior Specification</h2>
 
       <div style="display:grid;gap:.75rem;margin-top:1rem">
-        <div style="padding:1rem 1.25rem;border-left:3px solid var(--blue);background:var(--bg-alt);border-radius:0 4px 4px 0">
+        <div style="padding:1rem 1.25rem;border-left:3px solid var(--teal-bright);background:var(--bg-alt);border-radius:0 4px 4px 0">
           <strong style="color:var(--ink)">Deterministic output</strong>
           <p style="color:var(--body);font-size:.92rem;line-height:1.7;margin:.3rem 0 0">Identical input event + identical policy version → identical trace output. The policy engine is a pure function with no side effects. Output does not depend on wall-clock time, process state, or external calls.</p>
         </div>
-        <div style="padding:1rem 1.25rem;border-left:3px solid var(--blue);background:var(--bg-alt);border-radius:0 4px 4px 0">
+        <div style="padding:1rem 1.25rem;border-left:3px solid var(--teal-bright);background:var(--bg-alt);border-radius:0 4px 4px 0">
           <strong style="color:var(--ink)">Replay guarantee</strong>
           <p style="color:var(--body);font-size:.92rem;line-height:1.7;margin:.3rem 0 0">Any stored trace can be replayed. The policy version is embedded in each event header. Replay with a different policy version is detected and flagged as a mismatch.</p>
         </div>
-        <div style="padding:1rem 1.25rem;border-left:3px solid var(--blue);background:var(--bg-alt);border-radius:0 4px 4px 0">
+        <div style="padding:1rem 1.25rem;border-left:3px solid var(--teal-bright);background:var(--bg-alt);border-radius:0 4px 4px 0">
           <strong style="color:var(--ink)">Failure invariants</strong>
           <p style="color:var(--body);font-size:.92rem;line-height:1.7;margin:.3rem 0 0">The engine never raises an unhandled exception. Invalid or malformed input returns a deterministic error trace (action: LOG_ONLY, recoverable: true). The caller always gets a response.</p>
         </div>
-        <div style="padding:1rem 1.25rem;border-left:3px solid var(--blue);background:var(--bg-alt);border-radius:0 4px 4px 0">
+        <div style="padding:1rem 1.25rem;border-left:3px solid var(--teal-bright);background:var(--bg-alt);border-radius:0 4px 4px 0">
           <strong style="color:var(--ink)">Idempotency</strong>
           <p style="color:var(--body);font-size:.92rem;line-height:1.7;margin:.3rem 0 0">Submitting the same request_id twice produces the same policy decision. The event store deduplicates on request_id at the PERSIST stage.</p>
         </div>
@@ -173,7 +174,7 @@
 
       <!-- ── 2. Failure simulation ──────────────────────────────────────── -->
       <h2 style="margin-top:2.5rem">2. Failure &amp; Attack Simulation Coverage</h2>
-      <p style="color:var(--body);font-size:.95rem;line-height:1.75;margin-top:.75rem">The <a href="/developers.html" style="color:var(--blue)">failure injection harness</a> covers the following scenarios:</p>
+      <p style="color:var(--body);font-size:.95rem;line-height:1.75;margin-top:.75rem">The <a href="/developers.html" style="color:var(--teal-bright)">failure injection harness</a> covers the following scenarios:</p>
 
       <table style="width:100%;border-collapse:collapse;margin-top:1rem;font-size:.88rem;color:var(--body)">
         <thead>
@@ -313,9 +314,9 @@ t=00:00.152  PERSIST    Event written — disclosure_timestamp set</pre>
       </div>
 
       <div style="margin-top:2rem;display:flex;flex-wrap:wrap;gap:1rem">
-        <a href="/developers.html" style="color:var(--blue);font-weight:600;font-size:.9rem">← Full technical reference</a>
-        <a href="/specs/NHID-Clinical-v1.3-Overview.pdf" download style="color:var(--blue);font-weight:600;font-size:.9rem">Download Public Brief (PDF) →</a>
-        <a href="mailto:contact@nhid-clinical.org" style="color:var(--blue);font-weight:600;font-size:.9rem">Contact →</a>
+        <a href="/developers.html" style="color:var(--teal-bright);font-weight:600;font-size:.9rem">← Full technical reference</a>
+        <a href="/specs/NHID-Clinical-v1.3-Overview.pdf" download style="color:var(--teal-bright);font-weight:600;font-size:.9rem">Download Public Brief (PDF) →</a>
+        <a href="mailto:contact@nhid-clinical.org" style="color:var(--teal-bright);font-weight:600;font-size:.9rem">Contact →</a>
       </div>
 
     </div>

--- a/registry.html
+++ b/registry.html
@@ -132,12 +132,13 @@
 <div class="nav-backdrop" id="nav-backdrop"></div>
 
 <main>
-  <section class="inner-hero">
-    <div class="container">
+  <section class="inner-hero" style="position:relative;overflow:clip">
+    <div class="hero-glow" aria-hidden="true"></div>
+    <div class="container" style="position:relative;z-index:1">
       <div class="crumbs"><a href="/">Home</a><span>/</span><span>Implementation Registry</span></div>
       <p class="eyebrow">Registry · June 2026</p>
-      <h1>Implementation Registry</h1>
-      <p class="lede">Self-attested NHID-Clinical implementations, with live NHID-CAS conformance badges.</p>
+      <h1 class="reveal">Implementation Registry</h1>
+      <p class="lede reveal">Self-attested NHID-Clinical implementations, with live NHID-CAS conformance badges.</p>
     </div>
   </section>
 

--- a/regulatory-alignment.html
+++ b/regulatory-alignment.html
@@ -133,12 +133,13 @@
 <div class="nav-backdrop" id="nav-backdrop"></div>
 
 <main>
-  <section class="inner-hero">
-    <div class="container">
+  <section class="inner-hero" style="position:relative;overflow:clip">
+    <div class="hero-glow" aria-hidden="true"></div>
+    <div class="container" style="position:relative;z-index:1">
       <div class="crumbs"><a href="/">Home</a><span>/</span><span>Regulatory Alignment</span></div>
       <p class="eyebrow">Alignment · June 2026</p>
-      <h1>Regulatory Alignment</h1>
-      <p class="lede">How NHID-Clinical maps to current healthcare AI governance requirements.</p>
+      <h1 class="reveal">Regulatory Alignment</h1>
+      <p class="lede reveal">How NHID-Clinical maps to current healthcare AI governance requirements.</p>
     </div>
   </section>
 

--- a/roadmap.html
+++ b/roadmap.html
@@ -133,13 +133,14 @@
 <div class="nav-backdrop" id="nav-backdrop"></div>
 
 <main>
-  <section class="inner-hero">
-    <div class="container inner-hero-grid">
+  <section class="inner-hero" style="position:relative;overflow:clip">
+    <div class="hero-glow" aria-hidden="true"></div>
+    <div class="container inner-hero-grid" style="position:relative;z-index:1">
       <div>
         <div class="crumbs"><a href="/">Home</a><span>/</span><span>Roadmap</span></div>
         <p class="eyebrow">Public Reference Implementation</p>
-        <h1>NHID-Auth v2: Cryptographic Agent Identity</h1>
-        <p class="lede">v1.3 establishes behavioral disclosure. v2 addresses what v1.3 cannot: verifying that an AI agent is actually authorized by the provider it claims to represent. NPIs are public via NPPES — any caller can present a real one. v2 makes that insufficient.</p>
+        <h1 class="reveal">NHID-Auth v2: Cryptographic Agent Identity</h1>
+        <p class="lede reveal">v1.3 establishes behavioral disclosure. v2 addresses what v1.3 cannot: verifying that an AI agent is actually authorized by the provider it claims to represent. NPIs are public via NPPES — any caller can present a real one. v2 makes that insufficient.</p>
       </div>
     </div>
   </section>
@@ -199,22 +200,22 @@
       <h2 style="margin-top:2.5rem">What the Reference Implementation Contains</h2>
       <div style="display:grid;gap:.85rem;margin-top:1.25rem">
 
-        <div style="padding:1.1rem 1.4rem;background:var(--bg-alt);border-left:3px solid var(--blue);border-radius:0 6px 6px 0">
+        <div style="padding:1.1rem 1.4rem;background:var(--bg-alt);border-left:3px solid var(--teal-bright);border-radius:0 6px 6px 0">
           <p style="margin:0 0 .4rem;font-weight:700;color:var(--ink);font-size:.95rem">Provider-Issued Agent Credentials</p>
           <p style="margin:0;color:var(--body);font-size:.93rem;line-height:1.75">An agent's identity is signed by the provider organization it acts for, with the provider's 10-digit NPI bound into the credential. A valid credential requires the provider's private key — something public NPI data cannot produce.</p>
         </div>
 
-        <div style="padding:1.1rem 1.4rem;background:var(--bg-alt);border-left:3px solid var(--blue);border-radius:0 6px 6px 0">
+        <div style="padding:1.1rem 1.4rem;background:var(--bg-alt);border-left:3px solid var(--teal-bright);border-radius:0 6px 6px 0">
           <p style="margin:0 0 .4rem;font-weight:700;color:var(--ink);font-size:.95rem">Scoped, Time-Limited Authorization</p>
           <p style="margin:0;color:var(--body);font-size:.93rem;line-height:1.75">Agents carry only the operations their provider granted (eligibility, claim status, prior authorization). Credentials expire on a short TTL. Delegation can be narrowed, never expanded — scope escalation is rejected at verification.</p>
         </div>
 
-        <div style="padding:1.1rem 1.4rem;background:var(--bg-alt);border-left:3px solid var(--blue);border-radius:0 6px 6px 0">
+        <div style="padding:1.1rem 1.4rem;background:var(--bg-alt);border-left:3px solid var(--teal-bright);border-radius:0 6px 6px 0">
           <p style="margin:0 0 .4rem;font-weight:700;color:var(--ink);font-size:.95rem">Immediate Withdrawal</p>
           <p style="margin:0;color:var(--body);font-size:.93rem;line-height:1.75">A provider can revoke a compromised or decommissioned agent; the next verification fails. Revocation works per-agent or per-delegation. No central authority required.</p>
         </div>
 
-        <div style="padding:1.1rem 1.4rem;background:var(--bg-alt);border-left:3px solid var(--blue);border-radius:0 6px 6px 0">
+        <div style="padding:1.1rem 1.4rem;background:var(--bg-alt);border-left:3px solid var(--teal-bright);border-radius:0 6px 6px 0">
           <p style="margin:0 0 .4rem;font-weight:700;color:var(--ink);font-size:.95rem">Call Binding and Out-of-Band Verification</p>
           <p style="margin:0;color:var(--body);font-size:.93rem;line-height:1.75">Credentials can be bound to a specific call session, preventing replay across calls. All checks happen via API, not in the voice channel — no latency added to the call. v1.3 behavioral controls run unchanged alongside the v2 layer.</p>
         </div>
@@ -240,14 +241,14 @@ python examples/issue_and_verify.py          # end-to-end credential walkthrough
         <li>Credential delivery during live calls is not yet standardized</li>
         <li>Shadow pilot data will inform the formal v2 specification document</li>
       </ul>
-      <p style="color:var(--body);font-size:.93rem;line-height:1.75;margin-top:1rem">The reference implementation is live. If you want to test it against your own threat model or contribute to the formal specification, <a href="mailto:contact@nhid-clinical.org" style="color:var(--blue)">contact us</a>.</p>
+      <p style="color:var(--body);font-size:.93rem;line-height:1.75;margin-top:1rem">The reference implementation is live. If you want to test it against your own threat model or contribute to the formal specification, <a href="mailto:contact@nhid-clinical.org" style="color:var(--teal-bright)">contact us</a>.</p>
 
       <p style="margin-top:2rem;font-size:.9rem;color:var(--ink-soft)">
-        <a href="/for-payers.html" style="color:var(--blue)">← Pilot Guide</a>
+        <a href="/for-payers.html" style="color:var(--teal-bright)">← Pilot Guide</a>
         &nbsp;·&nbsp;
-        <a href="/specification.html" style="color:var(--blue)">v1.3 Spec</a>
+        <a href="/specification.html" style="color:var(--teal-bright)">v1.3 Spec</a>
         &nbsp;·&nbsp;
-        <a href="/technical-stack.html" style="color:var(--blue)">Five-layer trust architecture →</a>
+        <a href="/technical-stack.html" style="color:var(--teal-bright)">Five-layer trust architecture →</a>
       </p>
 
     </div>

--- a/script-examples.html
+++ b/script-examples.html
@@ -133,13 +133,14 @@
 <div class="nav-backdrop" id="nav-backdrop"></div>
 
 <main>
-  <section class="inner-hero">
-    <div class="container inner-hero-grid">
+  <section class="inner-hero" style="position:relative;overflow:clip">
+    <div class="hero-glow" aria-hidden="true"></div>
+    <div class="container inner-hero-grid" style="position:relative;z-index:1">
       <div>
         <div class="crumbs"><a href="/">Home</a><span>/</span><span>Examples</span></div>
         <p class="eyebrow">Dialogue Examples</p>
-        <h1>What transparent disclosure sounds like.</h1>
-        <p class="lede">Side-by-side examples of AI voice agent openings — the kind of interaction this proposal is trying to encourage, and the kind it is trying to reduce.</p>
+        <h1 class="reveal">What transparent disclosure sounds like.</h1>
+        <p class="lede reveal">Side-by-side examples of AI voice agent openings — the kind of interaction this proposal is trying to encourage, and the kind it is trying to reduce.</p>
       </div>
     </div>
   </section>
@@ -251,7 +252,7 @@
     <div class="container" style="max-width:52rem">
       <h2>A note on scope</h2>
       <p style="color:var(--body);font-size:.95rem;line-height:1.75;margin-top:.75rem">These examples cover B2B administrative voice workflows — AI systems calling payer offices on behalf of providers or vendors. They do not apply to patient-facing calls, secure messaging, or internal systems.</p>
-      <p style="color:var(--body);font-size:.95rem;line-height:1.75;margin-top:.75rem">The examples above are illustrative, not exhaustive. If you encounter patterns in real calls that are not covered here, <a href="mailto:contact@nhid-clinical.org" style="color:var(--blue);font-weight:600">we want to hear about them</a>.</p>
+      <p style="color:var(--body);font-size:.95rem;line-height:1.75;margin-top:.75rem">The examples above are illustrative, not exhaustive. If you encounter patterns in real calls that are not covered here, <a href="mailto:contact@nhid-clinical.org" style="color:var(--teal-bright);font-weight:600">we want to hear about them</a>.</p>
     </div>
   </section>
 

--- a/sms-opt-in.html
+++ b/sms-opt-in.html
@@ -133,11 +133,12 @@
 <div class="nav-backdrop" id="nav-backdrop"></div>
 
 <main>
-  <section class="inner-hero">
-    <div class="container">
+  <section class="inner-hero" style="position:relative;overflow:clip">
+    <div class="hero-glow" aria-hidden="true"></div>
+    <div class="container" style="position:relative;z-index:1">
       <div class="crumbs"><a href="/">Home</a><span>/</span><span>Starter Pack by Text</span></div>
-      <h1>Get the starter pack by text</h1>
-      <p class="lede">Enter your mobile number and we'll send you a one-time text with a link to the NHID-Clinical shadow-evaluation guide — the no-cost way to start assessing AI voice-agent transparency.</p>
+      <h1 class="reveal">Get the starter pack by text</h1>
+      <p class="lede reveal">Enter your mobile number and we'll send you a one-time text with a link to the NHID-Clinical shadow-evaluation guide — the no-cost way to start assessing AI voice-agent transparency.</p>
     </div>
   </section>
 

--- a/technical-stack.html
+++ b/technical-stack.html
@@ -133,12 +133,13 @@
 <div class="nav-backdrop" id="nav-backdrop"></div>
 
 <main>
-  <section class="inner-hero">
-    <div class="container">
+  <section class="inner-hero" style="position:relative;overflow:clip">
+    <div class="hero-glow" aria-hidden="true"></div>
+    <div class="container" style="position:relative;z-index:1">
       <div class="crumbs"><a href="/">Home</a><span>/</span><span>Technical Stack</span></div>
       <p class="eyebrow">Architecture · Five Layers · Open Standards</p>
-      <h1>Technical Stack</h1>
-      <p class="lede">The trust stack for B2B healthcare voice AI.</p>
+      <h1 class="reveal">Technical Stack</h1>
+      <p class="lede reveal">The trust stack for B2B healthcare voice AI.</p>
     </div>
   </section>
 


### PR DESCRIPTION
## Summary
Completes the page-by-page redesign so **every** site page shares one visual language (previously only index, specification, and shadow-evaluation-guide had it). **Presentation only — no content, claims, numbers, or disclaimers change; all prose preserved verbatim.** Same discipline as the earlier redesign passes.

## Changes

**About page** (`about.html`) — full treatment
- Glow hero + eyebrow/breadcrumb + `.reveal`, plus an "at a glance" summary card (reused `hero-summary-card`/`spec-badge`) surfacing facts already on the page.

**18 content pages** — glow hero + de-blue
`demo, developers, evidence-pack, faq, for-payers, icon-system, identity-layer, implementation-review, interoperability, news, privacy, proof, registry, regulatory-alignment, roadmap, script-examples, sms-opt-in, technical-stack`
- Wrapped each `.inner-hero` in `.hero-glow` (soft teal/cyan) with `position:relative;overflow:clip`, and added a `.reveal` scroll-entrance to the H1/lede.
- De-blued inline `var(--blue)` accents (links, callout borders) to the teal brand tokens (`--teal-bright`).
- `developers`: converted the ad-hoc blue "Open Playground" button to the `.primary-pill` CTA (contrast + consistency).

**2 simulator UIs** (`gov-sim`, `governance-simulator`) — de-blue only (no marketing hero to wrap).

## Design direction
Guided by the uploaded **"Ethical AI"** design ethos (legibility, honesty, human-scale trust) — but **adapted to keep the established teal/cyan brand** rather than that reference's Google-blue/Material palette, which would clash with the site's system.

## Verification
- Guards green: `validate_ci.py` (343), `check_number_drift.py` (DRIFT PASS), `check_baseline.py` (BASELINE PASS).
- Zero `var(--blue)` remaining in any root page; all 18 heroes carry exactly one `.hero-glow`.
- Rendered a representative sample in Chromium **light + dark** (About, developers, for-payers, proof, roadmap, technical-stack) — glow heroes, teal eyebrows, de-blued callouts, and CTAs render cleanly with no layout breaks or horizontal overflow.
- Transformation is mechanical/uniform (scripted) — `git diff` confirms only hero-wrapper markup, `.reveal` classes, and color-token swaps; no prose changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K6naAZodVs6Cftbq2miy1L