### PR TITLE
Refactor site IA: open framework first, separate platform layer

### DIFF
--- a/about.html
+++ b/about.html
@@ -31,44 +31,57 @@
       </span>
     </a>
     <div class="nav-links">
-      <a href="/">Home</a>
       <div class="nav-dropdown">
-        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Learn <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
+        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Framework <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
         <div class="nav-dropdown-menu">
+          <a href="/framework/">Framework overview</a>
           <a href="/specification.html">Specification</a>
+          <a href="/framework/controls.html">Controls</a>
+          <a href="/framework/nhid-auth.html">NHID-Auth</a>
+          <a href="/framework/reference-implementation.html">Reference Implementation</a>
+          <a href="/framework/conformance-suite.html">Conformance Test Suite</a>
           <a href="/technical-stack.html">Technical Stack</a>
           <a href="/regulatory-alignment.html">Regulatory Alignment</a>
-          <a href="/about.html">About</a>
         </div>
       </div>
       <div class="nav-dropdown">
-        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Evaluate <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
+        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Platform <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
         <div class="nav-dropdown-menu">
-          <a href="/simulator.html">Simulator</a>
-          <a href="/shadow-evaluation-guide.html">Shadow Evaluation</a>
-          <a href="/evidence-pack.html">Evidence Pack</a>
-          <a href="/for-payers.html">For Payers</a>
+          <a href="/platform/">TrustLayer overview</a>
+          <a href="/platform/agent-registry.html">Agent Registry</a>
+          <a href="/platform/trust-gateway.html">Trust Gateway</a>
+          <a href="/platform/evidence-center.html">Evidence Center</a>
+          <a href="/platform/continuous-conformance.html">Continuous Conformance</a>
+          <a href="/platform/enterprise.html">Enterprise Workflow</a>
         </div>
       </div>
+      <a href="/simulator.html">Simulator</a>
       <div class="nav-dropdown">
-        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Build <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
+        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Docs <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
         <div class="nav-dropdown-menu">
-          <a href="/developers.html">Developers</a>
+          <a href="/developers.html">Developer guide</a>
+          <a href="/docs.html">Live API explorer</a>
           <a href="/interoperability.html">Interoperability</a>
           <a href="/registry.html">Implementation Registry</a>
           <a href="/icon-system.html">Icon System</a>
         </div>
       </div>
       <div class="nav-dropdown">
-        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Community <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
+        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Resources <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
         <div class="nav-dropdown-menu">
-          <a href="/news.html">News</a>
+          <a href="/evidence-pack.html">Evidence Pack</a>
+          <a href="/shadow-evaluation-guide.html">Shadow Evaluation Guide</a>
+          <a href="/for-payers.html">For Payers</a>
+          <a href="/research-portfolio.html">Research Portfolio</a>
           <a href="/roadmap.html">Roadmap</a>
-          <a href="/research-portfolio.html">Portfolio</a>
-          <a href="https://github.com/NHID-Clinical/NHID-Clinical">GitHub &#x2197;</a>
+          <a href="/news.html">News</a>
+          <a href="/faq.html">FAQ</a>
+          <a href="https://ai-governance-map.vercel.app/" target="_blank" rel="noopener noreferrer">AI Governance Map &#x2197;</a>
         </div>
       </div>
-      <a href="https://ai-governance-map.vercel.app/" target="_blank" rel="noopener noreferrer">AI Map &#x2197;</a>
+      <a href="/pricing.html">Pricing</a>
+      <a href="/about.html">About</a>
+      <a href="https://github.com/NHID-Clinical" target="_blank" rel="noopener noreferrer">GitHub &#x2197;</a>
     </div>
     <div class="nav-actions">
       <button class="icon-button search-toggle" type="button" aria-label="Search" id="search-toggle">
@@ -100,27 +113,44 @@
 
 <nav class="mobile-nav" id="mobile-nav" aria-label="Mobile navigation">
   <a href="/">Home</a>
-  <strong class="mobile-nav-group">Learn</strong>
+  <strong class="mobile-nav-group">Framework</strong>
+  <a href="/framework/">Framework overview</a>
   <a href="/specification.html">Specification</a>
+  <a href="/framework/controls.html">Controls</a>
+  <a href="/framework/nhid-auth.html">NHID-Auth</a>
+  <a href="/framework/reference-implementation.html">Reference Implementation</a>
+  <a href="/framework/conformance-suite.html">Conformance Test Suite</a>
   <a href="/technical-stack.html">Technical Stack</a>
   <a href="/regulatory-alignment.html">Regulatory Alignment</a>
-  <a href="/about.html">About</a>
-  <strong class="mobile-nav-group">Evaluate</strong>
-  <a href="/simulator.html">Simulator</a>
-  <a href="/shadow-evaluation-guide.html">Shadow Evaluation</a>
-  <a href="/evidence-pack.html">Evidence Pack</a>
-  <a href="/for-payers.html">For Payers</a>
-  <strong class="mobile-nav-group">Build</strong>
-  <a href="/developers.html">Developers</a>
+  <strong class="mobile-nav-group">Platform</strong>
+  <a href="/platform/">TrustLayer overview</a>
+  <a href="/platform/agent-registry.html">Agent Registry</a>
+  <a href="/platform/trust-gateway.html">Trust Gateway</a>
+  <a href="/platform/evidence-center.html">Evidence Center</a>
+  <a href="/platform/continuous-conformance.html">Continuous Conformance</a>
+  <a href="/platform/enterprise.html">Enterprise Workflow</a>
+  <strong class="mobile-nav-group">Simulator</strong>
+  <a href="/simulator.html">Open the simulator</a>
+  <a href="/governance-simulator.html">Governance Simulator</a>
+  <strong class="mobile-nav-group">Docs</strong>
+  <a href="/developers.html">Developer guide</a>
+  <a href="/docs.html">Live API explorer</a>
   <a href="/interoperability.html">Interoperability</a>
   <a href="/registry.html">Implementation Registry</a>
   <a href="/icon-system.html">Icon System</a>
-  <strong class="mobile-nav-group">Community</strong>
-  <a href="/news.html">News</a>
+  <strong class="mobile-nav-group">Resources</strong>
+  <a href="/evidence-pack.html">Evidence Pack</a>
+  <a href="/shadow-evaluation-guide.html">Shadow Evaluation Guide</a>
+  <a href="/for-payers.html">For Payers</a>
+  <a href="/research-portfolio.html">Research Portfolio</a>
   <a href="/roadmap.html">Roadmap</a>
-  <a href="/research-portfolio.html">Portfolio</a>
-  <a href="https://github.com/NHID-Clinical/NHID-Clinical" target="_blank" rel="noopener noreferrer">GitHub &#x2197;</a>
-  <a href="https://ai-governance-map.vercel.app/" target="_blank" rel="noopener noreferrer">AI Map &#x2197;</a>
+  <a href="/news.html">News</a>
+  <a href="/faq.html">FAQ</a>
+  <a href="https://ai-governance-map.vercel.app/" target="_blank" rel="noopener noreferrer">AI Governance Map &#x2197;</a>
+  <strong class="mobile-nav-group">More</strong>
+  <a href="/pricing.html">Pricing</a>
+  <a href="/about.html">About</a>
+  <a href="https://github.com/NHID-Clinical" target="_blank" rel="noopener noreferrer">GitHub &#x2197;</a>
   <div class="mobile-nav-footer">
     <button class="theme-toggle mobile-theme-toggle" type="button" aria-label="Toggle dark mode">
       <svg class="sun-icon" viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M6.34 17.66l-1.41 1.41M19.07 4.93l-1.41 1.41"/></svg>

--- a/demo.html
+++ b/demo.html
@@ -32,44 +32,57 @@
       </span>
     </a>
     <div class="nav-links">
-      <a href="/">Home</a>
       <div class="nav-dropdown">
-        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Learn <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
+        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Framework <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
         <div class="nav-dropdown-menu">
+          <a href="/framework/">Framework overview</a>
           <a href="/specification.html">Specification</a>
+          <a href="/framework/controls.html">Controls</a>
+          <a href="/framework/nhid-auth.html">NHID-Auth</a>
+          <a href="/framework/reference-implementation.html">Reference Implementation</a>
+          <a href="/framework/conformance-suite.html">Conformance Test Suite</a>
           <a href="/technical-stack.html">Technical Stack</a>
           <a href="/regulatory-alignment.html">Regulatory Alignment</a>
-          <a href="/about.html">About</a>
         </div>
       </div>
       <div class="nav-dropdown">
-        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Evaluate <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
+        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Platform <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
         <div class="nav-dropdown-menu">
-          <a href="/simulator.html">Simulator</a>
-          <a href="/shadow-evaluation-guide.html">Shadow Evaluation</a>
-          <a href="/evidence-pack.html">Evidence Pack</a>
-          <a href="/for-payers.html">For Payers</a>
+          <a href="/platform/">TrustLayer overview</a>
+          <a href="/platform/agent-registry.html">Agent Registry</a>
+          <a href="/platform/trust-gateway.html">Trust Gateway</a>
+          <a href="/platform/evidence-center.html">Evidence Center</a>
+          <a href="/platform/continuous-conformance.html">Continuous Conformance</a>
+          <a href="/platform/enterprise.html">Enterprise Workflow</a>
         </div>
       </div>
+      <a href="/simulator.html">Simulator</a>
       <div class="nav-dropdown">
-        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Build <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
+        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Docs <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
         <div class="nav-dropdown-menu">
-          <a href="/developers.html">Developers</a>
+          <a href="/developers.html">Developer guide</a>
+          <a href="/docs.html">Live API explorer</a>
           <a href="/interoperability.html">Interoperability</a>
           <a href="/registry.html">Implementation Registry</a>
           <a href="/icon-system.html">Icon System</a>
         </div>
       </div>
       <div class="nav-dropdown">
-        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Community <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
+        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Resources <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
         <div class="nav-dropdown-menu">
-          <a href="/news.html">News</a>
+          <a href="/evidence-pack.html">Evidence Pack</a>
+          <a href="/shadow-evaluation-guide.html">Shadow Evaluation Guide</a>
+          <a href="/for-payers.html">For Payers</a>
+          <a href="/research-portfolio.html">Research Portfolio</a>
           <a href="/roadmap.html">Roadmap</a>
-          <a href="/research-portfolio.html">Portfolio</a>
-          <a href="https://github.com/NHID-Clinical/NHID-Clinical">GitHub &#x2197;</a>
+          <a href="/news.html">News</a>
+          <a href="/faq.html">FAQ</a>
+          <a href="https://ai-governance-map.vercel.app/" target="_blank" rel="noopener noreferrer">AI Governance Map &#x2197;</a>
         </div>
       </div>
-      <a href="https://ai-governance-map.vercel.app/" target="_blank" rel="noopener noreferrer">AI Map &#x2197;</a>
+      <a href="/pricing.html">Pricing</a>
+      <a href="/about.html">About</a>
+      <a href="https://github.com/NHID-Clinical" target="_blank" rel="noopener noreferrer">GitHub &#x2197;</a>
     </div>
     <div class="nav-actions">
       <button class="icon-button search-toggle" type="button" aria-label="Search" id="search-toggle">
@@ -101,27 +114,44 @@
 
 <nav class="mobile-nav" id="mobile-nav" aria-label="Mobile navigation">
   <a href="/">Home</a>
-  <strong class="mobile-nav-group">Learn</strong>
+  <strong class="mobile-nav-group">Framework</strong>
+  <a href="/framework/">Framework overview</a>
   <a href="/specification.html">Specification</a>
+  <a href="/framework/controls.html">Controls</a>
+  <a href="/framework/nhid-auth.html">NHID-Auth</a>
+  <a href="/framework/reference-implementation.html">Reference Implementation</a>
+  <a href="/framework/conformance-suite.html">Conformance Test Suite</a>
   <a href="/technical-stack.html">Technical Stack</a>
   <a href="/regulatory-alignment.html">Regulatory Alignment</a>
-  <a href="/about.html">About</a>
-  <strong class="mobile-nav-group">Evaluate</strong>
-  <a href="/simulator.html">Simulator</a>
-  <a href="/shadow-evaluation-guide.html">Shadow Evaluation</a>
-  <a href="/evidence-pack.html">Evidence Pack</a>
-  <a href="/for-payers.html">For Payers</a>
-  <strong class="mobile-nav-group">Build</strong>
-  <a href="/developers.html">Developers</a>
+  <strong class="mobile-nav-group">Platform</strong>
+  <a href="/platform/">TrustLayer overview</a>
+  <a href="/platform/agent-registry.html">Agent Registry</a>
+  <a href="/platform/trust-gateway.html">Trust Gateway</a>
+  <a href="/platform/evidence-center.html">Evidence Center</a>
+  <a href="/platform/continuous-conformance.html">Continuous Conformance</a>
+  <a href="/platform/enterprise.html">Enterprise Workflow</a>
+  <strong class="mobile-nav-group">Simulator</strong>
+  <a href="/simulator.html">Open the simulator</a>
+  <a href="/governance-simulator.html">Governance Simulator</a>
+  <strong class="mobile-nav-group">Docs</strong>
+  <a href="/developers.html">Developer guide</a>
+  <a href="/docs.html">Live API explorer</a>
   <a href="/interoperability.html">Interoperability</a>
   <a href="/registry.html">Implementation Registry</a>
   <a href="/icon-system.html">Icon System</a>
-  <strong class="mobile-nav-group">Community</strong>
-  <a href="/news.html">News</a>
+  <strong class="mobile-nav-group">Resources</strong>
+  <a href="/evidence-pack.html">Evidence Pack</a>
+  <a href="/shadow-evaluation-guide.html">Shadow Evaluation Guide</a>
+  <a href="/for-payers.html">For Payers</a>
+  <a href="/research-portfolio.html">Research Portfolio</a>
   <a href="/roadmap.html">Roadmap</a>
-  <a href="/research-portfolio.html">Portfolio</a>
-  <a href="https://github.com/NHID-Clinical/NHID-Clinical" target="_blank" rel="noopener noreferrer">GitHub &#x2197;</a>
-  <a href="https://ai-governance-map.vercel.app/" target="_blank" rel="noopener noreferrer">AI Map &#x2197;</a>
+  <a href="/news.html">News</a>
+  <a href="/faq.html">FAQ</a>
+  <a href="https://ai-governance-map.vercel.app/" target="_blank" rel="noopener noreferrer">AI Governance Map &#x2197;</a>
+  <strong class="mobile-nav-group">More</strong>
+  <a href="/pricing.html">Pricing</a>
+  <a href="/about.html">About</a>
+  <a href="https://github.com/NHID-Clinical" target="_blank" rel="noopener noreferrer">GitHub &#x2197;</a>
   <div class="mobile-nav-footer">
     <button class="theme-toggle mobile-theme-toggle" type="button" aria-label="Toggle dark mode">
       <svg class="sun-icon" viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M6.34 17.66l-1.41 1.41M19.07 4.93l-1.41 1.41"/></svg>

--- a/developers.html
+++ b/developers.html
@@ -32,44 +32,57 @@
       </span>
     </a>
     <div class="nav-links">
-      <a href="/">Home</a>
       <div class="nav-dropdown">
-        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Learn <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
+        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Framework <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
         <div class="nav-dropdown-menu">
+          <a href="/framework/">Framework overview</a>
           <a href="/specification.html">Specification</a>
+          <a href="/framework/controls.html">Controls</a>
+          <a href="/framework/nhid-auth.html">NHID-Auth</a>
+          <a href="/framework/reference-implementation.html">Reference Implementation</a>
+          <a href="/framework/conformance-suite.html">Conformance Test Suite</a>
           <a href="/technical-stack.html">Technical Stack</a>
           <a href="/regulatory-alignment.html">Regulatory Alignment</a>
-          <a href="/about.html">About</a>
         </div>
       </div>
       <div class="nav-dropdown">
-        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Evaluate <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
+        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Platform <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
         <div class="nav-dropdown-menu">
-          <a href="/simulator.html">Simulator</a>
-          <a href="/shadow-evaluation-guide.html">Shadow Evaluation</a>
-          <a href="/evidence-pack.html">Evidence Pack</a>
-          <a href="/for-payers.html">For Payers</a>
+          <a href="/platform/">TrustLayer overview</a>
+          <a href="/platform/agent-registry.html">Agent Registry</a>
+          <a href="/platform/trust-gateway.html">Trust Gateway</a>
+          <a href="/platform/evidence-center.html">Evidence Center</a>
+          <a href="/platform/continuous-conformance.html">Continuous Conformance</a>
+          <a href="/platform/enterprise.html">Enterprise Workflow</a>
         </div>
       </div>
+      <a href="/simulator.html">Simulator</a>
       <div class="nav-dropdown">
-        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Build <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
+        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Docs <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
         <div class="nav-dropdown-menu">
-          <a href="/developers.html">Developers</a>
+          <a href="/developers.html">Developer guide</a>
+          <a href="/docs.html">Live API explorer</a>
           <a href="/interoperability.html">Interoperability</a>
           <a href="/registry.html">Implementation Registry</a>
           <a href="/icon-system.html">Icon System</a>
         </div>
       </div>
       <div class="nav-dropdown">
-        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Community <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
+        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Resources <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
         <div class="nav-dropdown-menu">
-          <a href="/news.html">News</a>
+          <a href="/evidence-pack.html">Evidence Pack</a>
+          <a href="/shadow-evaluation-guide.html">Shadow Evaluation Guide</a>
+          <a href="/for-payers.html">For Payers</a>
+          <a href="/research-portfolio.html">Research Portfolio</a>
           <a href="/roadmap.html">Roadmap</a>
-          <a href="/research-portfolio.html">Portfolio</a>
-          <a href="https://github.com/NHID-Clinical/NHID-Clinical">GitHub &#x2197;</a>
+          <a href="/news.html">News</a>
+          <a href="/faq.html">FAQ</a>
+          <a href="https://ai-governance-map.vercel.app/" target="_blank" rel="noopener noreferrer">AI Governance Map &#x2197;</a>
         </div>
       </div>
-      <a href="https://ai-governance-map.vercel.app/" target="_blank" rel="noopener noreferrer">AI Map &#x2197;</a>
+      <a href="/pricing.html">Pricing</a>
+      <a href="/about.html">About</a>
+      <a href="https://github.com/NHID-Clinical" target="_blank" rel="noopener noreferrer">GitHub &#x2197;</a>
     </div>
     <div class="nav-actions">
       <button class="icon-button search-toggle" type="button" aria-label="Search" id="search-toggle">
@@ -101,27 +114,44 @@
 
 <nav class="mobile-nav" id="mobile-nav" aria-label="Mobile navigation">
   <a href="/">Home</a>
-  <strong class="mobile-nav-group">Learn</strong>
+  <strong class="mobile-nav-group">Framework</strong>
+  <a href="/framework/">Framework overview</a>
   <a href="/specification.html">Specification</a>
+  <a href="/framework/controls.html">Controls</a>
+  <a href="/framework/nhid-auth.html">NHID-Auth</a>
+  <a href="/framework/reference-implementation.html">Reference Implementation</a>
+  <a href="/framework/conformance-suite.html">Conformance Test Suite</a>
   <a href="/technical-stack.html">Technical Stack</a>
   <a href="/regulatory-alignment.html">Regulatory Alignment</a>
-  <a href="/about.html">About</a>
-  <strong class="mobile-nav-group">Evaluate</strong>
-  <a href="/simulator.html">Simulator</a>
-  <a href="/shadow-evaluation-guide.html">Shadow Evaluation</a>
-  <a href="/evidence-pack.html">Evidence Pack</a>
-  <a href="/for-payers.html">For Payers</a>
-  <strong class="mobile-nav-group">Build</strong>
-  <a href="/developers.html">Developers</a>
+  <strong class="mobile-nav-group">Platform</strong>
+  <a href="/platform/">TrustLayer overview</a>
+  <a href="/platform/agent-registry.html">Agent Registry</a>
+  <a href="/platform/trust-gateway.html">Trust Gateway</a>
+  <a href="/platform/evidence-center.html">Evidence Center</a>
+  <a href="/platform/continuous-conformance.html">Continuous Conformance</a>
+  <a href="/platform/enterprise.html">Enterprise Workflow</a>
+  <strong class="mobile-nav-group">Simulator</strong>
+  <a href="/simulator.html">Open the simulator</a>
+  <a href="/governance-simulator.html">Governance Simulator</a>
+  <strong class="mobile-nav-group">Docs</strong>
+  <a href="/developers.html">Developer guide</a>
+  <a href="/docs.html">Live API explorer</a>
   <a href="/interoperability.html">Interoperability</a>
   <a href="/registry.html">Implementation Registry</a>
   <a href="/icon-system.html">Icon System</a>
-  <strong class="mobile-nav-group">Community</strong>
-  <a href="/news.html">News</a>
+  <strong class="mobile-nav-group">Resources</strong>
+  <a href="/evidence-pack.html">Evidence Pack</a>
+  <a href="/shadow-evaluation-guide.html">Shadow Evaluation Guide</a>
+  <a href="/for-payers.html">For Payers</a>
+  <a href="/research-portfolio.html">Research Portfolio</a>
   <a href="/roadmap.html">Roadmap</a>
-  <a href="/research-portfolio.html">Portfolio</a>
-  <a href="https://github.com/NHID-Clinical/NHID-Clinical" target="_blank" rel="noopener noreferrer">GitHub &#x2197;</a>
-  <a href="https://ai-governance-map.vercel.app/" target="_blank" rel="noopener noreferrer">AI Map &#x2197;</a>
+  <a href="/news.html">News</a>
+  <a href="/faq.html">FAQ</a>
+  <a href="https://ai-governance-map.vercel.app/" target="_blank" rel="noopener noreferrer">AI Governance Map &#x2197;</a>
+  <strong class="mobile-nav-group">More</strong>
+  <a href="/pricing.html">Pricing</a>
+  <a href="/about.html">About</a>
+  <a href="https://github.com/NHID-Clinical" target="_blank" rel="noopener noreferrer">GitHub &#x2197;</a>
   <div class="mobile-nav-footer">
     <button class="theme-toggle mobile-theme-toggle" type="button" aria-label="Toggle dark mode">
       <svg class="sun-icon" viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M6.34 17.66l-1.41 1.41M19.07 4.93l-1.41 1.41"/></svg>

--- a/docs/repository-architecture.md
+++ b/docs/repository-architecture.md
@@ -1,0 +1,107 @@
+# Repository architecture
+
+Recommended GitHub organization structure for NHID-Clinical, separating the open
+framework from the commercial platform layer.
+
+## Principle
+
+**Do not merge open and commercial repositories.**
+
+The open framework is the source of legitimacy for this work. Its credibility depends on
+being independently implementable, auditable, and forkable by people who have no commercial
+relationship with us — including competitors and regulators. Mixing commercial code into the
+same tree makes that claim unverifiable, and makes it impossible to tell what a third party
+is actually free to use.
+
+## Open repositories
+
+Published under CC BY 4.0. Public, forkable, no commercial dependency.
+
+| Repository | Contents |
+|---|---|
+| `nhid-specification` | The normative v1.3 specification, control definitions, event schema, and versioned specification history |
+| `nhid-conformance-suite` | Machine-readable test definitions (YAML) and the runner that executes them against any implementation |
+| `nhid-reference-implementation` | The Python policy engine, TypeScript middleware, VAPI/Twilio adapters, and PowerShell module |
+| `nhid-simulator` | The open simulator that demonstrates the controls (currently `NHID-Clinical/Simulator`) |
+| `nhid-auth` | NHID-Auth v2 — Ed25519 agent passports, provider-signed delegation, offline verification |
+| `nhid-sdk-python` | Python client SDK |
+| `nhid-sdk-js` | JavaScript/TypeScript client SDK |
+
+## Commercial repositories
+
+Private. TrustLayer platform code. Consumes the open repositories as dependencies; the
+open repositories never depend on these.
+
+| Repository | Contents |
+|---|---|
+| `nhid-trustlayer` | The TrustLayer platform — agent registry, trust gateway, evidence center, continuous conformance monitoring |
+| `nhid-enterprise-connectors` | SSO, SIEM, ticketing, and GRC integrations |
+| `nhid-cloud` | Hosting, tenancy, and operational infrastructure |
+
+## Dependency direction
+
+```
+nhid-specification
+        ↑
+nhid-reference-implementation ← nhid-conformance-suite
+        ↑                              ↑
+   nhid-auth                     nhid-simulator
+        ↑
+   nhid-sdk-*
+        ↑
+  ─────────────────────────────────────────  (open / commercial boundary)
+        ↑
+   nhid-trustlayer ← nhid-enterprise-connectors
+        ↑
+    nhid-cloud
+```
+
+Dependencies point upward only. No open repository may depend on a commercial one. If
+TrustLayer were discontinued tomorrow, every open repository would continue to build, test,
+and function unchanged.
+
+## Current state
+
+Today the framework, the website, and the reference implementation all live in a single
+repository (`NHID-Clinical/NHID-Clinical`), with the simulator in `NHID-Clinical/Simulator`
+and platform work in `NHID-Clinical/NHID-Clinical-SaaS`.
+
+The repositories above have **not** been created yet. Creating them requires permissions the
+automation running this change does not hold — the GitHub App installation token cannot
+create repositories (`403 Resource not accessible by integration`), and `NHID-Clinical` is a
+user account rather than an organization, so there is no org-level repo creation path either.
+
+Creating them is a manual step: either from the GitHub UI while signed in as the account
+owner, or with a personal access token carrying the `repo` scope. Until then this document is
+the record of intent. `NHID-Clinical/NHID-Clinical` remains the live source of both the
+website (GitHub Pages → nhid-clinical.org) and the framework.
+
+## Migration sequence
+
+Splitting a repository with an active Pages deploy, live CI gates, and a substantial merged
+history is a project in its own right — it should not be attempted alongside unrelated work.
+When it happens, this order minimizes breakage:
+
+1. **`nhid-specification`** — lowest coupling. Move the specification documents and schema;
+   leave a pointer in the monorepo.
+2. **`nhid-conformance-suite`** — move the YAML definitions and runner. The reference
+   implementation consumes it as a dependency rather than a sibling directory.
+3. **`nhid-auth`** — self-contained cryptographic layer.
+4. **`nhid-reference-implementation`** — the engine, middleware, and adapters. Largest move;
+   requires CI to be rebuilt against the extracted dependencies.
+5. **`nhid-sdk-python` / `nhid-sdk-js`** — extract client code once the engine has moved.
+6. **`nhid-simulator`** — rename the existing `Simulator` repository. Update the redirect at
+   `/simulator.html` and the canonical URL in the same change.
+7. **Website stays put.** `NHID-Clinical/NHID-Clinical` becomes the website plus the org's
+   front door, with the Pages workflow untouched throughout.
+
+Each step should land independently, with the site's links verified before the next begins.
+
+## Constraints
+
+- The specification, conformance suite, and reference implementation must never require a
+  commercial account, key, or agreement to obtain, build, or run.
+- Commercial repositories may consume open repositories at pinned versions; they may not
+  fork them privately and diverge, because that would produce two different control
+  definitions with the same name.
+- Any control-logic change lands in the open repository first.

--- a/evidence-pack.html
+++ b/evidence-pack.html
@@ -49,44 +49,57 @@
       </span>
     </a>
     <div class="nav-links">
-      <a href="/">Home</a>
       <div class="nav-dropdown">
-        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Learn <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
+        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Framework <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
         <div class="nav-dropdown-menu">
+          <a href="/framework/">Framework overview</a>
           <a href="/specification.html">Specification</a>
+          <a href="/framework/controls.html">Controls</a>
+          <a href="/framework/nhid-auth.html">NHID-Auth</a>
+          <a href="/framework/reference-implementation.html">Reference Implementation</a>
+          <a href="/framework/conformance-suite.html">Conformance Test Suite</a>
           <a href="/technical-stack.html">Technical Stack</a>
           <a href="/regulatory-alignment.html">Regulatory Alignment</a>
-          <a href="/about.html">About</a>
         </div>
       </div>
       <div class="nav-dropdown">
-        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Evaluate <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
+        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Platform <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
         <div class="nav-dropdown-menu">
-          <a href="/simulator.html">Simulator</a>
-          <a href="/shadow-evaluation-guide.html">Shadow Evaluation</a>
-          <a href="/evidence-pack.html">Evidence Pack</a>
-          <a href="/for-payers.html">For Payers</a>
+          <a href="/platform/">TrustLayer overview</a>
+          <a href="/platform/agent-registry.html">Agent Registry</a>
+          <a href="/platform/trust-gateway.html">Trust Gateway</a>
+          <a href="/platform/evidence-center.html">Evidence Center</a>
+          <a href="/platform/continuous-conformance.html">Continuous Conformance</a>
+          <a href="/platform/enterprise.html">Enterprise Workflow</a>
         </div>
       </div>
+      <a href="/simulator.html">Simulator</a>
       <div class="nav-dropdown">
-        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Build <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
+        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Docs <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
         <div class="nav-dropdown-menu">
-          <a href="/developers.html">Developers</a>
+          <a href="/developers.html">Developer guide</a>
+          <a href="/docs.html">Live API explorer</a>
           <a href="/interoperability.html">Interoperability</a>
           <a href="/registry.html">Implementation Registry</a>
           <a href="/icon-system.html">Icon System</a>
         </div>
       </div>
       <div class="nav-dropdown">
-        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Community <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
+        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Resources <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
         <div class="nav-dropdown-menu">
-          <a href="/news.html">News</a>
+          <a href="/evidence-pack.html">Evidence Pack</a>
+          <a href="/shadow-evaluation-guide.html">Shadow Evaluation Guide</a>
+          <a href="/for-payers.html">For Payers</a>
+          <a href="/research-portfolio.html">Research Portfolio</a>
           <a href="/roadmap.html">Roadmap</a>
-          <a href="/research-portfolio.html">Portfolio</a>
-          <a href="https://github.com/NHID-Clinical/NHID-Clinical">GitHub &#x2197;</a>
+          <a href="/news.html">News</a>
+          <a href="/faq.html">FAQ</a>
+          <a href="https://ai-governance-map.vercel.app/" target="_blank" rel="noopener noreferrer">AI Governance Map &#x2197;</a>
         </div>
       </div>
-      <a href="https://ai-governance-map.vercel.app/" target="_blank" rel="noopener noreferrer">AI Map &#x2197;</a>
+      <a href="/pricing.html">Pricing</a>
+      <a href="/about.html">About</a>
+      <a href="https://github.com/NHID-Clinical" target="_blank" rel="noopener noreferrer">GitHub &#x2197;</a>
     </div>
     <div class="nav-actions">
       <button class="icon-button search-toggle" type="button" aria-label="Search" id="search-toggle">
@@ -118,27 +131,44 @@
 
 <nav class="mobile-nav" id="mobile-nav" aria-label="Mobile navigation">
   <a href="/">Home</a>
-  <strong class="mobile-nav-group">Learn</strong>
+  <strong class="mobile-nav-group">Framework</strong>
+  <a href="/framework/">Framework overview</a>
   <a href="/specification.html">Specification</a>
+  <a href="/framework/controls.html">Controls</a>
+  <a href="/framework/nhid-auth.html">NHID-Auth</a>
+  <a href="/framework/reference-implementation.html">Reference Implementation</a>
+  <a href="/framework/conformance-suite.html">Conformance Test Suite</a>
   <a href="/technical-stack.html">Technical Stack</a>
   <a href="/regulatory-alignment.html">Regulatory Alignment</a>
-  <a href="/about.html">About</a>
-  <strong class="mobile-nav-group">Evaluate</strong>
-  <a href="/simulator.html">Simulator</a>
-  <a href="/shadow-evaluation-guide.html">Shadow Evaluation</a>
-  <a href="/evidence-pack.html">Evidence Pack</a>
-  <a href="/for-payers.html">For Payers</a>
-  <strong class="mobile-nav-group">Build</strong>
-  <a href="/developers.html">Developers</a>
+  <strong class="mobile-nav-group">Platform</strong>
+  <a href="/platform/">TrustLayer overview</a>
+  <a href="/platform/agent-registry.html">Agent Registry</a>
+  <a href="/platform/trust-gateway.html">Trust Gateway</a>
+  <a href="/platform/evidence-center.html">Evidence Center</a>
+  <a href="/platform/continuous-conformance.html">Continuous Conformance</a>
+  <a href="/platform/enterprise.html">Enterprise Workflow</a>
+  <strong class="mobile-nav-group">Simulator</strong>
+  <a href="/simulator.html">Open the simulator</a>
+  <a href="/governance-simulator.html">Governance Simulator</a>
+  <strong class="mobile-nav-group">Docs</strong>
+  <a href="/developers.html">Developer guide</a>
+  <a href="/docs.html">Live API explorer</a>
   <a href="/interoperability.html">Interoperability</a>
   <a href="/registry.html">Implementation Registry</a>
   <a href="/icon-system.html">Icon System</a>
-  <strong class="mobile-nav-group">Community</strong>
-  <a href="/news.html">News</a>
+  <strong class="mobile-nav-group">Resources</strong>
+  <a href="/evidence-pack.html">Evidence Pack</a>
+  <a href="/shadow-evaluation-guide.html">Shadow Evaluation Guide</a>
+  <a href="/for-payers.html">For Payers</a>
+  <a href="/research-portfolio.html">Research Portfolio</a>
   <a href="/roadmap.html">Roadmap</a>
-  <a href="/research-portfolio.html">Portfolio</a>
-  <a href="https://github.com/NHID-Clinical/NHID-Clinical" target="_blank" rel="noopener noreferrer">GitHub &#x2197;</a>
-  <a href="https://ai-governance-map.vercel.app/" target="_blank" rel="noopener noreferrer">AI Map &#x2197;</a>
+  <a href="/news.html">News</a>
+  <a href="/faq.html">FAQ</a>
+  <a href="https://ai-governance-map.vercel.app/" target="_blank" rel="noopener noreferrer">AI Governance Map &#x2197;</a>
+  <strong class="mobile-nav-group">More</strong>
+  <a href="/pricing.html">Pricing</a>
+  <a href="/about.html">About</a>
+  <a href="https://github.com/NHID-Clinical" target="_blank" rel="noopener noreferrer">GitHub &#x2197;</a>
   <div class="mobile-nav-footer">
     <button class="theme-toggle mobile-theme-toggle" type="button" aria-label="Toggle dark mode">
       <svg class="sun-icon" viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M6.34 17.66l-1.41 1.41M19.07 4.93l-1.41 1.41"/></svg>

--- a/faq.html
+++ b/faq.html
@@ -31,44 +31,57 @@
       </span>
     </a>
     <div class="nav-links">
-      <a href="/">Home</a>
       <div class="nav-dropdown">
-        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Learn <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
+        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Framework <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
         <div class="nav-dropdown-menu">
+          <a href="/framework/">Framework overview</a>
           <a href="/specification.html">Specification</a>
+          <a href="/framework/controls.html">Controls</a>
+          <a href="/framework/nhid-auth.html">NHID-Auth</a>
+          <a href="/framework/reference-implementation.html">Reference Implementation</a>
+          <a href="/framework/conformance-suite.html">Conformance Test Suite</a>
           <a href="/technical-stack.html">Technical Stack</a>
           <a href="/regulatory-alignment.html">Regulatory Alignment</a>
-          <a href="/about.html">About</a>
         </div>
       </div>
       <div class="nav-dropdown">
-        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Evaluate <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
+        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Platform <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
         <div class="nav-dropdown-menu">
-          <a href="/simulator.html">Simulator</a>
-          <a href="/shadow-evaluation-guide.html">Shadow Evaluation</a>
-          <a href="/evidence-pack.html">Evidence Pack</a>
-          <a href="/for-payers.html">For Payers</a>
+          <a href="/platform/">TrustLayer overview</a>
+          <a href="/platform/agent-registry.html">Agent Registry</a>
+          <a href="/platform/trust-gateway.html">Trust Gateway</a>
+          <a href="/platform/evidence-center.html">Evidence Center</a>
+          <a href="/platform/continuous-conformance.html">Continuous Conformance</a>
+          <a href="/platform/enterprise.html">Enterprise Workflow</a>
         </div>
       </div>
+      <a href="/simulator.html">Simulator</a>
       <div class="nav-dropdown">
-        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Build <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
+        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Docs <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
         <div class="nav-dropdown-menu">
-          <a href="/developers.html">Developers</a>
+          <a href="/developers.html">Developer guide</a>
+          <a href="/docs.html">Live API explorer</a>
           <a href="/interoperability.html">Interoperability</a>
           <a href="/registry.html">Implementation Registry</a>
           <a href="/icon-system.html">Icon System</a>
         </div>
       </div>
       <div class="nav-dropdown">
-        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Community <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
+        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Resources <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
         <div class="nav-dropdown-menu">
-          <a href="/news.html">News</a>
+          <a href="/evidence-pack.html">Evidence Pack</a>
+          <a href="/shadow-evaluation-guide.html">Shadow Evaluation Guide</a>
+          <a href="/for-payers.html">For Payers</a>
+          <a href="/research-portfolio.html">Research Portfolio</a>
           <a href="/roadmap.html">Roadmap</a>
-          <a href="/research-portfolio.html">Portfolio</a>
-          <a href="https://github.com/NHID-Clinical/NHID-Clinical">GitHub &#x2197;</a>
+          <a href="/news.html">News</a>
+          <a href="/faq.html">FAQ</a>
+          <a href="https://ai-governance-map.vercel.app/" target="_blank" rel="noopener noreferrer">AI Governance Map &#x2197;</a>
         </div>
       </div>
-      <a href="https://ai-governance-map.vercel.app/" target="_blank" rel="noopener noreferrer">AI Map &#x2197;</a>
+      <a href="/pricing.html">Pricing</a>
+      <a href="/about.html">About</a>
+      <a href="https://github.com/NHID-Clinical" target="_blank" rel="noopener noreferrer">GitHub &#x2197;</a>
     </div>
     <div class="nav-actions">
       <button class="icon-button search-toggle" type="button" aria-label="Search" id="search-toggle">
@@ -100,27 +113,44 @@
 
 <nav class="mobile-nav" id="mobile-nav" aria-label="Mobile navigation">
   <a href="/">Home</a>
-  <strong class="mobile-nav-group">Learn</strong>
+  <strong class="mobile-nav-group">Framework</strong>
+  <a href="/framework/">Framework overview</a>
   <a href="/specification.html">Specification</a>
+  <a href="/framework/controls.html">Controls</a>
+  <a href="/framework/nhid-auth.html">NHID-Auth</a>
+  <a href="/framework/reference-implementation.html">Reference Implementation</a>
+  <a href="/framework/conformance-suite.html">Conformance Test Suite</a>
   <a href="/technical-stack.html">Technical Stack</a>
   <a href="/regulatory-alignment.html">Regulatory Alignment</a>
-  <a href="/about.html">About</a>
-  <strong class="mobile-nav-group">Evaluate</strong>
-  <a href="/simulator.html">Simulator</a>
-  <a href="/shadow-evaluation-guide.html">Shadow Evaluation</a>
-  <a href="/evidence-pack.html">Evidence Pack</a>
-  <a href="/for-payers.html">For Payers</a>
-  <strong class="mobile-nav-group">Build</strong>
-  <a href="/developers.html">Developers</a>
+  <strong class="mobile-nav-group">Platform</strong>
+  <a href="/platform/">TrustLayer overview</a>
+  <a href="/platform/agent-registry.html">Agent Registry</a>
+  <a href="/platform/trust-gateway.html">Trust Gateway</a>
+  <a href="/platform/evidence-center.html">Evidence Center</a>
+  <a href="/platform/continuous-conformance.html">Continuous Conformance</a>
+  <a href="/platform/enterprise.html">Enterprise Workflow</a>
+  <strong class="mobile-nav-group">Simulator</strong>
+  <a href="/simulator.html">Open the simulator</a>
+  <a href="/governance-simulator.html">Governance Simulator</a>
+  <strong class="mobile-nav-group">Docs</strong>
+  <a href="/developers.html">Developer guide</a>
+  <a href="/docs.html">Live API explorer</a>
   <a href="/interoperability.html">Interoperability</a>
   <a href="/registry.html">Implementation Registry</a>
   <a href="/icon-system.html">Icon System</a>
-  <strong class="mobile-nav-group">Community</strong>
-  <a href="/news.html">News</a>
+  <strong class="mobile-nav-group">Resources</strong>
+  <a href="/evidence-pack.html">Evidence Pack</a>
+  <a href="/shadow-evaluation-guide.html">Shadow Evaluation Guide</a>
+  <a href="/for-payers.html">For Payers</a>
+  <a href="/research-portfolio.html">Research Portfolio</a>
   <a href="/roadmap.html">Roadmap</a>
-  <a href="/research-portfolio.html">Portfolio</a>
-  <a href="https://github.com/NHID-Clinical/NHID-Clinical" target="_blank" rel="noopener noreferrer">GitHub &#x2197;</a>
-  <a href="https://ai-governance-map.vercel.app/" target="_blank" rel="noopener noreferrer">AI Map &#x2197;</a>
+  <a href="/news.html">News</a>
+  <a href="/faq.html">FAQ</a>
+  <a href="https://ai-governance-map.vercel.app/" target="_blank" rel="noopener noreferrer">AI Governance Map &#x2197;</a>
+  <strong class="mobile-nav-group">More</strong>
+  <a href="/pricing.html">Pricing</a>
+  <a href="/about.html">About</a>
+  <a href="https://github.com/NHID-Clinical" target="_blank" rel="noopener noreferrer">GitHub &#x2197;</a>
   <div class="mobile-nav-footer">
     <button class="theme-toggle mobile-theme-toggle" type="button" aria-label="Toggle dark mode">
       <svg class="sun-icon" viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M6.34 17.66l-1.41 1.41M19.07 4.93l-1.41 1.41"/></svg>

--- a/for-payers.html
+++ b/for-payers.html
@@ -83,44 +83,57 @@
       </span>
     </a>
     <div class="nav-links">
-      <a href="/">Home</a>
       <div class="nav-dropdown">
-        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Learn <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
+        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Framework <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
         <div class="nav-dropdown-menu">
+          <a href="/framework/">Framework overview</a>
           <a href="/specification.html">Specification</a>
+          <a href="/framework/controls.html">Controls</a>
+          <a href="/framework/nhid-auth.html">NHID-Auth</a>
+          <a href="/framework/reference-implementation.html">Reference Implementation</a>
+          <a href="/framework/conformance-suite.html">Conformance Test Suite</a>
           <a href="/technical-stack.html">Technical Stack</a>
           <a href="/regulatory-alignment.html">Regulatory Alignment</a>
-          <a href="/about.html">About</a>
         </div>
       </div>
       <div class="nav-dropdown">
-        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Evaluate <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
+        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Platform <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
         <div class="nav-dropdown-menu">
-          <a href="/simulator.html">Simulator</a>
-          <a href="/shadow-evaluation-guide.html">Shadow Evaluation</a>
-          <a href="/evidence-pack.html">Evidence Pack</a>
-          <a href="/for-payers.html">For Payers</a>
+          <a href="/platform/">TrustLayer overview</a>
+          <a href="/platform/agent-registry.html">Agent Registry</a>
+          <a href="/platform/trust-gateway.html">Trust Gateway</a>
+          <a href="/platform/evidence-center.html">Evidence Center</a>
+          <a href="/platform/continuous-conformance.html">Continuous Conformance</a>
+          <a href="/platform/enterprise.html">Enterprise Workflow</a>
         </div>
       </div>
+      <a href="/simulator.html">Simulator</a>
       <div class="nav-dropdown">
-        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Build <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
+        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Docs <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
         <div class="nav-dropdown-menu">
-          <a href="/developers.html">Developers</a>
+          <a href="/developers.html">Developer guide</a>
+          <a href="/docs.html">Live API explorer</a>
           <a href="/interoperability.html">Interoperability</a>
           <a href="/registry.html">Implementation Registry</a>
           <a href="/icon-system.html">Icon System</a>
         </div>
       </div>
       <div class="nav-dropdown">
-        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Community <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
+        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Resources <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
         <div class="nav-dropdown-menu">
-          <a href="/news.html">News</a>
+          <a href="/evidence-pack.html">Evidence Pack</a>
+          <a href="/shadow-evaluation-guide.html">Shadow Evaluation Guide</a>
+          <a href="/for-payers.html">For Payers</a>
+          <a href="/research-portfolio.html">Research Portfolio</a>
           <a href="/roadmap.html">Roadmap</a>
-          <a href="/research-portfolio.html">Portfolio</a>
-          <a href="https://github.com/NHID-Clinical/NHID-Clinical">GitHub &#x2197;</a>
+          <a href="/news.html">News</a>
+          <a href="/faq.html">FAQ</a>
+          <a href="https://ai-governance-map.vercel.app/" target="_blank" rel="noopener noreferrer">AI Governance Map &#x2197;</a>
         </div>
       </div>
-      <a href="https://ai-governance-map.vercel.app/" target="_blank" rel="noopener noreferrer">AI Map &#x2197;</a>
+      <a href="/pricing.html">Pricing</a>
+      <a href="/about.html">About</a>
+      <a href="https://github.com/NHID-Clinical" target="_blank" rel="noopener noreferrer">GitHub &#x2197;</a>
     </div>
     <div class="nav-actions">
       <button class="icon-button search-toggle" type="button" aria-label="Search" id="search-toggle">
@@ -152,27 +165,44 @@
 
 <nav class="mobile-nav" id="mobile-nav" aria-label="Mobile navigation">
   <a href="/">Home</a>
-  <strong class="mobile-nav-group">Learn</strong>
+  <strong class="mobile-nav-group">Framework</strong>
+  <a href="/framework/">Framework overview</a>
   <a href="/specification.html">Specification</a>
+  <a href="/framework/controls.html">Controls</a>
+  <a href="/framework/nhid-auth.html">NHID-Auth</a>
+  <a href="/framework/reference-implementation.html">Reference Implementation</a>
+  <a href="/framework/conformance-suite.html">Conformance Test Suite</a>
   <a href="/technical-stack.html">Technical Stack</a>
   <a href="/regulatory-alignment.html">Regulatory Alignment</a>
-  <a href="/about.html">About</a>
-  <strong class="mobile-nav-group">Evaluate</strong>
-  <a href="/simulator.html">Simulator</a>
-  <a href="/shadow-evaluation-guide.html">Shadow Evaluation</a>
-  <a href="/evidence-pack.html">Evidence Pack</a>
-  <a href="/for-payers.html">For Payers</a>
-  <strong class="mobile-nav-group">Build</strong>
-  <a href="/developers.html">Developers</a>
+  <strong class="mobile-nav-group">Platform</strong>
+  <a href="/platform/">TrustLayer overview</a>
+  <a href="/platform/agent-registry.html">Agent Registry</a>
+  <a href="/platform/trust-gateway.html">Trust Gateway</a>
+  <a href="/platform/evidence-center.html">Evidence Center</a>
+  <a href="/platform/continuous-conformance.html">Continuous Conformance</a>
+  <a href="/platform/enterprise.html">Enterprise Workflow</a>
+  <strong class="mobile-nav-group">Simulator</strong>
+  <a href="/simulator.html">Open the simulator</a>
+  <a href="/governance-simulator.html">Governance Simulator</a>
+  <strong class="mobile-nav-group">Docs</strong>
+  <a href="/developers.html">Developer guide</a>
+  <a href="/docs.html">Live API explorer</a>
   <a href="/interoperability.html">Interoperability</a>
   <a href="/registry.html">Implementation Registry</a>
   <a href="/icon-system.html">Icon System</a>
-  <strong class="mobile-nav-group">Community</strong>
-  <a href="/news.html">News</a>
+  <strong class="mobile-nav-group">Resources</strong>
+  <a href="/evidence-pack.html">Evidence Pack</a>
+  <a href="/shadow-evaluation-guide.html">Shadow Evaluation Guide</a>
+  <a href="/for-payers.html">For Payers</a>
+  <a href="/research-portfolio.html">Research Portfolio</a>
   <a href="/roadmap.html">Roadmap</a>
-  <a href="/research-portfolio.html">Portfolio</a>
-  <a href="https://github.com/NHID-Clinical/NHID-Clinical" target="_blank" rel="noopener noreferrer">GitHub &#x2197;</a>
-  <a href="https://ai-governance-map.vercel.app/" target="_blank" rel="noopener noreferrer">AI Map &#x2197;</a>
+  <a href="/news.html">News</a>
+  <a href="/faq.html">FAQ</a>
+  <a href="https://ai-governance-map.vercel.app/" target="_blank" rel="noopener noreferrer">AI Governance Map &#x2197;</a>
+  <strong class="mobile-nav-group">More</strong>
+  <a href="/pricing.html">Pricing</a>
+  <a href="/about.html">About</a>
+  <a href="https://github.com/NHID-Clinical" target="_blank" rel="noopener noreferrer">GitHub &#x2197;</a>
   <div class="mobile-nav-footer">
     <button class="theme-toggle mobile-theme-toggle" type="button" aria-label="Toggle dark mode">
       <svg class="sun-icon" viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M6.34 17.66l-1.41 1.41M19.07 4.93l-1.41 1.41"/></svg>

--- a/framework/conformance-suite.html
+++ b/framework/conformance-suite.html
@@ -1,16 +1,18 @@
-﻿<!doctype html>
+<!doctype html>
 <html lang="en">
 <head>
   <meta charset="utf-8"/>
   <meta name="viewport" content="width=device-width, initial-scale=1"/>
-  <meta name="description" content="NHID-Clinical Implementation Registry — self-attested vendor implementations with live NHID-CAS badges."/>
-  <title>Implementation Registry | NHID-Clinical</title>
+  <meta name="description" content="The NHID-Clinical conformance test suite — machine-readable, deterministic pass/fail tests for IDG-01, PDX-01, DBC-01, EIT-01, and ATR-01, runnable by anyone against any implementation."/>
+  <title>Conformance Test Suite | NHID-Clinical Framework</title>
+  <link rel="canonical" href="https://nhid-clinical.org/framework/conformance-suite.html"/>
   <link rel="icon" href="/assets/brand/favicon.svg" type="image/svg+xml"/>
   <link rel="icon" href="/assets/brand-icon.png" type="image/png"/>
   <link rel="preconnect" href="https://fonts.googleapis.com"/>
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
   <link href="https://fonts.googleapis.com/css2?family=Raleway:wght@600;700;800&family=Inter:wght@400;500;600;700;800&family=IBM+Plex+Mono:wght@400;500&display=swap" rel="stylesheet"/>
   <link rel="stylesheet" href="/nhid-clinical-ui.css"/>
+  <link rel="stylesheet" href="/assets/css/premium.css"/>
   <script>try{document.documentElement.setAttribute('data-theme',localStorage.getItem('nhid-theme')||'light')}catch(e){}</script>
   <script defer data-domain="nhid-clinical.org" src="https://plausible.io/js/script.js"></script>
 </head>
@@ -162,66 +164,92 @@
 <div class="nav-backdrop" id="nav-backdrop"></div>
 
 <main>
-  <section class="inner-hero" style="position:relative;overflow:clip">
+
+  <section class="inner-hero">
     <div class="hero-glow" aria-hidden="true"></div>
-    <div class="container" style="position:relative;z-index:1">
-      <div class="crumbs"><a href="/">Home</a><span>/</span><span>Implementation Registry</span></div>
-      <p class="eyebrow">Registry · June 2026</p>
-      <h1 class="reveal">Implementation Registry</h1>
-      <p class="lede reveal">Self-attested NHID-Clinical implementations, with live NHID-CAS conformance badges.</p>
+    <div class="container" style="position:relative;z-index:1;max-width:60rem">
+      <div class="crumbs"><a href="/">Home</a><span>/</span><a href="/framework/">Framework</a><span>/</span><span>Conformance Test Suite</span></div>
+      <p class="eyebrow">Machine-readable · deterministic · CC BY 4.0</p>
+      <h1>Conformance test suite</h1>
+      <p class="lede">A conformance claim you cannot verify is marketing. This suite makes the claim checkable by anyone, including people with no reason to trust the claimant.</p>
     </div>
   </section>
 
   <section class="page-section">
-    <div class="container" style="max-width:52rem">
-      <div class="callout" role="note" style="margin-bottom:2rem">
-        <strong>This is a self-attestation list, not a certification.</strong> NHID-Clinical does not
-        certify, audit, or warrant any vendor's implementation. A listing means the vendor ran the
-        public conformance test suite (CTS) against their own integration and chose to publish the
-        result. Badge scores update from each vendor's own live <code>/v1/public/vendor/{id}/badge</code>
-        endpoint call — verify independently before relying on them for procurement decisions.
+    <div class="container" style="max-width:60rem">
+      <h2>What it is</h2>
+      <p style="color:var(--body);line-height:1.85;margin-top:.75rem">A machine-readable specification of test cases — published as YAML in the open repository at <code style="font-family:'IBM Plex Mono',monospace;font-size:.9rem">conformance/nhid_conformance_test_suite_v1.yaml</code> — paired with a runner that executes them against an implementation and reports pass or fail per control.</p>
+      <p style="color:var(--body);line-height:1.85;margin-top:.75rem">The test definitions are separate from the runner on purpose. If you write your own engine in another language, you can consume the same YAML and be measured against the same cases.</p>
+
+      <h2 style="margin-top:2.5rem">What it tests</h2>
+      <div class="field-table-wrap">
+        <table class="field-table">
+          <thead><tr><th>Control</th><th>Verifies</th><th>Failure severity</th></tr></thead>
+          <tbody>
+            <tr><td><code>IDG-01</code></td><td>Disclosure occurs before the first operational data exchange, with a recorded timestamp</td><td>Critical</td></tr>
+            <tr><td><code>PDX-01</code></td><td>No protected data moves on any turn not preceded by a confirmed disclosure</td><td>Critical</td></tr>
+            <tr><td><code>DBC-01</code></td><td>No deceptive artifacts and no false or evasive human-status claims</td><td>Critical</td></tr>
+            <tr><td><code>EIT-01</code></td><td>Escalation is available, honored on request, and its outcome is recorded</td><td>High</td></tr>
+            <tr><td><code>ATR-01</code></td><td>Every event carries a complete audit envelope that validates against the trace schema</td><td>Critical</td></tr>
+          </tbody>
+        </table>
       </div>
 
-      <h2>Listed Implementations</h2>
-      <div id="registry-list" style="margin:1.5rem 0">
-        <p style="color:var(--body)">Loading…</p>
+      <h2 style="margin-top:2.5rem">Illustrative result</h2>
+      <div class="console-panel">
+        <div class="console-bar"><span class="mock-dot"></span><span class="mock-dot"></span><span class="mock-dot"></span><span class="console-title">nhid-cts run --suite v1 --target ./engine</span></div>
+        <div class="console-body">
+          <div class="console-verdict"><strong>Suite result</strong><span class="console-pill">Conformant</span></div>
+          <div class="console-line"><span class="k">IDG-01 &middot; Identity Disclosure Gate</span><span class="v pass">PASS</span></div>
+          <div class="console-line"><span class="k">PDX-01 &middot; Pre-Data Exchange Gate</span><span class="v pass">PASS</span></div>
+          <div class="console-line"><span class="k">DBC-01 &middot; Deceptive Behavior Check</span><span class="v pass">PASS</span></div>
+          <div class="console-line"><span class="k">EIT-01 &middot; Escalation Implementation</span><span class="v pass">PASS</span></div>
+          <div class="console-line"><span class="k">ATR-01 &middot; Audit Trail Requirements</span><span class="v pass">PASS</span></div>
+          <p class="console-note">Illustrative output — not a live test run.</p>
+        </div>
       </div>
 
-      <h2 style="margin-top:2.5rem">How to Get Listed</h2>
-      <p style="margin-bottom:1rem">
-        Run the conformance test suite against your integration, then complete the
-        <a href="https://github.com/NHID-Clinical/NHID-Clinical/blob/main/docs/vendor-trust-questionnaire.md">vendor trust questionnaire</a>
-        and open a pull request adding your entry to
-        <a href="https://github.com/NHID-Clinical/NHID-Clinical/blob/main/content/registry_entries.json">content/registry_entries.json</a>.
-        Each entry needs a <code>vendor_id</code> matching the one used when recording conformance results
-        (see <code>record_conformance_result()</code> in <code>nhid_event_store.py</code>), so your badge
-        renders live CAS data instead of the unknown/grey default.
-      </p>
-      <div style="display:flex;gap:1rem;flex-wrap:wrap;margin-bottom:2rem">
-        <a href="https://github.com/NHID-Clinical/NHID-Clinical/blob/main/docs/vendor-trust-questionnaire.md"
-           class="secondary-button" style="display:inline-flex;align-items:center;gap:.4rem">
-          Vendor Trust Questionnaire →
-        </a>
-        <a href="/developers.html#adapters" class="secondary-button" style="display:inline-flex;align-items:center;gap:.4rem">
-          Adapter Reference →
-        </a>
+      <h2 style="margin-top:2.5rem">What a pass does and does not mean</h2>
+      <div class="pass-fail" style="margin-top:1rem">
+        <div class="pass-box">
+          <strong style="display:block;font-size:.74rem;letter-spacing:.1em;text-transform:uppercase;margin-bottom:.5rem">A pass means</strong>
+          <ul style="margin:0;padding-left:1.1rem;color:var(--body);font-size:.9rem;line-height:1.7">
+            <li>Your implementation produced the expected verdict on every published case</li>
+            <li>Someone else can reproduce that result from the same inputs</li>
+            <li>You have evidence to show a counterparty during procurement</li>
+          </ul>
+        </div>
+        <div class="fail-box">
+          <strong style="display:block;font-size:.74rem;letter-spacing:.1em;text-transform:uppercase;margin-bottom:.5rem">A pass does not mean</strong>
+          <ul style="margin:0;padding-left:1.1rem;color:var(--body);font-size:.9rem;line-height:1.7">
+            <li>Certification — there is no certifying body and no accreditation</li>
+            <li>Regulatory compliance in any jurisdiction</li>
+            <li>That your production agents behave this way on live calls</li>
+          </ul>
+        </div>
       </div>
+      <div class="status-note">
+        <span>&#9432;</span>
+        <span><b>Self-attestation only.</b> The <a href="/registry.html" style="color:var(--teal-bright);font-weight:600">Implementation Registry</a> lists implementations that report their own results. NHID-Clinical does not verify, audit, or certify entries.</span>
+      </div>
+    </div>
+  </section>
+
+  <section class="page-cta">
+    <div class="container">
+      <h2>Run it</h2>
+      <p>Locally against your own engine, or continuously against your production agents.</p>
+      <div class="page-cta-grid">
+        <a class="page-cta-card" href="https://github.com/NHID-Clinical/NHID-Clinical"><b>Get the suite <span class="arr">&rarr;</span></b><span>YAML definitions and the runner.</span></a>
+        <a class="page-cta-card" href="/docs.html"><b>Live API explorer <span class="arr">&rarr;</span></b><span>Demo routes, no key required.</span></a>
+        <a class="page-cta-card" href="/evidence-pack.html"><b>Evidence pack <span class="arr">&rarr;</span></b><span>What to show a procurement team.</span></a>
+        <a class="page-cta-card" href="/platform/continuous-conformance.html"><b>Continuous monitoring <span class="arr">&rarr;</span></b><span>Static tests as an ongoing signal.</span></a>
+      </div>
+      <p class="disclaimer-small" style="margin-top:1.5rem">NHID-Clinical is a voluntary open framework — not an accredited standard, certification, or regulatory requirement. Everything on this page is published under CC BY 4.0.</p>
     </div>
   </section>
 </main>
 
-<section class="page-cta">
-  <div class="container">
-    <h2>Where to go next</h2>
-    <p>Four ways into NHID-Clinical, whatever you came to do.</p>
-    <div class="page-cta-grid">
-      <a class="page-cta-card" href="/specification.html"><b>Read the Specification <span class="arr">&rarr;</span></b><span>The v1.3 controls, in full.</span></a>
-      <a class="page-cta-card" href="/simulator.html"><b>Try the Simulator <span class="arr">&rarr;</span></b><span>Run the controls on call scenarios.</span></a>
-      <a class="page-cta-card" href="/evidence-pack.html"><b>Review the Evidence Pack <span class="arr">&rarr;</span></b><span>Guarantees, a failure trace, the audit model.</span></a>
-      <a class="page-cta-card" href="https://github.com/NHID-Clinical/NHID-Clinical/discussions" target="_blank" rel="noopener noreferrer"><b>Join the Community <span class="arr">&#x2197;</span></b><span>Questions and feedback on GitHub.</span></a>
-    </div>
-  </div>
-</section>
 <footer id="contact" class="site-footer">
   <div class="container footer-inner">
     <p>&copy; 2026 Brianna Baynard | NIST-2025-0035-0026 | CC BY 4.0</p>
@@ -231,50 +259,9 @@
       <a href="https://nhid-clinical.org">nhid-clinical.org</a>
     </div>
   </div>
+  <p class="footer-copy" style="margin-top:.4rem">This is an open, actively maintained framework — feedback and contributions welcome. <a href="https://github.com/NHID-Clinical/NHID-Clinical">GitHub</a> · NIST-2025-0035-0026 · CC BY 4.0</p>
 </footer>
 
 <script src="/site.js"></script>
-<script>
-(function () {
-  var listEl = document.getElementById('registry-list');
-  var BADGE_BASE = 'https://gfvq4swdtf.execute-api.us-east-1.amazonaws.com/prod/v1/public/vendor/';
-
-  function escapeHtml(str) {
-    return String(str).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
-  }
-
-  function renderEntries(entries) {
-    if (!entries.length) {
-      listEl.innerHTML = '<p style="color:var(--body)">No implementations are listed yet. ' +
-        'Be the first — see "How to Get Listed" below.</p>';
-      return;
-    }
-    var rows = entries.map(function (e) {
-      var badgeUrl = BADGE_BASE + encodeURIComponent(e.vendor_id) + '/badge';
-      return '<tr style="border-bottom:1px solid var(--border)">' +
-        '<td style="padding:.75rem">' + escapeHtml(e.name || e.vendor_id) + '</td>' +
-        '<td style="padding:.75rem">' + (e.website ? '<a href="' + escapeHtml(e.website) + '" target="_blank" rel="noopener noreferrer">' + escapeHtml(e.website) + '</a>' : '—') + '</td>' +
-        '<td style="padding:.75rem">' + escapeHtml(e.integration_type || '—') + '</td>' +
-        '<td style="padding:.75rem"><img src="' + badgeUrl + '" alt="NHID-CAS badge for ' + escapeHtml(e.vendor_id) + '" /></td>' +
-        '</tr>';
-    }).join('');
-    listEl.innerHTML = '<table style="width:100%;border-collapse:collapse">' +
-      '<thead><tr style="border-bottom:2px solid var(--border);text-align:left">' +
-      '<th style="padding:.75rem">Implementation</th>' +
-      '<th style="padding:.75rem">Website</th>' +
-      '<th style="padding:.75rem">Integration</th>' +
-      '<th style="padding:.75rem">NHID-CAS</th>' +
-      '</tr></thead><tbody>' + rows + '</tbody></table>';
-  }
-
-  fetch('/content/registry_entries.json')
-    .then(function (r) { return r.json(); })
-    .then(renderEntries)
-    .catch(function () {
-      listEl.innerHTML = '<p style="color:var(--body)">No implementations are listed yet. ' +
-        'Be the first — see "How to Get Listed" below.</p>';
-    });
-})();
-</script>
 </body>
 </html>

--- a/framework/controls.html
+++ b/framework/controls.html
@@ -3,9 +3,9 @@
 <head>
   <meta charset="utf-8"/>
   <meta name="viewport" content="width=device-width, initial-scale=1"/>
-  <meta name="description" content="NHID-Clinical pricing — the open framework, specification, conformance tests, simulator, and documentation are free under CC BY 4.0. TrustLayer platform plans for developers and enterprises."/>
-  <title>Pricing | NHID-Clinical</title>
-  <link rel="canonical" href="https://nhid-clinical.org/pricing.html"/>
+  <meta name="description" content="The NHID-Clinical control catalog: IDG-01 Identity Disclosure Gate, PDX-01 Pre-Data Exchange Gate, DBC-01 Deceptive Behavior Check, EIT-01 Escalation Implementation Test, and ATR-01 Audit Trail Requirements."/>
+  <title>Controls | NHID-Clinical Framework</title>
+  <link rel="canonical" href="https://nhid-clinical.org/framework/controls.html"/>
   <link rel="icon" href="/assets/brand/favicon.svg" type="image/svg+xml"/>
   <link rel="icon" href="/assets/brand-icon.png" type="image/png"/>
   <link rel="preconnect" href="https://fonts.googleapis.com"/>
@@ -168,104 +168,124 @@
   <section class="inner-hero">
     <div class="hero-glow" aria-hidden="true"></div>
     <div class="container" style="position:relative;z-index:1;max-width:60rem">
-      <div class="crumbs"><a href="/">Home</a><span>/</span><span>Pricing</span></div>
-      <p class="eyebrow">Open framework &middot; optional platform</p>
-      <h1>The framework is free. The platform is optional.</h1>
-      <p class="lede">The specification, control catalog, conformance test suite, reference implementation, simulator, and documentation are published under CC BY 4.0 and stay that way. TrustLayer adds hosted production infrastructure for organizations that want it.</p>
+      <div class="crumbs"><a href="/">Home</a><span>/</span><a href="/framework/">Framework</a><span>/</span><span>Controls</span></div>
+      <p class="eyebrow">Control catalog · v1.3</p>
+      <h1>Five deterministic controls</h1>
+      <p class="lede">Each control is observable on a real call, checkable against a machine-readable trace, and produces the same verdict for the same inputs every time.</p>
     </div>
   </section>
 
   <section class="page-section">
-    <div class="container">
-      <div class="plan-grid">
-
-        <div class="plan-card">
-          <span class="plan-name">Community</span>
-          <div class="plan-price">$0</div>
-          <p class="plan-for">For practitioners, researchers, developers, and anyone implementing the framework themselves. No account, no signup, no expiry.</p>
-          <ul>
-            <li>Full v1.3 specification and control catalog</li>
-            <li>Conformance test suite (YAML definitions + runner)</li>
-            <li>Reference implementation &mdash; policy engine, middleware, adapters</li>
-            <li>NHID-Auth v2 cryptographic authorization reference code</li>
-            <li>The open simulator, with no account required</li>
-            <li>All documentation and regulatory alignment mappings</li>
-            <li>Community support through GitHub issues and discussions</li>
-          </ul>
-          <div class="plan-cta">
-            <a class="cta-button" href="/framework/" style="width:100%;justify-content:center">Explore the framework <span aria-hidden="true">&rarr;</span></a>
+    <div class="container" style="max-width:60rem">
+      <div class="callout" role="note" style="margin-bottom:1.75rem">
+        <strong>This page is the navigable index.</strong> The normative control text — including RFC 2119 language and the exact conditions of conformance — lives in the <a href="/specification.html" style="color:var(--teal-bright);font-weight:600">v1.3 specification</a>. Where this page and the specification differ, the specification governs.
+      </div>
+      <div style="display:grid;gap:1.5rem">
+      <article class="content-card" id="idg-01" style="padding:2rem">
+        <span class="code">IDG-01</span>
+        <h3 style="font-size:1.25rem;margin:.5rem 0 .35rem">Identity Disclosure Gate</h3>
+        <p style="font-size:1rem;color:var(--ink-soft);font-weight:500;margin-bottom:.75rem">Disclose non-human identity before any protected data is exchanged.</p>
+        <p style="color:var(--body);line-height:1.75">The agent must identify itself as automated as the first meaningful act of the call — not when challenged, not after pleasantries, and not buried in a closing statement. Disclosure is proactive, unambiguous, and timestamped.</p>
+        <div class="pass-fail" style="margin-top:1.25rem">
+          <div class="pass-box">
+            <strong style="display:block;font-size:.74rem;letter-spacing:.1em;text-transform:uppercase;margin-bottom:.5rem">Conformant</strong>
+            <ul style="margin:0;padding-left:1.1rem;color:var(--body);font-size:.88rem;line-height:1.65"><li>Disclosure occurs before the first operational data exchange</li><li>The assertion clearly states the caller is automated</li><li>A disclosure timestamp is present in the audit envelope</li></ul>
+          </div>
+          <div class="fail-box">
+            <strong style="display:block;font-size:.74rem;letter-spacing:.1em;text-transform:uppercase;margin-bottom:.5rem">Non-conformant</strong>
+            <ul style="margin:0;padding-left:1.1rem;color:var(--body);font-size:.88rem;line-height:1.65"><li>Disclosure delayed until the representative asks &ldquo;is this a recording?&rdquo;</li><li>Ambiguous phrasing that a listener could reasonably read as human</li><li>No disclosure timestamp recorded</li></ul>
           </div>
         </div>
-
-        <div class="plan-card is-highlight">
-          <span class="plan-name">Developer</span>
-          <div class="plan-price"><small>Contact for pricing</small></div>
-          <p class="plan-for">For AI vendors and engineering teams building agents that need to demonstrate conformance to their customers.</p>
-          <ul>
-            <li>Everything in Community</li>
-            <li>Hosted sandbox environment</li>
-            <li>API access beyond the public demo routes</li>
-            <li>Generated conformance reports you can share</li>
-            <li>Conformance history across agent versions</li>
-            <li>Integration support during onboarding</li>
-          </ul>
-          <div class="plan-cta">
-            <a class="cta-button" href="mailto:contact@nhid-clinical.org?subject=TrustLayer%20Developer%20plan" style="width:100%;justify-content:center">Talk to us <span aria-hidden="true">&rarr;</span></a>
+      </article>
+      <article class="content-card" id="pdx-01" style="padding:2rem">
+        <span class="code">PDX-01</span>
+        <h3 style="font-size:1.25rem;margin:.5rem 0 .35rem">Pre-Data Exchange Gate</h3>
+        <p style="font-size:1rem;color:var(--ink-soft);font-weight:500;margin-bottom:.75rem">No protected data moves until identity is disclosed.</p>
+        <p style="color:var(--body);line-height:1.75">The complement to IDG-01: rather than checking that disclosure happened, PDX-01 blocks the data path until it has. Every turn is evaluated — late disclosure still blocks protected health information on the turns that preceded it.</p>
+        <div class="pass-fail" style="margin-top:1.25rem">
+          <div class="pass-box">
+            <strong style="display:block;font-size:.74rem;letter-spacing:.1em;text-transform:uppercase;margin-bottom:.5rem">Conformant</strong>
+            <ul style="margin:0;padding-left:1.1rem;color:var(--body);font-size:.88rem;line-height:1.65"><li>Every PHI-bearing turn is preceded by a confirmed disclosure</li><li>Blocked turns are recorded with the reason for the block</li><li>The gate evaluates per turn, not once per call</li></ul>
+          </div>
+          <div class="fail-box">
+            <strong style="display:block;font-size:.74rem;letter-spacing:.1em;text-transform:uppercase;margin-bottom:.5rem">Non-conformant</strong>
+            <ul style="margin:0;padding-left:1.1rem;color:var(--body);font-size:.88rem;line-height:1.65"><li>Member ID, NPI, or claim detail requested before disclosure</li><li>Disclosure treated as a one-time flag rather than a per-turn precondition</li><li>Blocked exchanges dropped silently with no trace</li></ul>
           </div>
         </div>
-
-        <div class="plan-card">
-          <span class="plan-name">Enterprise</span>
-          <div class="plan-price"><small>Contact for pricing</small></div>
-          <p class="plan-for">For payers, provider organizations, and health systems operating or receiving AI agent traffic at scale.</p>
-          <ul>
-            <li>Everything in Developer</li>
-            <li>Trust Gateway &mdash; runtime enforcement</li>
-            <li>Evidence Center &mdash; audit-ready evidence generation</li>
-            <li>Continuous conformance monitoring across an agent fleet</li>
-            <li>Agent Registry with approval workflows</li>
-            <li>SSO, RBAC, integrations, and SIEM export</li>
-            <li>Named support</li>
-          </ul>
-          <div class="plan-cta">
-            <a class="cta-button" href="mailto:contact@nhid-clinical.org?subject=TrustLayer%20Enterprise" style="width:100%;justify-content:center">Talk to us <span aria-hidden="true">&rarr;</span></a>
+      </article>
+      <article class="content-card" id="dbc-01" style="padding:2rem">
+        <span class="code">DBC-01</span>
+        <h3 style="font-size:1.25rem;margin:.5rem 0 .35rem">Deceptive Behavior Check</h3>
+        <p style="font-size:1rem;color:var(--ink-soft);font-weight:500;margin-bottom:.75rem">No synthetic human-presence cues or false human-status claims.</p>
+        <p style="color:var(--body);line-height:1.75">The agent behaves like a machine. No fabricated breathing, typing, or background office noise; no filler designed to imply a person is thinking; no direct or implied claim of being human when asked.</p>
+        <div class="pass-fail" style="margin-top:1.25rem">
+          <div class="pass-box">
+            <strong style="display:block;font-size:.74rem;letter-spacing:.1em;text-transform:uppercase;margin-bottom:.5rem">Conformant</strong>
+            <ul style="margin:0;padding-left:1.1rem;color:var(--body);font-size:.88rem;line-height:1.65"><li>Direct answer of &ldquo;no&rdquo; when asked whether the caller is human</li><li>No audio artifacts engineered to imply human presence</li><li>No persona framing that misrepresents the agent&rsquo;s nature</li></ul>
+          </div>
+          <div class="fail-box">
+            <strong style="display:block;font-size:.74rem;letter-spacing:.1em;text-transform:uppercase;margin-bottom:.5rem">Non-conformant</strong>
+            <ul style="margin:0;padding-left:1.1rem;color:var(--body);font-size:.88rem;line-height:1.65"><li>Synthetic keyboard, breathing, or call-center ambience</li><li>&ldquo;Let me just check that for you&rdquo; paired with simulated hold behavior</li><li>Deflecting rather than answering a direct human-status question</li></ul>
           </div>
         </div>
-
-      </div>
-
-      <div class="status-note" style="margin-top:2rem">
-        <span>&#9432;</span>
-        <span><b>The specification is never paid.</b> No plan, tier, or contract gates the specification, the control catalog, or the conformance test suite. Paid plans buy hosted operations &mdash; monitoring, evidence generation, identity management, and enterprise integration &mdash; never access to the standard itself.</span>
-      </div>
-
-      <div class="status-note">
-        <span>&#9432;</span>
-        <span><b>Pricing is not yet set.</b> TrustLayer is in development with design partners. Developer and Enterprise plans describe the intended packaging; specific pricing will be published once the platform is generally available.</span>
-      </div>
+      </article>
+      <article class="content-card" id="eit-01" style="padding:2rem">
+        <span class="code">EIT-01</span>
+        <h3 style="font-size:1.25rem;margin:.5rem 0 .35rem">Escalation Implementation Test</h3>
+        <p style="font-size:1rem;color:var(--ink-soft);font-weight:500;margin-bottom:.75rem">A clear human handoff, honored on request.</p>
+        <p style="color:var(--body);line-height:1.75">When the person on the other end asks for a human, the transition happens — immediately, unambiguously, and without requiring a specific phrase. The escalation and its outcome are recorded.</p>
+        <div class="pass-fail" style="margin-top:1.25rem">
+          <div class="pass-box">
+            <strong style="display:block;font-size:.74rem;letter-spacing:.1em;text-transform:uppercase;margin-bottom:.5rem">Conformant</strong>
+            <ul style="margin:0;padding-left:1.1rem;color:var(--body);font-size:.88rem;line-height:1.65"><li>Escalation path is available for the duration of the call</li><li>Request is honored without requiring exact wording</li><li>Escalation timestamp and outcome are both recorded</li></ul>
+          </div>
+          <div class="fail-box">
+            <strong style="display:block;font-size:.74rem;letter-spacing:.1em;text-transform:uppercase;margin-bottom:.5rem">Non-conformant</strong>
+            <ul style="margin:0;padding-left:1.1rem;color:var(--body);font-size:.88rem;line-height:1.65"><li>Escalation offered but not actually routed</li><li>Requires a magic phrase or repeated requests</li><li>Escalation attempted with no outcome recorded</li></ul>
+          </div>
+        </div>
+      </article>
+      <article class="content-card" id="atr-01" style="padding:2rem">
+        <span class="code">ATR-01</span>
+        <h3 style="font-size:1.25rem;margin:.5rem 0 .35rem">Audit Trail Requirements</h3>
+        <p style="font-size:1rem;color:var(--ink-soft);font-weight:500;margin-bottom:.75rem">Every call produces a complete, replayable machine-readable trace.</p>
+        <p style="color:var(--body);line-height:1.75">Each event carries a full audit envelope — actor, timestamps, state transitions, and execution context — so the call can be reconstructed after the fact. Missing envelope fields are treated as critical findings, not warnings.</p>
+        <div class="pass-fail" style="margin-top:1.25rem">
+          <div class="pass-box">
+            <strong style="display:block;font-size:.74rem;letter-spacing:.1em;text-transform:uppercase;margin-bottom:.5rem">Conformant</strong>
+            <ul style="margin:0;padding-left:1.1rem;color:var(--body);font-size:.88rem;line-height:1.65"><li>Actor identity, request ID, and session ID present on every event</li><li>State before and after each transition recorded</li><li>Envelope validates against the published trace schema</li></ul>
+          </div>
+          <div class="fail-box">
+            <strong style="display:block;font-size:.74rem;letter-spacing:.1em;text-transform:uppercase;margin-bottom:.5rem">Non-conformant</strong>
+            <ul style="margin:0;padding-left:1.1rem;color:var(--body);font-size:.88rem;line-height:1.65"><li>Partial envelopes with missing actor or timing fields</li><li>Free-text logs that cannot be machine-validated</li><li>Events that cannot be ordered into a replayable sequence</li></ul>
+          </div>
+        </div>
+      </article></div>
     </div>
   </section>
 
   <section class="page-section" style="background:var(--mist)">
-    <div class="container" style="max-width:56rem">
-      <p class="section-kicker">Common question</p>
-      <h2>Why is there a paid tier at all?</h2>
-      <p style="color:var(--body);line-height:1.85;margin-top:.85rem">Because running the controls in production is a different job from defining them. Someone has to operate the monitoring, retain the evidence, integrate with an identity provider, and answer the phone when a control fails at 2am. Organizations that want to do that themselves have everything they need under CC BY 4.0 &mdash; and that path stays fully supported.</p>
-      <p style="color:var(--body);line-height:1.85;margin-top:.85rem">The open framework is the source of legitimacy for this work. Putting it behind a paywall would destroy the thing that makes it worth adopting.</p>
+    <div class="container" style="max-width:60rem">
+      <p class="section-kicker">Beyond pass/fail</p>
+      <h2>Call Authorization Score</h2>
+      <p style="color:var(--body);line-height:1.8;margin-top:.85rem">CAS condenses identity assurance, operational confidence, and audit-envelope completeness into a single 0&ndash;1 score with plain trust tiers. Below the conditional-trust threshold, a human reviews the call. CAS is a measurement, not a certification — it describes one call, not an organization.</p>
+      <div style="margin-top:1.25rem">
+        <a class="cta-button" href="/specification.html">Read the normative definitions <span aria-hidden="true">&rarr;</span></a>
+      </div>
     </div>
   </section>
 
   <section class="page-cta">
     <div class="container">
-      <h2>Not sure where to start?</h2>
-      <p>Most people start free, and most stay there.</p>
+      <h2>See the controls run</h2>
+      <p>Every control here is testable today, on synthetic scenarios or your own call logs.</p>
       <div class="page-cta-grid">
-        <a class="page-cta-card" href="/framework/"><b>Explore the framework <span class="arr">&rarr;</span></b><span>Spec, controls, tests, code &mdash; free.</span></a>
-        <a class="page-cta-card" href="/simulator.html"><b>Run a free evaluation <span class="arr">&rarr;</span></b><span>See the controls fire in the simulator.</span></a>
-        <a class="page-cta-card" href="/shadow-evaluation-guide.html"><b>Shadow evaluation <span class="arr">&rarr;</span></b><span>Baseline your own call logs, no cost.</span></a>
-        <a class="page-cta-card" href="/platform/"><b>TrustLayer platform <span class="arr">&rarr;</span></b><span>What the paid tiers operate.</span></a>
+        <a class="page-cta-card" href="/simulator.html"><b>Open the simulator <span class="arr">&rarr;</span></b><span>Watch the controls fire on a scenario.</span></a>
+        <a class="page-cta-card" href="/framework/conformance-suite.html"><b>Run the test suite <span class="arr">&rarr;</span></b><span>Deterministic pass/fail on your engine.</span></a>
+        <a class="page-cta-card" href="/framework/reference-implementation.html"><b>Read the engine <span class="arr">&rarr;</span></b><span>How each control is evaluated in code.</span></a>
+        <a class="page-cta-card" href="/platform/continuous-conformance.html"><b>Monitor continuously <span class="arr">&rarr;</span></b><span>The same controls, running in production.</span></a>
       </div>
-      <p class="disclaimer-small" style="margin-top:1.5rem">NHID-Clinical is a voluntary open framework — not an accredited standard, certification, or regulatory requirement. TrustLayer is in active development and does not constitute a compliance guarantee.</p>
+      <p class="disclaimer-small" style="margin-top:1.5rem">NHID-Clinical is a voluntary open framework — not an accredited standard, certification, or regulatory requirement. Everything on this page is published under CC BY 4.0.</p>
     </div>
   </section>
 </main>

--- a/framework/index.html
+++ b/framework/index.html
@@ -1,16 +1,18 @@
-﻿<!doctype html>
+<!doctype html>
 <html lang="en">
 <head>
   <meta charset="utf-8"/>
   <meta name="viewport" content="width=device-width, initial-scale=1"/>
-  <meta name="description" content="NHID-Clinical Implementation Registry — self-attested vendor implementations with live NHID-CAS badges."/>
-  <title>Implementation Registry | NHID-Clinical</title>
+  <meta name="description" content="The NHID-Clinical open framework: specification, control catalog, NHID-Auth, reference implementation, conformance test suite, technical stack, and regulatory alignment."/>
+  <title>Framework | NHID-Clinical</title>
+  <link rel="canonical" href="https://nhid-clinical.org/framework/"/>
   <link rel="icon" href="/assets/brand/favicon.svg" type="image/svg+xml"/>
   <link rel="icon" href="/assets/brand-icon.png" type="image/png"/>
   <link rel="preconnect" href="https://fonts.googleapis.com"/>
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
   <link href="https://fonts.googleapis.com/css2?family=Raleway:wght@600;700;800&family=Inter:wght@400;500;600;700;800&family=IBM+Plex+Mono:wght@400;500&display=swap" rel="stylesheet"/>
   <link rel="stylesheet" href="/nhid-clinical-ui.css"/>
+  <link rel="stylesheet" href="/assets/css/premium.css"/>
   <script>try{document.documentElement.setAttribute('data-theme',localStorage.getItem('nhid-theme')||'light')}catch(e){}</script>
   <script defer data-domain="nhid-clinical.org" src="https://plausible.io/js/script.js"></script>
 </head>
@@ -162,66 +164,118 @@
 <div class="nav-backdrop" id="nav-backdrop"></div>
 
 <main>
-  <section class="inner-hero" style="position:relative;overflow:clip">
+
+  <section class="inner-hero">
     <div class="hero-glow" aria-hidden="true"></div>
-    <div class="container" style="position:relative;z-index:1">
-      <div class="crumbs"><a href="/">Home</a><span>/</span><span>Implementation Registry</span></div>
-      <p class="eyebrow">Registry · June 2026</p>
-      <h1 class="reveal">Implementation Registry</h1>
-      <p class="lede reveal">Self-attested NHID-Clinical implementations, with live NHID-CAS conformance badges.</p>
+    <div class="container inner-hero-grid" style="position:relative;z-index:1">
+      <div>
+        <div class="crumbs"><a href="/">Home</a><span>/</span><span>Framework</span></div>
+        <p class="eyebrow">Open Framework · v1.3 · CC BY 4.0</p>
+        <h1>The open framework</h1>
+        <p class="lede">Specification, control catalog, reference implementation, conformance tests, and regulatory mapping for AI agent identity, authorization, disclosure, and audit evidence in healthcare voice workflows.</p>
+        <div class="hero-actions-premium">
+          <a href="/specification.html" class="btn-premium">Read the v1.3 specification</a>
+          <a href="/framework/controls.html" class="btn-ghost">Browse the controls</a>
+        </div>
+      </div>
+      <aside class="hero-summary-card">
+        <div class="spec-badges">
+          <span class="spec-badge">CC BY 4.0</span>
+          <span class="spec-badge">v1.3</span>
+          <span class="spec-badge spec-badge-green">Open</span>
+        </div>
+        <p style="font-size:.88rem;color:var(--body);line-height:1.65;margin:.75rem 0 1rem">The framework is the source of legitimacy for everything NHID-Clinical publishes. It stays open, free, and independently implementable — with or without any commercial product.</p>
+        <a class="primary-pill" href="https://github.com/NHID-Clinical/NHID-Clinical" target="_blank" rel="noopener noreferrer" style="width:100%;justify-content:center">View the repository &#x2197;</a>
+      </aside>
     </div>
   </section>
 
   <section class="page-section">
-    <div class="container" style="max-width:52rem">
-      <div class="callout" role="note" style="margin-bottom:2rem">
-        <strong>This is a self-attestation list, not a certification.</strong> NHID-Clinical does not
-        certify, audit, or warrant any vendor's implementation. A listing means the vendor ran the
-        public conformance test suite (CTS) against their own integration and chose to publish the
-        result. Badge scores update from each vendor's own live <code>/v1/public/vendor/{id}/badge</code>
-        endpoint call — verify independently before relying on them for procurement decisions.
-      </div>
-
-      <h2>Listed Implementations</h2>
-      <div id="registry-list" style="margin:1.5rem 0">
-        <p style="color:var(--body)">Loading…</p>
-      </div>
-
-      <h2 style="margin-top:2.5rem">How to Get Listed</h2>
-      <p style="margin-bottom:1rem">
-        Run the conformance test suite against your integration, then complete the
-        <a href="https://github.com/NHID-Clinical/NHID-Clinical/blob/main/docs/vendor-trust-questionnaire.md">vendor trust questionnaire</a>
-        and open a pull request adding your entry to
-        <a href="https://github.com/NHID-Clinical/NHID-Clinical/blob/main/content/registry_entries.json">content/registry_entries.json</a>.
-        Each entry needs a <code>vendor_id</code> matching the one used when recording conformance results
-        (see <code>record_conformance_result()</code> in <code>nhid_event_store.py</code>), so your badge
-        renders live CAS data instead of the unknown/grey default.
-      </p>
-      <div style="display:flex;gap:1rem;flex-wrap:wrap;margin-bottom:2rem">
-        <a href="https://github.com/NHID-Clinical/NHID-Clinical/blob/main/docs/vendor-trust-questionnaire.md"
-           class="secondary-button" style="display:inline-flex;align-items:center;gap:.4rem">
-          Vendor Trust Questionnaire →
+    <div class="container">
+      <p class="section-kicker">What the framework contains</p>
+      <h2 style="margin-bottom:.35rem">Seven components, all open</h2>
+      <p style="color:var(--body);max-width:62ch;margin-bottom:1.75rem">Each is independently usable. You can adopt the controls without the reference implementation, run the conformance suite against your own engine, or read the regulatory mapping on its own.</p>
+      <div class="module-grid">
+        <a class="module-card" href="/specification.html">
+          <span class="module-num">01</span>
+          <h3>Specification</h3>
+          <p>The v1.3 normative document: the problem, the behaviors, the sequence of interaction, scope boundaries, and known gaps.</p>
+          <span class="arr">Read the specification &rarr;</span>
         </a>
-        <a href="/developers.html#adapters" class="secondary-button" style="display:inline-flex;align-items:center;gap:.4rem">
-          Adapter Reference →
+        <a class="module-card" href="/framework/controls.html">
+          <span class="module-num">02</span>
+          <h3>Control catalog</h3>
+          <p>IDG-01, PDX-01, DBC-01, EIT-01, and ATR-01 — what each control checks, what a pass looks like, and where to try it.</p>
+          <span class="arr">Browse the controls &rarr;</span>
+        </a>
+        <a class="module-card" href="/framework/nhid-auth.html">
+          <span class="module-num">03</span>
+          <h3>NHID-Auth</h3>
+          <p>The v2 cryptographic authorization layer: Ed25519 agent passports, provider-signed delegation, and offline verification.</p>
+          <span class="arr">Read about NHID-Auth &rarr;</span>
+        </a>
+        <a class="module-card" href="/framework/reference-implementation.html">
+          <span class="module-num">04</span>
+          <h3>Reference implementation</h3>
+          <p>A pure-Python policy engine with no runtime dependencies, TypeScript middleware, voice-platform adapters, and a PowerShell module.</p>
+          <span class="arr">See the implementation &rarr;</span>
+        </a>
+        <a class="module-card" href="/framework/conformance-suite.html">
+          <span class="module-num">05</span>
+          <h3>Conformance test suite</h3>
+          <p>Machine-readable, deterministic pass/fail tests. Same inputs, same verdict — every time, for anyone who runs them.</p>
+          <span class="arr">Run the tests &rarr;</span>
+        </a>
+        <a class="module-card" href="/technical-stack.html">
+          <span class="module-num">06</span>
+          <h3>Technical stack</h3>
+          <p>The five-layer trust stack, from carrier authentication through behavioral disclosure to audit and observability.</p>
+          <span class="arr">See the stack &rarr;</span>
+        </a>
+        <a class="module-card" href="/regulatory-alignment.html">
+          <span class="module-num">07</span>
+          <h3>Regulatory alignment</h3>
+          <p>How the controls map to NIST AI RMF, the EU AI Act, ISO/IEC 42001, CMS-0057-F, HIPAA documentation, and state AI laws.</p>
+          <span class="arr">Read the mapping &rarr;</span>
+        </a>
+        <a class="module-card" href="/simulator.html">
+          <span class="module-num">+</span>
+          <h3>Simulator</h3>
+          <p>The open simulator demonstrates NHID-Clinical controls against realistic call scenarios — no setup, no account.</p>
+          <span class="arr">Open the simulator &rarr;</span>
         </a>
       </div>
     </div>
   </section>
+
+  <section class="page-section" style="background:var(--mist)">
+    <div class="container" style="max-width:56rem">
+      <p class="section-kicker">How the framework relates to the platform</p>
+      <h2>The framework is the standard. TrustLayer is optional infrastructure.</h2>
+      <p style="color:var(--body);line-height:1.8;margin-top:.85rem">The specification, control catalog, conformance tests, reference implementation, and simulator remain open under CC BY 4.0. You can implement all of it yourself and never talk to us.</p>
+      <p style="color:var(--body);line-height:1.8;margin-top:.85rem"><a href="/platform/" style="color:var(--teal-bright);font-weight:600">TrustLayer</a> runs the same deterministic controls as production infrastructure — monitoring, evidence generation, agent identity management, authorization, and reporting for organizations operating AI agents at scale. It operationalizes the framework. It does not replace it, and it never becomes a prerequisite for using it.</p>
+      <div class="status-note">
+        <span>&#9432;</span>
+        <span><b>The specification is never paid.</b> No tier, plan, or contract gates the specification, the control catalog, or the conformance test suite.</span>
+      </div>
+    </div>
+  </section>
+
+  <section class="page-cta">
+    <div class="container">
+      <h2>Start with the framework</h2>
+      <p>Read it, run it, and tell us where it breaks.</p>
+      <div class="page-cta-grid">
+        <a class="page-cta-card" href="/specification.html"><b>Read the specification <span class="arr">&rarr;</span></b><span>The v1.3 normative document.</span></a>
+        <a class="page-cta-card" href="/framework/conformance-suite.html"><b>Run the tests <span class="arr">&rarr;</span></b><span>Deterministic pass/fail conformance.</span></a>
+        <a class="page-cta-card" href="/simulator.html"><b>Open the simulator <span class="arr">&rarr;</span></b><span>See the controls fire on a call.</span></a>
+        <a class="page-cta-card" href="https://github.com/NHID-Clinical/NHID-Clinical"><b>Contribute <span class="arr">&rarr;</span></b><span>Issues, discussions, pull requests.</span></a>
+      </div>
+      <p class="disclaimer-small" style="margin-top:1.5rem">NHID-Clinical is a voluntary open framework — not an accredited standard, certification, or regulatory requirement. Everything on this page is published under CC BY 4.0.</p>
+    </div>
+  </section>
 </main>
 
-<section class="page-cta">
-  <div class="container">
-    <h2>Where to go next</h2>
-    <p>Four ways into NHID-Clinical, whatever you came to do.</p>
-    <div class="page-cta-grid">
-      <a class="page-cta-card" href="/specification.html"><b>Read the Specification <span class="arr">&rarr;</span></b><span>The v1.3 controls, in full.</span></a>
-      <a class="page-cta-card" href="/simulator.html"><b>Try the Simulator <span class="arr">&rarr;</span></b><span>Run the controls on call scenarios.</span></a>
-      <a class="page-cta-card" href="/evidence-pack.html"><b>Review the Evidence Pack <span class="arr">&rarr;</span></b><span>Guarantees, a failure trace, the audit model.</span></a>
-      <a class="page-cta-card" href="https://github.com/NHID-Clinical/NHID-Clinical/discussions" target="_blank" rel="noopener noreferrer"><b>Join the Community <span class="arr">&#x2197;</span></b><span>Questions and feedback on GitHub.</span></a>
-    </div>
-  </div>
-</section>
 <footer id="contact" class="site-footer">
   <div class="container footer-inner">
     <p>&copy; 2026 Brianna Baynard | NIST-2025-0035-0026 | CC BY 4.0</p>
@@ -231,50 +285,9 @@
       <a href="https://nhid-clinical.org">nhid-clinical.org</a>
     </div>
   </div>
+  <p class="footer-copy" style="margin-top:.4rem">This is an open, actively maintained framework — feedback and contributions welcome. <a href="https://github.com/NHID-Clinical/NHID-Clinical">GitHub</a> · NIST-2025-0035-0026 · CC BY 4.0</p>
 </footer>
 
 <script src="/site.js"></script>
-<script>
-(function () {
-  var listEl = document.getElementById('registry-list');
-  var BADGE_BASE = 'https://gfvq4swdtf.execute-api.us-east-1.amazonaws.com/prod/v1/public/vendor/';
-
-  function escapeHtml(str) {
-    return String(str).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
-  }
-
-  function renderEntries(entries) {
-    if (!entries.length) {
-      listEl.innerHTML = '<p style="color:var(--body)">No implementations are listed yet. ' +
-        'Be the first — see "How to Get Listed" below.</p>';
-      return;
-    }
-    var rows = entries.map(function (e) {
-      var badgeUrl = BADGE_BASE + encodeURIComponent(e.vendor_id) + '/badge';
-      return '<tr style="border-bottom:1px solid var(--border)">' +
-        '<td style="padding:.75rem">' + escapeHtml(e.name || e.vendor_id) + '</td>' +
-        '<td style="padding:.75rem">' + (e.website ? '<a href="' + escapeHtml(e.website) + '" target="_blank" rel="noopener noreferrer">' + escapeHtml(e.website) + '</a>' : '—') + '</td>' +
-        '<td style="padding:.75rem">' + escapeHtml(e.integration_type || '—') + '</td>' +
-        '<td style="padding:.75rem"><img src="' + badgeUrl + '" alt="NHID-CAS badge for ' + escapeHtml(e.vendor_id) + '" /></td>' +
-        '</tr>';
-    }).join('');
-    listEl.innerHTML = '<table style="width:100%;border-collapse:collapse">' +
-      '<thead><tr style="border-bottom:2px solid var(--border);text-align:left">' +
-      '<th style="padding:.75rem">Implementation</th>' +
-      '<th style="padding:.75rem">Website</th>' +
-      '<th style="padding:.75rem">Integration</th>' +
-      '<th style="padding:.75rem">NHID-CAS</th>' +
-      '</tr></thead><tbody>' + rows + '</tbody></table>';
-  }
-
-  fetch('/content/registry_entries.json')
-    .then(function (r) { return r.json(); })
-    .then(renderEntries)
-    .catch(function () {
-      listEl.innerHTML = '<p style="color:var(--body)">No implementations are listed yet. ' +
-        'Be the first — see "How to Get Listed" below.</p>';
-    });
-})();
-</script>
 </body>
 </html>

--- a/framework/nhid-auth.html
+++ b/framework/nhid-auth.html
@@ -1,16 +1,18 @@
-﻿<!doctype html>
+<!doctype html>
 <html lang="en">
 <head>
   <meta charset="utf-8"/>
   <meta name="viewport" content="width=device-width, initial-scale=1"/>
-  <meta name="description" content="NHID-Clinical Implementation Registry — self-attested vendor implementations with live NHID-CAS badges."/>
-  <title>Implementation Registry | NHID-Clinical</title>
+  <meta name="description" content="NHID-Auth v2 — the open cryptographic authorization layer for healthcare AI agents: Ed25519 agent passports, provider-signed delegation, NPI binding, and offline verification."/>
+  <title>NHID-Auth | NHID-Clinical Framework</title>
+  <link rel="canonical" href="https://nhid-clinical.org/framework/nhid-auth.html"/>
   <link rel="icon" href="/assets/brand/favicon.svg" type="image/svg+xml"/>
   <link rel="icon" href="/assets/brand-icon.png" type="image/png"/>
   <link rel="preconnect" href="https://fonts.googleapis.com"/>
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
   <link href="https://fonts.googleapis.com/css2?family=Raleway:wght@600;700;800&family=Inter:wght@400;500;600;700;800&family=IBM+Plex+Mono:wght@400;500&display=swap" rel="stylesheet"/>
   <link rel="stylesheet" href="/nhid-clinical-ui.css"/>
+  <link rel="stylesheet" href="/assets/css/premium.css"/>
   <script>try{document.documentElement.setAttribute('data-theme',localStorage.getItem('nhid-theme')||'light')}catch(e){}</script>
   <script defer data-domain="nhid-clinical.org" src="https://plausible.io/js/script.js"></script>
 </head>
@@ -162,66 +164,74 @@
 <div class="nav-backdrop" id="nav-backdrop"></div>
 
 <main>
-  <section class="inner-hero" style="position:relative;overflow:clip">
+
+  <section class="inner-hero">
     <div class="hero-glow" aria-hidden="true"></div>
-    <div class="container" style="position:relative;z-index:1">
-      <div class="crumbs"><a href="/">Home</a><span>/</span><span>Implementation Registry</span></div>
-      <p class="eyebrow">Registry · June 2026</p>
-      <h1 class="reveal">Implementation Registry</h1>
-      <p class="lede reveal">Self-attested NHID-Clinical implementations, with live NHID-CAS conformance badges.</p>
+    <div class="container" style="position:relative;z-index:1;max-width:60rem">
+      <div class="crumbs"><a href="/">Home</a><span>/</span><a href="/framework/">Framework</a><span>/</span><span>NHID-Auth</span></div>
+      <p class="eyebrow">Layer 3 · v2 · CC BY 4.0</p>
+      <h1>NHID-Auth</h1>
+      <p class="lede">v1.3 tells you the caller was automated. NHID-Auth tells you the caller was authorized.</p>
     </div>
   </section>
 
   <section class="page-section">
-    <div class="container" style="max-width:52rem">
-      <div class="callout" role="note" style="margin-bottom:2rem">
-        <strong>This is a self-attestation list, not a certification.</strong> NHID-Clinical does not
-        certify, audit, or warrant any vendor's implementation. A listing means the vendor ran the
-        public conformance test suite (CTS) against their own integration and chose to publish the
-        result. Badge scores update from each vendor's own live <code>/v1/public/vendor/{id}/badge</code>
-        endpoint call — verify independently before relying on them for procurement decisions.
+    <div class="container" style="max-width:56rem">
+      <h2>The gap it closes</h2>
+      <p style="color:var(--body);line-height:1.85;margin-top:.75rem">NPIs are public. A caller can state one truthfully and still have no relationship to the organization it names. Behavioral controls establish that a caller disclosed itself as automated; they cannot establish that it was ever delegated authority to act for the provider it claims.</p>
+      <p style="color:var(--body);line-height:1.85;margin-top:.75rem">NHID-Auth addresses that with signed delegation rather than a registry or a gatekeeper. A provider signs a statement binding an agent&rsquo;s public key to an NPI and a bounded scope. The receiving side verifies that signature offline — no lookup, no central authority, no service to call.</p>
+
+      <h2 style="margin-top:2.5rem">How it works</h2>
+      <ol class="gateway-flow">
+        <li class="gateway-step"><span class="gw-num">1</span><strong>Provider signs a delegation</strong><span>The provider organization holds a key pair and signs a passport binding an agent public key to its NPI, a purpose, a scope, and an expiration.</span></li>
+        <li class="gateway-step"><span class="gw-num">2</span><strong>Agent presents the passport</strong><span>The AI agent carries the signed passport into the call alongside its behavioral disclosure.</span></li>
+        <li class="gateway-step"><span class="gw-num">3</span><strong>Receiver verifies offline</strong><span>Ed25519 signature verification against the provider&rsquo;s published public key. No network call to NHID-Clinical, no registry lookup, no dependency on us.</span></li>
+        <li class="gateway-step"><span class="gw-num">4</span><strong>Scope is enforced</strong><span>An agent delegated for eligibility checks cannot use the same passport to pursue claims appeals. Scope is a precondition, not a suggestion.</span></li>
+        <li class="gateway-step is-endpoint"><span class="gw-num">5</span><strong>Expiration and revocation</strong><span>Passports carry an expiry. A provider revokes by rotating keys or publishing a revocation, without coordinating with any third party.</span></li>
+      </ol>
+
+      <h2 style="margin-top:2.5rem">Design properties</h2>
+      <div class="content-cards" style="grid-template-columns:repeat(auto-fit,minmax(15rem,1fr));margin-top:1.25rem">
+        <div class="content-card">
+          <h3>No registry, no gatekeeper</h3>
+          <p>Verification is a signature check. NHID-Clinical is not in the trust path and cannot become a chokepoint.</p>
+        </div>
+        <div class="content-card">
+          <h3>Offline verifiable</h3>
+          <p>Works when the network does not. Nothing about verification requires reaching an external service in real time.</p>
+        </div>
+        <div class="content-card">
+          <h3>Bounded by construction</h3>
+          <p>Scope and expiration are fields in the signed payload, so an over-broad or stale passport fails verification rather than relying on policy.</p>
+        </div>
+        <div class="content-card">
+          <h3>Open reference code</h3>
+          <p>The implementation is public in the repository under CC BY 4.0. Fork it, port it, or write your own against the format.</p>
+        </div>
       </div>
 
-      <h2>Listed Implementations</h2>
-      <div id="registry-list" style="margin:1.5rem 0">
-        <p style="color:var(--body)">Loading…</p>
+      <div class="status-note">
+        <span>&#9432;</span>
+        <span><b>Status:</b> NHID-Auth v2 is a published open reference implementation, not a deployed identity infrastructure. There are no production issuers yet. It documents a workable approach to delegated agent authority and invites implementers to break it.</span>
       </div>
+    </div>
+  </section>
 
-      <h2 style="margin-top:2.5rem">How to Get Listed</h2>
-      <p style="margin-bottom:1rem">
-        Run the conformance test suite against your integration, then complete the
-        <a href="https://github.com/NHID-Clinical/NHID-Clinical/blob/main/docs/vendor-trust-questionnaire.md">vendor trust questionnaire</a>
-        and open a pull request adding your entry to
-        <a href="https://github.com/NHID-Clinical/NHID-Clinical/blob/main/content/registry_entries.json">content/registry_entries.json</a>.
-        Each entry needs a <code>vendor_id</code> matching the one used when recording conformance results
-        (see <code>record_conformance_result()</code> in <code>nhid_event_store.py</code>), so your badge
-        renders live CAS data instead of the unknown/grey default.
-      </p>
-      <div style="display:flex;gap:1rem;flex-wrap:wrap;margin-bottom:2rem">
-        <a href="https://github.com/NHID-Clinical/NHID-Clinical/blob/main/docs/vendor-trust-questionnaire.md"
-           class="secondary-button" style="display:inline-flex;align-items:center;gap:.4rem">
-          Vendor Trust Questionnaire →
-        </a>
-        <a href="/developers.html#adapters" class="secondary-button" style="display:inline-flex;align-items:center;gap:.4rem">
-          Adapter Reference →
-        </a>
+  <section class="page-cta">
+    <div class="container">
+      <h2>Work with NHID-Auth</h2>
+      <p>The reference code, the integration notes, and the layer it sits in.</p>
+      <div class="page-cta-grid">
+        <a class="page-cta-card" href="/framework/reference-implementation.html"><b>Reference implementation <span class="arr">&rarr;</span></b><span>Where the code lives and how to run it.</span></a>
+        <a class="page-cta-card" href="/technical-stack.html"><b>The five-layer stack <span class="arr">&rarr;</span></b><span>How Layer 3 relates to the rest.</span></a>
+        <a class="page-cta-card" href="/developers.html"><b>Developer guide <span class="arr">&rarr;</span></b><span>APIs, schemas, and integration.</span></a>
+        <a class="page-cta-card" href="/platform/agent-registry.html"><b>Managed identity <span class="arr">&rarr;</span></b><span>TrustLayer&rsquo;s hosted agent registry.</span></a>
       </div>
+      <p class="disclaimer-small" style="margin-top:1.5rem">NHID-Clinical is a voluntary open framework — not an accredited standard, certification, or regulatory requirement. Everything on this page is published under CC BY 4.0.</p>
     </div>
   </section>
 </main>
 
-<section class="page-cta">
-  <div class="container">
-    <h2>Where to go next</h2>
-    <p>Four ways into NHID-Clinical, whatever you came to do.</p>
-    <div class="page-cta-grid">
-      <a class="page-cta-card" href="/specification.html"><b>Read the Specification <span class="arr">&rarr;</span></b><span>The v1.3 controls, in full.</span></a>
-      <a class="page-cta-card" href="/simulator.html"><b>Try the Simulator <span class="arr">&rarr;</span></b><span>Run the controls on call scenarios.</span></a>
-      <a class="page-cta-card" href="/evidence-pack.html"><b>Review the Evidence Pack <span class="arr">&rarr;</span></b><span>Guarantees, a failure trace, the audit model.</span></a>
-      <a class="page-cta-card" href="https://github.com/NHID-Clinical/NHID-Clinical/discussions" target="_blank" rel="noopener noreferrer"><b>Join the Community <span class="arr">&#x2197;</span></b><span>Questions and feedback on GitHub.</span></a>
-    </div>
-  </div>
-</section>
 <footer id="contact" class="site-footer">
   <div class="container footer-inner">
     <p>&copy; 2026 Brianna Baynard | NIST-2025-0035-0026 | CC BY 4.0</p>
@@ -231,50 +241,9 @@
       <a href="https://nhid-clinical.org">nhid-clinical.org</a>
     </div>
   </div>
+  <p class="footer-copy" style="margin-top:.4rem">This is an open, actively maintained framework — feedback and contributions welcome. <a href="https://github.com/NHID-Clinical/NHID-Clinical">GitHub</a> · NIST-2025-0035-0026 · CC BY 4.0</p>
 </footer>
 
 <script src="/site.js"></script>
-<script>
-(function () {
-  var listEl = document.getElementById('registry-list');
-  var BADGE_BASE = 'https://gfvq4swdtf.execute-api.us-east-1.amazonaws.com/prod/v1/public/vendor/';
-
-  function escapeHtml(str) {
-    return String(str).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
-  }
-
-  function renderEntries(entries) {
-    if (!entries.length) {
-      listEl.innerHTML = '<p style="color:var(--body)">No implementations are listed yet. ' +
-        'Be the first — see "How to Get Listed" below.</p>';
-      return;
-    }
-    var rows = entries.map(function (e) {
-      var badgeUrl = BADGE_BASE + encodeURIComponent(e.vendor_id) + '/badge';
-      return '<tr style="border-bottom:1px solid var(--border)">' +
-        '<td style="padding:.75rem">' + escapeHtml(e.name || e.vendor_id) + '</td>' +
-        '<td style="padding:.75rem">' + (e.website ? '<a href="' + escapeHtml(e.website) + '" target="_blank" rel="noopener noreferrer">' + escapeHtml(e.website) + '</a>' : '—') + '</td>' +
-        '<td style="padding:.75rem">' + escapeHtml(e.integration_type || '—') + '</td>' +
-        '<td style="padding:.75rem"><img src="' + badgeUrl + '" alt="NHID-CAS badge for ' + escapeHtml(e.vendor_id) + '" /></td>' +
-        '</tr>';
-    }).join('');
-    listEl.innerHTML = '<table style="width:100%;border-collapse:collapse">' +
-      '<thead><tr style="border-bottom:2px solid var(--border);text-align:left">' +
-      '<th style="padding:.75rem">Implementation</th>' +
-      '<th style="padding:.75rem">Website</th>' +
-      '<th style="padding:.75rem">Integration</th>' +
-      '<th style="padding:.75rem">NHID-CAS</th>' +
-      '</tr></thead><tbody>' + rows + '</tbody></table>';
-  }
-
-  fetch('/content/registry_entries.json')
-    .then(function (r) { return r.json(); })
-    .then(renderEntries)
-    .catch(function () {
-      listEl.innerHTML = '<p style="color:var(--body)">No implementations are listed yet. ' +
-        'Be the first — see "How to Get Listed" below.</p>';
-    });
-})();
-</script>
 </body>
 </html>

--- a/framework/reference-implementation.html
+++ b/framework/reference-implementation.html
@@ -1,16 +1,18 @@
-﻿<!doctype html>
+<!doctype html>
 <html lang="en">
 <head>
   <meta charset="utf-8"/>
   <meta name="viewport" content="width=device-width, initial-scale=1"/>
-  <meta name="description" content="NHID-Clinical Implementation Registry — self-attested vendor implementations with live NHID-CAS badges."/>
-  <title>Implementation Registry | NHID-Clinical</title>
+  <meta name="description" content="The NHID-Clinical open reference implementation: a dependency-free Python policy engine, TypeScript middleware, VAPI and Twilio adapters, PowerShell module, OpenAPI spec, and Postman collection."/>
+  <title>Reference Implementation | NHID-Clinical Framework</title>
+  <link rel="canonical" href="https://nhid-clinical.org/framework/reference-implementation.html"/>
   <link rel="icon" href="/assets/brand/favicon.svg" type="image/svg+xml"/>
   <link rel="icon" href="/assets/brand-icon.png" type="image/png"/>
   <link rel="preconnect" href="https://fonts.googleapis.com"/>
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
   <link href="https://fonts.googleapis.com/css2?family=Raleway:wght@600;700;800&family=Inter:wght@400;500;600;700;800&family=IBM+Plex+Mono:wght@400;500&display=swap" rel="stylesheet"/>
   <link rel="stylesheet" href="/nhid-clinical-ui.css"/>
+  <link rel="stylesheet" href="/assets/css/premium.css"/>
   <script>try{document.documentElement.setAttribute('data-theme',localStorage.getItem('nhid-theme')||'light')}catch(e){}</script>
   <script defer data-domain="nhid-clinical.org" src="https://plausible.io/js/script.js"></script>
 </head>
@@ -162,66 +164,100 @@
 <div class="nav-backdrop" id="nav-backdrop"></div>
 
 <main>
-  <section class="inner-hero" style="position:relative;overflow:clip">
+
+  <section class="inner-hero">
     <div class="hero-glow" aria-hidden="true"></div>
-    <div class="container" style="position:relative;z-index:1">
-      <div class="crumbs"><a href="/">Home</a><span>/</span><span>Implementation Registry</span></div>
-      <p class="eyebrow">Registry · June 2026</p>
-      <h1 class="reveal">Implementation Registry</h1>
-      <p class="lede reveal">Self-attested NHID-Clinical implementations, with live NHID-CAS conformance badges.</p>
+    <div class="container" style="position:relative;z-index:1;max-width:60rem">
+      <div class="crumbs"><a href="/">Home</a><span>/</span><a href="/framework/">Framework</a><span>/</span><span>Reference Implementation</span></div>
+      <p class="eyebrow">Open source · CC BY 4.0</p>
+      <h1>Reference implementation</h1>
+      <p class="lede">A working implementation of every control in the specification — so &ldquo;conformant&rdquo; means something you can run, not something you can claim.</p>
+      <div class="hero-actions-premium">
+        <a href="https://github.com/NHID-Clinical/NHID-Clinical" class="btn-premium" target="_blank" rel="noopener noreferrer">View the repository &#x2197;</a>
+        <a href="/developers.html" class="btn-ghost">Developer guide</a>
+      </div>
     </div>
   </section>
 
   <section class="page-section">
-    <div class="container" style="max-width:52rem">
-      <div class="callout" role="note" style="margin-bottom:2rem">
-        <strong>This is a self-attestation list, not a certification.</strong> NHID-Clinical does not
-        certify, audit, or warrant any vendor's implementation. A listing means the vendor ran the
-        public conformance test suite (CTS) against their own integration and chose to publish the
-        result. Badge scores update from each vendor's own live <code>/v1/public/vendor/{id}/badge</code>
-        endpoint call — verify independently before relying on them for procurement decisions.
+    <div class="container" style="max-width:60rem">
+      <h2>What ships</h2>
+      <div class="module-grid">
+        <div class="module-card">
+          <span class="module-num">ENGINE</span>
+          <h3>Policy engine</h3>
+          <p>Pure Python with zero runtime dependencies. Evaluates each control against a session and event and returns a deterministic verdict.</p>
+        </div>
+        <div class="module-card">
+          <span class="module-num">MIDDLEWARE</span>
+          <h3>TypeScript middleware</h3>
+          <p>Request-path enforcement for Node services, mirroring the Python engine&rsquo;s verdicts.</p>
+        </div>
+        <div class="module-card">
+          <span class="module-num">ADAPTERS</span>
+          <h3>VAPI &amp; Twilio adapters</h3>
+          <p>Accept native call payloads from either platform and normalize them into the evaluation format — no transcript reformatting required.</p>
+        </div>
+        <div class="module-card">
+          <span class="module-num">AUTH</span>
+          <h3>NHID-Auth v2</h3>
+          <p>Ed25519 agent passports, provider-signed delegation, and offline verification. <a href="/framework/nhid-auth.html" style="color:var(--teal-bright);font-weight:600">Details &rarr;</a></p>
+        </div>
+        <div class="module-card">
+          <span class="module-num">SCHEMA</span>
+          <h3>Trace schema</h3>
+          <p>The machine-readable audit envelope every event validates against, published as JSON Schema.</p>
+        </div>
+        <div class="module-card">
+          <span class="module-num">TOOLING</span>
+          <h3>OpenAPI, Postman, PowerShell</h3>
+          <p>An OpenAPI description, a Postman collection, and a PowerShell module for teams whose operations tooling lives there.</p>
+        </div>
       </div>
 
-      <h2>Listed Implementations</h2>
-      <div id="registry-list" style="margin:1.5rem 0">
-        <p style="color:var(--body)">Loading…</p>
-      </div>
+      <h2 style="margin-top:2.75rem">Determinism is the point</h2>
+      <p style="color:var(--body);line-height:1.85;margin-top:.75rem">The engine contains no model calls and no scoring heuristics in the control path. The same session and event produce the same verdict on every machine, every run. That is what makes a conformance claim checkable by someone who does not trust you — including a regulator, an auditor, or a competitor.</p>
+      <p style="color:var(--body);line-height:1.85;margin-top:.75rem">It is also what lets the same control logic run in three places without drift: in the test suite, in the simulator, and in production enforcement.</p>
 
-      <h2 style="margin-top:2.5rem">How to Get Listed</h2>
-      <p style="margin-bottom:1rem">
-        Run the conformance test suite against your integration, then complete the
-        <a href="https://github.com/NHID-Clinical/NHID-Clinical/blob/main/docs/vendor-trust-questionnaire.md">vendor trust questionnaire</a>
-        and open a pull request adding your entry to
-        <a href="https://github.com/NHID-Clinical/NHID-Clinical/blob/main/content/registry_entries.json">content/registry_entries.json</a>.
-        Each entry needs a <code>vendor_id</code> matching the one used when recording conformance results
-        (see <code>record_conformance_result()</code> in <code>nhid_event_store.py</code>), so your badge
-        renders live CAS data instead of the unknown/grey default.
-      </p>
-      <div style="display:flex;gap:1rem;flex-wrap:wrap;margin-bottom:2rem">
-        <a href="https://github.com/NHID-Clinical/NHID-Clinical/blob/main/docs/vendor-trust-questionnaire.md"
-           class="secondary-button" style="display:inline-flex;align-items:center;gap:.4rem">
-          Vendor Trust Questionnaire →
-        </a>
-        <a href="/developers.html#adapters" class="secondary-button" style="display:inline-flex;align-items:center;gap:.4rem">
-          Adapter Reference →
-        </a>
+      <h2 style="margin-top:2.5rem">Getting started</h2>
+      <div class="content-cards" style="grid-template-columns:repeat(auto-fit,minmax(15rem,1fr));margin-top:1.25rem">
+        <div class="content-card">
+          <span class="step-num">1</span>
+          <h3>Clone and run the tests</h3>
+          <p>The repository ships with its full test suite. Run it before you write a line of integration code.</p>
+          <a class="card-link" href="https://github.com/NHID-Clinical/NHID-Clinical">Get the repository &rarr;</a>
+        </div>
+        <div class="content-card">
+          <span class="step-num">2</span>
+          <h3>Try the live API</h3>
+          <p>Demo routes require no key. Send a VAPI or Twilio payload and read the verdict.</p>
+          <a class="card-link" href="/docs.html">Open the API explorer &rarr;</a>
+        </div>
+        <div class="content-card">
+          <span class="step-num">3</span>
+          <h3>Wire it into your stack</h3>
+          <p>The developer guide covers architecture, the event schema, and the failure-injection harness.</p>
+          <a class="card-link" href="/developers.html">Read the developer guide &rarr;</a>
+        </div>
       </div>
+    </div>
+  </section>
+
+  <section class="page-cta">
+    <div class="container">
+      <h2>Build on it</h2>
+      <p>Everything here is CC BY 4.0. Fork it, vendor it, or replace it with your own engine and test against the same suite.</p>
+      <div class="page-cta-grid">
+        <a class="page-cta-card" href="/framework/conformance-suite.html"><b>Conformance suite <span class="arr">&rarr;</span></b><span>Prove your engine agrees.</span></a>
+        <a class="page-cta-card" href="/interoperability.html"><b>Interoperability <span class="arr">&rarr;</span></b><span>Working with existing telephony.</span></a>
+        <a class="page-cta-card" href="/registry.html"><b>Implementation Registry <span class="arr">&rarr;</span></b><span>Self-attested implementations.</span></a>
+        <a class="page-cta-card" href="https://github.com/NHID-Clinical/NHID-Clinical"><b>Contribute <span class="arr">&rarr;</span></b><span>Issues, discussions, pull requests.</span></a>
+      </div>
+      <p class="disclaimer-small" style="margin-top:1.5rem">NHID-Clinical is a voluntary open framework — not an accredited standard, certification, or regulatory requirement. Everything on this page is published under CC BY 4.0.</p>
     </div>
   </section>
 </main>
 
-<section class="page-cta">
-  <div class="container">
-    <h2>Where to go next</h2>
-    <p>Four ways into NHID-Clinical, whatever you came to do.</p>
-    <div class="page-cta-grid">
-      <a class="page-cta-card" href="/specification.html"><b>Read the Specification <span class="arr">&rarr;</span></b><span>The v1.3 controls, in full.</span></a>
-      <a class="page-cta-card" href="/simulator.html"><b>Try the Simulator <span class="arr">&rarr;</span></b><span>Run the controls on call scenarios.</span></a>
-      <a class="page-cta-card" href="/evidence-pack.html"><b>Review the Evidence Pack <span class="arr">&rarr;</span></b><span>Guarantees, a failure trace, the audit model.</span></a>
-      <a class="page-cta-card" href="https://github.com/NHID-Clinical/NHID-Clinical/discussions" target="_blank" rel="noopener noreferrer"><b>Join the Community <span class="arr">&#x2197;</span></b><span>Questions and feedback on GitHub.</span></a>
-    </div>
-  </div>
-</section>
 <footer id="contact" class="site-footer">
   <div class="container footer-inner">
     <p>&copy; 2026 Brianna Baynard | NIST-2025-0035-0026 | CC BY 4.0</p>
@@ -231,50 +267,9 @@
       <a href="https://nhid-clinical.org">nhid-clinical.org</a>
     </div>
   </div>
+  <p class="footer-copy" style="margin-top:.4rem">This is an open, actively maintained framework — feedback and contributions welcome. <a href="https://github.com/NHID-Clinical/NHID-Clinical">GitHub</a> · NIST-2025-0035-0026 · CC BY 4.0</p>
 </footer>
 
 <script src="/site.js"></script>
-<script>
-(function () {
-  var listEl = document.getElementById('registry-list');
-  var BADGE_BASE = 'https://gfvq4swdtf.execute-api.us-east-1.amazonaws.com/prod/v1/public/vendor/';
-
-  function escapeHtml(str) {
-    return String(str).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
-  }
-
-  function renderEntries(entries) {
-    if (!entries.length) {
-      listEl.innerHTML = '<p style="color:var(--body)">No implementations are listed yet. ' +
-        'Be the first — see "How to Get Listed" below.</p>';
-      return;
-    }
-    var rows = entries.map(function (e) {
-      var badgeUrl = BADGE_BASE + encodeURIComponent(e.vendor_id) + '/badge';
-      return '<tr style="border-bottom:1px solid var(--border)">' +
-        '<td style="padding:.75rem">' + escapeHtml(e.name || e.vendor_id) + '</td>' +
-        '<td style="padding:.75rem">' + (e.website ? '<a href="' + escapeHtml(e.website) + '" target="_blank" rel="noopener noreferrer">' + escapeHtml(e.website) + '</a>' : '—') + '</td>' +
-        '<td style="padding:.75rem">' + escapeHtml(e.integration_type || '—') + '</td>' +
-        '<td style="padding:.75rem"><img src="' + badgeUrl + '" alt="NHID-CAS badge for ' + escapeHtml(e.vendor_id) + '" /></td>' +
-        '</tr>';
-    }).join('');
-    listEl.innerHTML = '<table style="width:100%;border-collapse:collapse">' +
-      '<thead><tr style="border-bottom:2px solid var(--border);text-align:left">' +
-      '<th style="padding:.75rem">Implementation</th>' +
-      '<th style="padding:.75rem">Website</th>' +
-      '<th style="padding:.75rem">Integration</th>' +
-      '<th style="padding:.75rem">NHID-CAS</th>' +
-      '</tr></thead><tbody>' + rows + '</tbody></table>';
-  }
-
-  fetch('/content/registry_entries.json')
-    .then(function (r) { return r.json(); })
-    .then(renderEntries)
-    .catch(function () {
-      listEl.innerHTML = '<p style="color:var(--body)">No implementations are listed yet. ' +
-        'Be the first — see "How to Get Listed" below.</p>';
-    });
-})();
-</script>
 </body>
 </html>

--- a/governance-simulator.html
+++ b/governance-simulator.html
@@ -341,44 +341,57 @@
       </span>
     </a>
     <div class="nav-links">
-      <a href="/">Home</a>
       <div class="nav-dropdown">
-        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Learn <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
+        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Framework <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
         <div class="nav-dropdown-menu">
+          <a href="/framework/">Framework overview</a>
           <a href="/specification.html">Specification</a>
+          <a href="/framework/controls.html">Controls</a>
+          <a href="/framework/nhid-auth.html">NHID-Auth</a>
+          <a href="/framework/reference-implementation.html">Reference Implementation</a>
+          <a href="/framework/conformance-suite.html">Conformance Test Suite</a>
           <a href="/technical-stack.html">Technical Stack</a>
           <a href="/regulatory-alignment.html">Regulatory Alignment</a>
-          <a href="/about.html">About</a>
         </div>
       </div>
       <div class="nav-dropdown">
-        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Evaluate <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
+        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Platform <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
         <div class="nav-dropdown-menu">
-          <a href="/simulator.html">Simulator</a>
-          <a href="/shadow-evaluation-guide.html">Shadow Evaluation</a>
-          <a href="/evidence-pack.html">Evidence Pack</a>
-          <a href="/for-payers.html">For Payers</a>
+          <a href="/platform/">TrustLayer overview</a>
+          <a href="/platform/agent-registry.html">Agent Registry</a>
+          <a href="/platform/trust-gateway.html">Trust Gateway</a>
+          <a href="/platform/evidence-center.html">Evidence Center</a>
+          <a href="/platform/continuous-conformance.html">Continuous Conformance</a>
+          <a href="/platform/enterprise.html">Enterprise Workflow</a>
         </div>
       </div>
+      <a href="/simulator.html">Simulator</a>
       <div class="nav-dropdown">
-        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Build <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
+        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Docs <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
         <div class="nav-dropdown-menu">
-          <a href="/developers.html">Developers</a>
+          <a href="/developers.html">Developer guide</a>
+          <a href="/docs.html">Live API explorer</a>
           <a href="/interoperability.html">Interoperability</a>
           <a href="/registry.html">Implementation Registry</a>
           <a href="/icon-system.html">Icon System</a>
         </div>
       </div>
       <div class="nav-dropdown">
-        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Community <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
+        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Resources <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
         <div class="nav-dropdown-menu">
-          <a href="/news.html">News</a>
+          <a href="/evidence-pack.html">Evidence Pack</a>
+          <a href="/shadow-evaluation-guide.html">Shadow Evaluation Guide</a>
+          <a href="/for-payers.html">For Payers</a>
+          <a href="/research-portfolio.html">Research Portfolio</a>
           <a href="/roadmap.html">Roadmap</a>
-          <a href="/research-portfolio.html">Portfolio</a>
-          <a href="https://github.com/NHID-Clinical/NHID-Clinical">GitHub &#x2197;</a>
+          <a href="/news.html">News</a>
+          <a href="/faq.html">FAQ</a>
+          <a href="https://ai-governance-map.vercel.app/" target="_blank" rel="noopener noreferrer">AI Governance Map &#x2197;</a>
         </div>
       </div>
-      <a href="https://ai-governance-map.vercel.app/" target="_blank" rel="noopener noreferrer">AI Map &#x2197;</a>
+      <a href="/pricing.html">Pricing</a>
+      <a href="/about.html">About</a>
+      <a href="https://github.com/NHID-Clinical" target="_blank" rel="noopener noreferrer">GitHub &#x2197;</a>
     </div>
     <div class="nav-actions">
       <button class="icon-button search-toggle" type="button" aria-label="Search" id="search-toggle">
@@ -410,27 +423,44 @@
 
 <nav class="mobile-nav" id="mobile-nav" aria-label="Mobile navigation">
   <a href="/">Home</a>
-  <strong class="mobile-nav-group">Learn</strong>
+  <strong class="mobile-nav-group">Framework</strong>
+  <a href="/framework/">Framework overview</a>
   <a href="/specification.html">Specification</a>
+  <a href="/framework/controls.html">Controls</a>
+  <a href="/framework/nhid-auth.html">NHID-Auth</a>
+  <a href="/framework/reference-implementation.html">Reference Implementation</a>
+  <a href="/framework/conformance-suite.html">Conformance Test Suite</a>
   <a href="/technical-stack.html">Technical Stack</a>
   <a href="/regulatory-alignment.html">Regulatory Alignment</a>
-  <a href="/about.html">About</a>
-  <strong class="mobile-nav-group">Evaluate</strong>
-  <a href="/simulator.html">Simulator</a>
-  <a href="/shadow-evaluation-guide.html">Shadow Evaluation</a>
-  <a href="/evidence-pack.html">Evidence Pack</a>
-  <a href="/for-payers.html">For Payers</a>
-  <strong class="mobile-nav-group">Build</strong>
-  <a href="/developers.html">Developers</a>
+  <strong class="mobile-nav-group">Platform</strong>
+  <a href="/platform/">TrustLayer overview</a>
+  <a href="/platform/agent-registry.html">Agent Registry</a>
+  <a href="/platform/trust-gateway.html">Trust Gateway</a>
+  <a href="/platform/evidence-center.html">Evidence Center</a>
+  <a href="/platform/continuous-conformance.html">Continuous Conformance</a>
+  <a href="/platform/enterprise.html">Enterprise Workflow</a>
+  <strong class="mobile-nav-group">Simulator</strong>
+  <a href="/simulator.html">Open the simulator</a>
+  <a href="/governance-simulator.html">Governance Simulator</a>
+  <strong class="mobile-nav-group">Docs</strong>
+  <a href="/developers.html">Developer guide</a>
+  <a href="/docs.html">Live API explorer</a>
   <a href="/interoperability.html">Interoperability</a>
   <a href="/registry.html">Implementation Registry</a>
   <a href="/icon-system.html">Icon System</a>
-  <strong class="mobile-nav-group">Community</strong>
-  <a href="/news.html">News</a>
+  <strong class="mobile-nav-group">Resources</strong>
+  <a href="/evidence-pack.html">Evidence Pack</a>
+  <a href="/shadow-evaluation-guide.html">Shadow Evaluation Guide</a>
+  <a href="/for-payers.html">For Payers</a>
+  <a href="/research-portfolio.html">Research Portfolio</a>
   <a href="/roadmap.html">Roadmap</a>
-  <a href="/research-portfolio.html">Portfolio</a>
-  <a href="https://github.com/NHID-Clinical/NHID-Clinical" target="_blank" rel="noopener noreferrer">GitHub &#x2197;</a>
-  <a href="https://ai-governance-map.vercel.app/" target="_blank" rel="noopener noreferrer">AI Map &#x2197;</a>
+  <a href="/news.html">News</a>
+  <a href="/faq.html">FAQ</a>
+  <a href="https://ai-governance-map.vercel.app/" target="_blank" rel="noopener noreferrer">AI Governance Map &#x2197;</a>
+  <strong class="mobile-nav-group">More</strong>
+  <a href="/pricing.html">Pricing</a>
+  <a href="/about.html">About</a>
+  <a href="https://github.com/NHID-Clinical" target="_blank" rel="noopener noreferrer">GitHub &#x2197;</a>
   <div class="mobile-nav-footer">
     <button class="theme-toggle mobile-theme-toggle" type="button" aria-label="Toggle dark mode">
       <svg class="sun-icon" viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M6.34 17.66l-1.41 1.41M19.07 4.93l-1.41 1.41"/></svg>

--- a/icon-system.html
+++ b/icon-system.html
@@ -31,44 +31,57 @@
       </span>
     </a>
     <div class="nav-links">
-      <a href="/">Home</a>
       <div class="nav-dropdown">
-        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Learn <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
+        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Framework <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
         <div class="nav-dropdown-menu">
+          <a href="/framework/">Framework overview</a>
           <a href="/specification.html">Specification</a>
+          <a href="/framework/controls.html">Controls</a>
+          <a href="/framework/nhid-auth.html">NHID-Auth</a>
+          <a href="/framework/reference-implementation.html">Reference Implementation</a>
+          <a href="/framework/conformance-suite.html">Conformance Test Suite</a>
           <a href="/technical-stack.html">Technical Stack</a>
           <a href="/regulatory-alignment.html">Regulatory Alignment</a>
-          <a href="/about.html">About</a>
         </div>
       </div>
       <div class="nav-dropdown">
-        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Evaluate <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
+        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Platform <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
         <div class="nav-dropdown-menu">
-          <a href="/simulator.html">Simulator</a>
-          <a href="/shadow-evaluation-guide.html">Shadow Evaluation</a>
-          <a href="/evidence-pack.html">Evidence Pack</a>
-          <a href="/for-payers.html">For Payers</a>
+          <a href="/platform/">TrustLayer overview</a>
+          <a href="/platform/agent-registry.html">Agent Registry</a>
+          <a href="/platform/trust-gateway.html">Trust Gateway</a>
+          <a href="/platform/evidence-center.html">Evidence Center</a>
+          <a href="/platform/continuous-conformance.html">Continuous Conformance</a>
+          <a href="/platform/enterprise.html">Enterprise Workflow</a>
         </div>
       </div>
+      <a href="/simulator.html">Simulator</a>
       <div class="nav-dropdown">
-        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Build <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
+        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Docs <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
         <div class="nav-dropdown-menu">
-          <a href="/developers.html">Developers</a>
+          <a href="/developers.html">Developer guide</a>
+          <a href="/docs.html">Live API explorer</a>
           <a href="/interoperability.html">Interoperability</a>
           <a href="/registry.html">Implementation Registry</a>
           <a href="/icon-system.html">Icon System</a>
         </div>
       </div>
       <div class="nav-dropdown">
-        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Community <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
+        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Resources <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
         <div class="nav-dropdown-menu">
-          <a href="/news.html">News</a>
+          <a href="/evidence-pack.html">Evidence Pack</a>
+          <a href="/shadow-evaluation-guide.html">Shadow Evaluation Guide</a>
+          <a href="/for-payers.html">For Payers</a>
+          <a href="/research-portfolio.html">Research Portfolio</a>
           <a href="/roadmap.html">Roadmap</a>
-          <a href="/research-portfolio.html">Portfolio</a>
-          <a href="https://github.com/NHID-Clinical/NHID-Clinical">GitHub &#x2197;</a>
+          <a href="/news.html">News</a>
+          <a href="/faq.html">FAQ</a>
+          <a href="https://ai-governance-map.vercel.app/" target="_blank" rel="noopener noreferrer">AI Governance Map &#x2197;</a>
         </div>
       </div>
-      <a href="https://ai-governance-map.vercel.app/" target="_blank" rel="noopener noreferrer">AI Map &#x2197;</a>
+      <a href="/pricing.html">Pricing</a>
+      <a href="/about.html">About</a>
+      <a href="https://github.com/NHID-Clinical" target="_blank" rel="noopener noreferrer">GitHub &#x2197;</a>
     </div>
     <div class="nav-actions">
       <button class="icon-button search-toggle" type="button" aria-label="Search" id="search-toggle">
@@ -100,27 +113,44 @@
 
 <nav class="mobile-nav" id="mobile-nav" aria-label="Mobile navigation">
   <a href="/">Home</a>
-  <strong class="mobile-nav-group">Learn</strong>
+  <strong class="mobile-nav-group">Framework</strong>
+  <a href="/framework/">Framework overview</a>
   <a href="/specification.html">Specification</a>
+  <a href="/framework/controls.html">Controls</a>
+  <a href="/framework/nhid-auth.html">NHID-Auth</a>
+  <a href="/framework/reference-implementation.html">Reference Implementation</a>
+  <a href="/framework/conformance-suite.html">Conformance Test Suite</a>
   <a href="/technical-stack.html">Technical Stack</a>
   <a href="/regulatory-alignment.html">Regulatory Alignment</a>
-  <a href="/about.html">About</a>
-  <strong class="mobile-nav-group">Evaluate</strong>
-  <a href="/simulator.html">Simulator</a>
-  <a href="/shadow-evaluation-guide.html">Shadow Evaluation</a>
-  <a href="/evidence-pack.html">Evidence Pack</a>
-  <a href="/for-payers.html">For Payers</a>
-  <strong class="mobile-nav-group">Build</strong>
-  <a href="/developers.html">Developers</a>
+  <strong class="mobile-nav-group">Platform</strong>
+  <a href="/platform/">TrustLayer overview</a>
+  <a href="/platform/agent-registry.html">Agent Registry</a>
+  <a href="/platform/trust-gateway.html">Trust Gateway</a>
+  <a href="/platform/evidence-center.html">Evidence Center</a>
+  <a href="/platform/continuous-conformance.html">Continuous Conformance</a>
+  <a href="/platform/enterprise.html">Enterprise Workflow</a>
+  <strong class="mobile-nav-group">Simulator</strong>
+  <a href="/simulator.html">Open the simulator</a>
+  <a href="/governance-simulator.html">Governance Simulator</a>
+  <strong class="mobile-nav-group">Docs</strong>
+  <a href="/developers.html">Developer guide</a>
+  <a href="/docs.html">Live API explorer</a>
   <a href="/interoperability.html">Interoperability</a>
   <a href="/registry.html">Implementation Registry</a>
   <a href="/icon-system.html">Icon System</a>
-  <strong class="mobile-nav-group">Community</strong>
-  <a href="/news.html">News</a>
+  <strong class="mobile-nav-group">Resources</strong>
+  <a href="/evidence-pack.html">Evidence Pack</a>
+  <a href="/shadow-evaluation-guide.html">Shadow Evaluation Guide</a>
+  <a href="/for-payers.html">For Payers</a>
+  <a href="/research-portfolio.html">Research Portfolio</a>
   <a href="/roadmap.html">Roadmap</a>
-  <a href="/research-portfolio.html">Portfolio</a>
-  <a href="https://github.com/NHID-Clinical/NHID-Clinical" target="_blank" rel="noopener noreferrer">GitHub &#x2197;</a>
-  <a href="https://ai-governance-map.vercel.app/" target="_blank" rel="noopener noreferrer">AI Map &#x2197;</a>
+  <a href="/news.html">News</a>
+  <a href="/faq.html">FAQ</a>
+  <a href="https://ai-governance-map.vercel.app/" target="_blank" rel="noopener noreferrer">AI Governance Map &#x2197;</a>
+  <strong class="mobile-nav-group">More</strong>
+  <a href="/pricing.html">Pricing</a>
+  <a href="/about.html">About</a>
+  <a href="https://github.com/NHID-Clinical" target="_blank" rel="noopener noreferrer">GitHub &#x2197;</a>
   <div class="mobile-nav-footer">
     <button class="theme-toggle mobile-theme-toggle" type="button" aria-label="Toggle dark mode">
       <svg class="sun-icon" viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M6.34 17.66l-1.41 1.41M19.07 4.93l-1.41 1.41"/></svg>

--- a/identity-layer.html
+++ b/identity-layer.html
@@ -31,44 +31,57 @@
       </span>
     </a>
                 <div class="nav-links">
-      <a href="/">Home</a>
       <div class="nav-dropdown">
-        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Learn <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
+        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Framework <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
         <div class="nav-dropdown-menu">
+          <a href="/framework/">Framework overview</a>
           <a href="/specification.html">Specification</a>
+          <a href="/framework/controls.html">Controls</a>
+          <a href="/framework/nhid-auth.html">NHID-Auth</a>
+          <a href="/framework/reference-implementation.html">Reference Implementation</a>
+          <a href="/framework/conformance-suite.html">Conformance Test Suite</a>
           <a href="/technical-stack.html">Technical Stack</a>
           <a href="/regulatory-alignment.html">Regulatory Alignment</a>
-          <a href="/about.html">About</a>
         </div>
       </div>
       <div class="nav-dropdown">
-        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Evaluate <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
+        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Platform <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
         <div class="nav-dropdown-menu">
-          <a href="/simulator.html">Simulator</a>
-          <a href="/shadow-evaluation-guide.html">Shadow Evaluation</a>
-          <a href="/evidence-pack.html">Evidence Pack</a>
-          <a href="/for-payers.html">For Payers</a>
+          <a href="/platform/">TrustLayer overview</a>
+          <a href="/platform/agent-registry.html">Agent Registry</a>
+          <a href="/platform/trust-gateway.html">Trust Gateway</a>
+          <a href="/platform/evidence-center.html">Evidence Center</a>
+          <a href="/platform/continuous-conformance.html">Continuous Conformance</a>
+          <a href="/platform/enterprise.html">Enterprise Workflow</a>
         </div>
       </div>
+      <a href="/simulator.html">Simulator</a>
       <div class="nav-dropdown">
-        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Build <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
+        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Docs <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
         <div class="nav-dropdown-menu">
-          <a href="/developers.html">Developers</a>
+          <a href="/developers.html">Developer guide</a>
+          <a href="/docs.html">Live API explorer</a>
           <a href="/interoperability.html">Interoperability</a>
           <a href="/registry.html">Implementation Registry</a>
           <a href="/icon-system.html">Icon System</a>
         </div>
       </div>
       <div class="nav-dropdown">
-        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Community <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
+        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Resources <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
         <div class="nav-dropdown-menu">
-          <a href="/news.html">News</a>
+          <a href="/evidence-pack.html">Evidence Pack</a>
+          <a href="/shadow-evaluation-guide.html">Shadow Evaluation Guide</a>
+          <a href="/for-payers.html">For Payers</a>
+          <a href="/research-portfolio.html">Research Portfolio</a>
           <a href="/roadmap.html">Roadmap</a>
-          <a href="/research-portfolio.html">Portfolio</a>
-          <a href="https://github.com/NHID-Clinical/NHID-Clinical">GitHub &#x2197;</a>
+          <a href="/news.html">News</a>
+          <a href="/faq.html">FAQ</a>
+          <a href="https://ai-governance-map.vercel.app/" target="_blank" rel="noopener noreferrer">AI Governance Map &#x2197;</a>
         </div>
       </div>
-      <a href="https://ai-governance-map.vercel.app/" target="_blank" rel="noopener noreferrer">AI Map &#x2197;</a>
+      <a href="/pricing.html">Pricing</a>
+      <a href="/about.html">About</a>
+      <a href="https://github.com/NHID-Clinical" target="_blank" rel="noopener noreferrer">GitHub &#x2197;</a>
     </div>
     <div class="nav-actions">
       <button class="icon-button search-toggle" type="button" aria-label="Search" id="search-toggle">
@@ -100,27 +113,44 @@
 
 <nav class="mobile-nav" id="mobile-nav" aria-label="Mobile navigation">
   <a href="/">Home</a>
-  <strong class="mobile-nav-group">Learn</strong>
+  <strong class="mobile-nav-group">Framework</strong>
+  <a href="/framework/">Framework overview</a>
   <a href="/specification.html">Specification</a>
+  <a href="/framework/controls.html">Controls</a>
+  <a href="/framework/nhid-auth.html">NHID-Auth</a>
+  <a href="/framework/reference-implementation.html">Reference Implementation</a>
+  <a href="/framework/conformance-suite.html">Conformance Test Suite</a>
   <a href="/technical-stack.html">Technical Stack</a>
   <a href="/regulatory-alignment.html">Regulatory Alignment</a>
-  <a href="/about.html">About</a>
-  <strong class="mobile-nav-group">Evaluate</strong>
-  <a href="/simulator.html">Simulator</a>
-  <a href="/shadow-evaluation-guide.html">Shadow Evaluation</a>
-  <a href="/evidence-pack.html">Evidence Pack</a>
-  <a href="/for-payers.html">For Payers</a>
-  <strong class="mobile-nav-group">Build</strong>
-  <a href="/developers.html">Developers</a>
+  <strong class="mobile-nav-group">Platform</strong>
+  <a href="/platform/">TrustLayer overview</a>
+  <a href="/platform/agent-registry.html">Agent Registry</a>
+  <a href="/platform/trust-gateway.html">Trust Gateway</a>
+  <a href="/platform/evidence-center.html">Evidence Center</a>
+  <a href="/platform/continuous-conformance.html">Continuous Conformance</a>
+  <a href="/platform/enterprise.html">Enterprise Workflow</a>
+  <strong class="mobile-nav-group">Simulator</strong>
+  <a href="/simulator.html">Open the simulator</a>
+  <a href="/governance-simulator.html">Governance Simulator</a>
+  <strong class="mobile-nav-group">Docs</strong>
+  <a href="/developers.html">Developer guide</a>
+  <a href="/docs.html">Live API explorer</a>
   <a href="/interoperability.html">Interoperability</a>
   <a href="/registry.html">Implementation Registry</a>
   <a href="/icon-system.html">Icon System</a>
-  <strong class="mobile-nav-group">Community</strong>
-  <a href="/news.html">News</a>
+  <strong class="mobile-nav-group">Resources</strong>
+  <a href="/evidence-pack.html">Evidence Pack</a>
+  <a href="/shadow-evaluation-guide.html">Shadow Evaluation Guide</a>
+  <a href="/for-payers.html">For Payers</a>
+  <a href="/research-portfolio.html">Research Portfolio</a>
   <a href="/roadmap.html">Roadmap</a>
-  <a href="/research-portfolio.html">Portfolio</a>
-  <a href="https://github.com/NHID-Clinical/NHID-Clinical" target="_blank" rel="noopener noreferrer">GitHub &#x2197;</a>
-  <a href="https://ai-governance-map.vercel.app/" target="_blank" rel="noopener noreferrer">AI Map &#x2197;</a>
+  <a href="/news.html">News</a>
+  <a href="/faq.html">FAQ</a>
+  <a href="https://ai-governance-map.vercel.app/" target="_blank" rel="noopener noreferrer">AI Governance Map &#x2197;</a>
+  <strong class="mobile-nav-group">More</strong>
+  <a href="/pricing.html">Pricing</a>
+  <a href="/about.html">About</a>
+  <a href="https://github.com/NHID-Clinical" target="_blank" rel="noopener noreferrer">GitHub &#x2197;</a>
   <div class="mobile-nav-footer">
     <button class="theme-toggle mobile-theme-toggle" type="button" aria-label="Toggle dark mode">
       <svg class="sun-icon" viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M6.34 17.66l-1.41 1.41M19.07 4.93l-1.41 1.41"/></svg>

--- a/implementation-review.html
+++ b/implementation-review.html
@@ -31,44 +31,57 @@
       </span>
     </a>
     <div class="nav-links">
-      <a href="/">Home</a>
       <div class="nav-dropdown">
-        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Learn <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
+        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Framework <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
         <div class="nav-dropdown-menu">
+          <a href="/framework/">Framework overview</a>
           <a href="/specification.html">Specification</a>
+          <a href="/framework/controls.html">Controls</a>
+          <a href="/framework/nhid-auth.html">NHID-Auth</a>
+          <a href="/framework/reference-implementation.html">Reference Implementation</a>
+          <a href="/framework/conformance-suite.html">Conformance Test Suite</a>
           <a href="/technical-stack.html">Technical Stack</a>
           <a href="/regulatory-alignment.html">Regulatory Alignment</a>
-          <a href="/about.html">About</a>
         </div>
       </div>
       <div class="nav-dropdown">
-        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Evaluate <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
+        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Platform <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
         <div class="nav-dropdown-menu">
-          <a href="/simulator.html">Simulator</a>
-          <a href="/shadow-evaluation-guide.html">Shadow Evaluation</a>
-          <a href="/evidence-pack.html">Evidence Pack</a>
-          <a href="/for-payers.html">For Payers</a>
+          <a href="/platform/">TrustLayer overview</a>
+          <a href="/platform/agent-registry.html">Agent Registry</a>
+          <a href="/platform/trust-gateway.html">Trust Gateway</a>
+          <a href="/platform/evidence-center.html">Evidence Center</a>
+          <a href="/platform/continuous-conformance.html">Continuous Conformance</a>
+          <a href="/platform/enterprise.html">Enterprise Workflow</a>
         </div>
       </div>
+      <a href="/simulator.html">Simulator</a>
       <div class="nav-dropdown">
-        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Build <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
+        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Docs <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
         <div class="nav-dropdown-menu">
-          <a href="/developers.html">Developers</a>
+          <a href="/developers.html">Developer guide</a>
+          <a href="/docs.html">Live API explorer</a>
           <a href="/interoperability.html">Interoperability</a>
           <a href="/registry.html">Implementation Registry</a>
           <a href="/icon-system.html">Icon System</a>
         </div>
       </div>
       <div class="nav-dropdown">
-        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Community <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
+        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Resources <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
         <div class="nav-dropdown-menu">
-          <a href="/news.html">News</a>
+          <a href="/evidence-pack.html">Evidence Pack</a>
+          <a href="/shadow-evaluation-guide.html">Shadow Evaluation Guide</a>
+          <a href="/for-payers.html">For Payers</a>
+          <a href="/research-portfolio.html">Research Portfolio</a>
           <a href="/roadmap.html">Roadmap</a>
-          <a href="/research-portfolio.html">Portfolio</a>
-          <a href="https://github.com/NHID-Clinical/NHID-Clinical">GitHub &#x2197;</a>
+          <a href="/news.html">News</a>
+          <a href="/faq.html">FAQ</a>
+          <a href="https://ai-governance-map.vercel.app/" target="_blank" rel="noopener noreferrer">AI Governance Map &#x2197;</a>
         </div>
       </div>
-      <a href="https://ai-governance-map.vercel.app/" target="_blank" rel="noopener noreferrer">AI Map &#x2197;</a>
+      <a href="/pricing.html">Pricing</a>
+      <a href="/about.html">About</a>
+      <a href="https://github.com/NHID-Clinical" target="_blank" rel="noopener noreferrer">GitHub &#x2197;</a>
     </div>
     <div class="nav-actions">
       <button class="icon-button search-toggle" type="button" aria-label="Search" id="search-toggle">
@@ -100,27 +113,44 @@
 
 <nav class="mobile-nav" id="mobile-nav" aria-label="Mobile navigation">
   <a href="/">Home</a>
-  <strong class="mobile-nav-group">Learn</strong>
+  <strong class="mobile-nav-group">Framework</strong>
+  <a href="/framework/">Framework overview</a>
   <a href="/specification.html">Specification</a>
+  <a href="/framework/controls.html">Controls</a>
+  <a href="/framework/nhid-auth.html">NHID-Auth</a>
+  <a href="/framework/reference-implementation.html">Reference Implementation</a>
+  <a href="/framework/conformance-suite.html">Conformance Test Suite</a>
   <a href="/technical-stack.html">Technical Stack</a>
   <a href="/regulatory-alignment.html">Regulatory Alignment</a>
-  <a href="/about.html">About</a>
-  <strong class="mobile-nav-group">Evaluate</strong>
-  <a href="/simulator.html">Simulator</a>
-  <a href="/shadow-evaluation-guide.html">Shadow Evaluation</a>
-  <a href="/evidence-pack.html">Evidence Pack</a>
-  <a href="/for-payers.html">For Payers</a>
-  <strong class="mobile-nav-group">Build</strong>
-  <a href="/developers.html">Developers</a>
+  <strong class="mobile-nav-group">Platform</strong>
+  <a href="/platform/">TrustLayer overview</a>
+  <a href="/platform/agent-registry.html">Agent Registry</a>
+  <a href="/platform/trust-gateway.html">Trust Gateway</a>
+  <a href="/platform/evidence-center.html">Evidence Center</a>
+  <a href="/platform/continuous-conformance.html">Continuous Conformance</a>
+  <a href="/platform/enterprise.html">Enterprise Workflow</a>
+  <strong class="mobile-nav-group">Simulator</strong>
+  <a href="/simulator.html">Open the simulator</a>
+  <a href="/governance-simulator.html">Governance Simulator</a>
+  <strong class="mobile-nav-group">Docs</strong>
+  <a href="/developers.html">Developer guide</a>
+  <a href="/docs.html">Live API explorer</a>
   <a href="/interoperability.html">Interoperability</a>
   <a href="/registry.html">Implementation Registry</a>
   <a href="/icon-system.html">Icon System</a>
-  <strong class="mobile-nav-group">Community</strong>
-  <a href="/news.html">News</a>
+  <strong class="mobile-nav-group">Resources</strong>
+  <a href="/evidence-pack.html">Evidence Pack</a>
+  <a href="/shadow-evaluation-guide.html">Shadow Evaluation Guide</a>
+  <a href="/for-payers.html">For Payers</a>
+  <a href="/research-portfolio.html">Research Portfolio</a>
   <a href="/roadmap.html">Roadmap</a>
-  <a href="/research-portfolio.html">Portfolio</a>
-  <a href="https://github.com/NHID-Clinical/NHID-Clinical" target="_blank" rel="noopener noreferrer">GitHub &#x2197;</a>
-  <a href="https://ai-governance-map.vercel.app/" target="_blank" rel="noopener noreferrer">AI Map &#x2197;</a>
+  <a href="/news.html">News</a>
+  <a href="/faq.html">FAQ</a>
+  <a href="https://ai-governance-map.vercel.app/" target="_blank" rel="noopener noreferrer">AI Governance Map &#x2197;</a>
+  <strong class="mobile-nav-group">More</strong>
+  <a href="/pricing.html">Pricing</a>
+  <a href="/about.html">About</a>
+  <a href="https://github.com/NHID-Clinical" target="_blank" rel="noopener noreferrer">GitHub &#x2197;</a>
   <div class="mobile-nav-footer">
     <button class="theme-toggle mobile-theme-toggle" type="button" aria-label="Toggle dark mode">
       <svg class="sun-icon" viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M6.34 17.66l-1.41 1.41M19.07 4.93l-1.41 1.41"/></svg>

--- a/index.html
+++ b/index.html
@@ -32,44 +32,57 @@
       </span>
     </a>
     <div class="nav-links">
-      <a href="/">Home</a>
       <div class="nav-dropdown">
-        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Learn <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
+        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Framework <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
         <div class="nav-dropdown-menu">
+          <a href="/framework/">Framework overview</a>
           <a href="/specification.html">Specification</a>
+          <a href="/framework/controls.html">Controls</a>
+          <a href="/framework/nhid-auth.html">NHID-Auth</a>
+          <a href="/framework/reference-implementation.html">Reference Implementation</a>
+          <a href="/framework/conformance-suite.html">Conformance Test Suite</a>
           <a href="/technical-stack.html">Technical Stack</a>
           <a href="/regulatory-alignment.html">Regulatory Alignment</a>
-          <a href="/about.html">About</a>
         </div>
       </div>
       <div class="nav-dropdown">
-        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Evaluate <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
+        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Platform <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
         <div class="nav-dropdown-menu">
-          <a href="/simulator.html">Simulator</a>
-          <a href="/shadow-evaluation-guide.html">Shadow Evaluation</a>
-          <a href="/evidence-pack.html">Evidence Pack</a>
-          <a href="/for-payers.html">For Payers</a>
+          <a href="/platform/">TrustLayer overview</a>
+          <a href="/platform/agent-registry.html">Agent Registry</a>
+          <a href="/platform/trust-gateway.html">Trust Gateway</a>
+          <a href="/platform/evidence-center.html">Evidence Center</a>
+          <a href="/platform/continuous-conformance.html">Continuous Conformance</a>
+          <a href="/platform/enterprise.html">Enterprise Workflow</a>
         </div>
       </div>
+      <a href="/simulator.html">Simulator</a>
       <div class="nav-dropdown">
-        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Build <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
+        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Docs <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
         <div class="nav-dropdown-menu">
-          <a href="/developers.html">Developers</a>
+          <a href="/developers.html">Developer guide</a>
+          <a href="/docs.html">Live API explorer</a>
           <a href="/interoperability.html">Interoperability</a>
           <a href="/registry.html">Implementation Registry</a>
           <a href="/icon-system.html">Icon System</a>
         </div>
       </div>
       <div class="nav-dropdown">
-        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Community <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
+        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Resources <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
         <div class="nav-dropdown-menu">
-          <a href="/news.html">News</a>
+          <a href="/evidence-pack.html">Evidence Pack</a>
+          <a href="/shadow-evaluation-guide.html">Shadow Evaluation Guide</a>
+          <a href="/for-payers.html">For Payers</a>
+          <a href="/research-portfolio.html">Research Portfolio</a>
           <a href="/roadmap.html">Roadmap</a>
-          <a href="/research-portfolio.html">Portfolio</a>
-          <a href="https://github.com/NHID-Clinical/NHID-Clinical">GitHub &#x2197;</a>
+          <a href="/news.html">News</a>
+          <a href="/faq.html">FAQ</a>
+          <a href="https://ai-governance-map.vercel.app/" target="_blank" rel="noopener noreferrer">AI Governance Map &#x2197;</a>
         </div>
       </div>
-      <a href="https://ai-governance-map.vercel.app/" target="_blank" rel="noopener noreferrer">AI Map &#x2197;</a>
+      <a href="/pricing.html">Pricing</a>
+      <a href="/about.html">About</a>
+      <a href="https://github.com/NHID-Clinical" target="_blank" rel="noopener noreferrer">GitHub &#x2197;</a>
     </div>
     <div class="nav-actions">
       <button class="icon-button search-toggle" type="button" aria-label="Search" id="search-toggle">
@@ -101,27 +114,44 @@
 
 <nav class="mobile-nav" id="mobile-nav" aria-label="Mobile navigation">
   <a href="/">Home</a>
-  <strong class="mobile-nav-group">Learn</strong>
+  <strong class="mobile-nav-group">Framework</strong>
+  <a href="/framework/">Framework overview</a>
   <a href="/specification.html">Specification</a>
+  <a href="/framework/controls.html">Controls</a>
+  <a href="/framework/nhid-auth.html">NHID-Auth</a>
+  <a href="/framework/reference-implementation.html">Reference Implementation</a>
+  <a href="/framework/conformance-suite.html">Conformance Test Suite</a>
   <a href="/technical-stack.html">Technical Stack</a>
   <a href="/regulatory-alignment.html">Regulatory Alignment</a>
-  <a href="/about.html">About</a>
-  <strong class="mobile-nav-group">Evaluate</strong>
-  <a href="/simulator.html">Simulator</a>
-  <a href="/shadow-evaluation-guide.html">Shadow Evaluation</a>
-  <a href="/evidence-pack.html">Evidence Pack</a>
-  <a href="/for-payers.html">For Payers</a>
-  <strong class="mobile-nav-group">Build</strong>
-  <a href="/developers.html">Developers</a>
+  <strong class="mobile-nav-group">Platform</strong>
+  <a href="/platform/">TrustLayer overview</a>
+  <a href="/platform/agent-registry.html">Agent Registry</a>
+  <a href="/platform/trust-gateway.html">Trust Gateway</a>
+  <a href="/platform/evidence-center.html">Evidence Center</a>
+  <a href="/platform/continuous-conformance.html">Continuous Conformance</a>
+  <a href="/platform/enterprise.html">Enterprise Workflow</a>
+  <strong class="mobile-nav-group">Simulator</strong>
+  <a href="/simulator.html">Open the simulator</a>
+  <a href="/governance-simulator.html">Governance Simulator</a>
+  <strong class="mobile-nav-group">Docs</strong>
+  <a href="/developers.html">Developer guide</a>
+  <a href="/docs.html">Live API explorer</a>
   <a href="/interoperability.html">Interoperability</a>
   <a href="/registry.html">Implementation Registry</a>
   <a href="/icon-system.html">Icon System</a>
-  <strong class="mobile-nav-group">Community</strong>
-  <a href="/news.html">News</a>
+  <strong class="mobile-nav-group">Resources</strong>
+  <a href="/evidence-pack.html">Evidence Pack</a>
+  <a href="/shadow-evaluation-guide.html">Shadow Evaluation Guide</a>
+  <a href="/for-payers.html">For Payers</a>
+  <a href="/research-portfolio.html">Research Portfolio</a>
   <a href="/roadmap.html">Roadmap</a>
-  <a href="/research-portfolio.html">Portfolio</a>
-  <a href="https://github.com/NHID-Clinical/NHID-Clinical" target="_blank" rel="noopener noreferrer">GitHub &#x2197;</a>
-  <a href="https://ai-governance-map.vercel.app/" target="_blank" rel="noopener noreferrer">AI Map &#x2197;</a>
+  <a href="/news.html">News</a>
+  <a href="/faq.html">FAQ</a>
+  <a href="https://ai-governance-map.vercel.app/" target="_blank" rel="noopener noreferrer">AI Governance Map &#x2197;</a>
+  <strong class="mobile-nav-group">More</strong>
+  <a href="/pricing.html">Pricing</a>
+  <a href="/about.html">About</a>
+  <a href="https://github.com/NHID-Clinical" target="_blank" rel="noopener noreferrer">GitHub &#x2197;</a>
   <div class="mobile-nav-footer">
     <button class="theme-toggle mobile-theme-toggle" type="button" aria-label="Toggle dark mode">
       <svg class="sun-icon" viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M6.34 17.66l-1.41 1.41M19.07 4.93l-1.41 1.41"/></svg>
@@ -139,18 +169,32 @@
   <section class="hero-section hero-centered">
     <div class="hero-glow" aria-hidden="true"></div>
     <div class="container hero-centered-inner">
-      <span class="hero-kicker reveal">Operational AI-governance framework · v1.3</span>
-      <h1 class="reveal">Non-human actor accountability for healthcare voice AI.</h1>
-      <p class="hero-lead reveal">Disclosure, delegated authority, and audit for AI voice agents on payer–provider calls — so an agent can't ask for sensitive information before it is confirmed automated and authorized to act.</p>
+      <span class="hero-kicker reveal">Open framework · v1.3 · CC BY 4.0</span>
+      <h1 class="reveal">NHID-Clinical</h1>
+      <p class="hero-lead reveal">An open framework for healthcare AI agent identity, authorization, disclosure, and audit evidence.</p>
       <div class="hero-actions-premium reveal">
-        <a href="/specification.html" class="btn-premium">Read the v1.3 specification</a>
-        <a href="/for-payers.html" class="btn-premium">Start a pilot</a>
-        <a href="/simulator.html" class="btn-ghost">Open the simulator</a>
+        <a href="/framework/" class="btn-premium">Explore the Open Framework</a>
+        <a href="/platform/" class="btn-ghost">Try TrustLayer Platform</a>
       </div>
+      <p class="reveal" style="max-width:60ch;margin:1.4rem auto 0;color:var(--body);font-size:.98rem;line-height:1.7">The specification, tests, and reference implementation remain open. TrustLayer provides optional production infrastructure for organizations running AI agents at scale.</p>
       <div class="hero-illo reveal">
         <img src="/assets/images/3d-svg/hero-orbit.svg" alt="Soft isometric illustration: floating governance platforms connected by verified identity nodes, with disclosure, verification, and audit tokens." loading="eager"/>
       </div>
       <p class="disclaimer-small" style="margin-top:1.5rem">Voluntary and testable — not an accredited standard, certification, or regulatory requirement. No production pilots yet; seeking the first shadow-evaluation partners.</p>
+    </div>
+  </section>
+
+  <!-- ── Why NHID exists ───────────────────────────────────────────────────── -->
+  <section class="page-section" id="why-nhid">
+    <div class="container" style="max-width:58rem">
+      <p class="section-kicker reveal">Why NHID exists</p>
+      <h2 class="reveal" style="margin-bottom:.75rem">Impersonation latency</h2>
+      <p class="reveal" style="color:var(--ink-soft);font-size:1.08rem;line-height:1.8;border-left:3px solid var(--teal);padding-left:1.25rem">The measurable trust delay between an AI agent initiating a call and the receiving system verifying that the caller is authorized to represent the claimed organization.</p>
+      <p class="reveal" style="color:var(--body);line-height:1.85;margin-top:1.25rem">In most healthcare voice workflows today that delay is effectively infinite, because no standard verification pathway exists. Telephony authenticates the number. Identity systems authenticate the account. Neither establishes that <em>this</em> caller may act for <em>that</em> provider — so operational data changes hands during the gap.</p>
+      <p class="reveal" style="color:var(--body);line-height:1.85;margin-top:.85rem">NHID-Clinical exists to make that delay measurable, then to close it: disclose before data moves, verify delegated authority, enforce scope, and leave a replayable record.</p>
+      <div style="margin-top:1.5rem">
+        <a class="cta-button" href="/framework/controls.html">See how the controls close it <span aria-hidden="true">→</span></a>
+      </div>
     </div>
   </section>
 
@@ -361,6 +405,53 @@
     </div>
   </section>
 
+  <!-- ── Open core vs platform ─────────────────────────────────────────────── -->
+  <section class="page-section" id="open-core-vs-platform">
+    <div class="container">
+      <p class="section-kicker reveal">Open core vs platform</p>
+      <h2 class="reveal" style="margin-bottom:.35rem">What is open, and what is operated</h2>
+      <p class="reveal" style="color:var(--body);max-width:64ch">The left column is free forever under CC BY 4.0 and needs nothing from us. The right column is what TrustLayer runs on your behalf when you would otherwise build and operate it yourself.</p>
+      <div class="compare-matrix-wrap reveal">
+        <table class="compare-matrix">
+          <thead>
+            <tr><th scope="col">Capability</th><th scope="col">Open framework</th><th scope="col">TrustLayer</th></tr>
+          </thead>
+          <tbody>
+            <tr><th scope="row">Specification</th><td><span class="yes">✓</span> CC BY 4.0, always free</td><td><span class="yes">✓</span> Same specification</td></tr>
+            <tr><th scope="row">Conformance tests</th><td><span class="yes">✓</span> Run them yourself</td><td><span class="yes">✓</span> Hosted and scheduled</td></tr>
+            <tr><th scope="row">Simulator</th><td><span class="yes">✓</span> Open, no account</td><td><span class="yes">✓</span> Plus evaluation of your own agents</td></tr>
+            <tr><th scope="row">Documentation</th><td><span class="yes">✓</span> Public</td><td><span class="yes">✓</span> Public</td></tr>
+            <tr><th scope="row">Reference implementation</th><td><span class="yes">✓</span> Fork it, vendor it, replace it</td><td><span class="yes">✓</span> Managed and operated</td></tr>
+            <tr><th scope="row">Community</th><td><span class="yes">✓</span> Issues, discussions, pull requests</td><td><span class="yes">✓</span> Same community</td></tr>
+            <tr><th scope="row">Hosted monitoring</th><td><span class="no">—</span> Run it yourself</td><td><span class="yes">✓</span> Continuous, on every agent change</td></tr>
+            <tr><th scope="row">Dashboards</th><td><span class="no">—</span></td><td><span class="yes">✓</span> Fleet-wide operational view</td></tr>
+            <tr><th scope="row">Agent registry</th><td><span class="no">—</span> Passport format only</td><td><span class="yes">✓</span> Managed identity lifecycle</td></tr>
+            <tr><th scope="row">Evidence center</th><td><span class="no">—</span> Evidence pack template</td><td><span class="yes">✓</span> Generated audit-ready packages</td></tr>
+            <tr><th scope="row">Enterprise integrations</th><td><span class="no">—</span></td><td><span class="yes">✓</span> SSO, RBAC, SIEM, approvals</td></tr>
+          </tbody>
+        </table>
+      </div>
+      <div class="status-note reveal">
+        <span>&#9432;</span>
+        <span><b>The specification is never paid.</b> No tier, plan, or contract gates the specification, the control catalog, or the conformance test suite. If TrustLayer disappeared tomorrow, every open component would keep working.</span>
+      </div>
+      <div class="dual-path reveal" style="margin-top:1.75rem">
+        <div class="dual-path-card">
+          <span class="path-tag">Open framework</span>
+          <h3>Adopt it yourself</h3>
+          <p>Everything you need to implement, test, and evidence the controls without talking to anyone.</p>
+          <a class="card-link" href="/framework/">Explore the framework →</a>
+        </div>
+        <div class="dual-path-card is-platform">
+          <span class="path-tag">TrustLayer</span>
+          <h3>Operational trust infrastructure</h3>
+          <p>Monitoring, evidence, identity management, authorization, and reporting for AI agents in production.</p>
+          <a class="card-link" href="/platform/">See the platform →</a>
+        </div>
+      </div>
+    </div>
+  </section>
+
   <!-- ── Live conformance API (floating UI mockup) ─────────────────────────── -->
   <section class="page-section" style="background:var(--mist)">
     <div class="container split-visual">
@@ -473,6 +564,69 @@
           <h3>Evidence Pack</h3>
           <p>Guarantees, a worked failure trace, and the audit-readiness model for procurement.</p>
           <a class="card-link" href="/evidence-pack.html">Review the evidence pack →</a>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ── Simulator demo ─────────────────────────────────────────────────── -->
+  <section class="page-section" id="simulator-demo" style="background:var(--mist)">
+    <div class="container split-visual">
+      <div class="reveal">
+        <p class="section-kicker">Simulator</p>
+        <h2>The open simulator demonstrates NHID-Clinical controls.</h2>
+        <p style="color:var(--body);max-width:54ch;line-height:1.75;margin-top:.85rem">Sit at a payer desk and watch an AI caller reveal itself too late. The zero-latency modules, dashboard, knowledge base, and evaluation records are all open — no account, no signup, nothing to install.</p>
+        <div class="hero-actions-premium" style="margin-top:1.4rem">
+          <a class="btn-premium" href="/simulator.html">Run a free evaluation</a>
+          <a class="btn-ghost" href="/platform/">Connect your agent to TrustLayer</a>
+        </div>
+        <p class="disclaimer-small" style="margin-top:1rem">The simulator is education and demonstration — not the framework itself, and not a certification.</p>
+      </div>
+      <div class="console-panel reveal" role="img" aria-label="Illustrative simulator evaluation record: four controls pass, one fails, routing to human review.">
+        <div class="console-bar"><span class="mock-dot"></span><span class="mock-dot"></span><span class="mock-dot"></span><span class="console-title">simulator / evaluation-record</span></div>
+        <div class="console-body">
+          <div class="console-verdict"><strong>Scenario · spoofed identity</strong><span class="console-pill is-review">Human review</span></div>
+          <div class="console-line"><span class="k">IDG-01 · Identity disclosure</span><span class="v pass">PASS</span></div>
+          <div class="console-line"><span class="k">PDX-01 · Pre-data exchange</span><span class="v pass">PASS</span></div>
+          <div class="console-line"><span class="k">DBC-01 · Deceptive behavior</span><span class="v fail">FAIL</span></div>
+          <div class="console-line"><span class="k">EIT-01 · Escalation path</span><span class="v pass">PASS</span></div>
+          <div class="console-line"><span class="k">ATR-01 · Audit trace</span><span class="v pass">PASS</span></div>
+          <p class="console-note">Illustrative evaluation record — open the simulator for a live run.</p>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ── Pathways: developer + enterprise ───────────────────────────────── -->
+  <section class="page-section" id="pathways">
+    <div class="container">
+      <p class="section-kicker reveal">Two ways in</p>
+      <h2 class="reveal" style="margin-bottom:.35rem">Pick the path that matches your job</h2>
+      <p class="reveal" style="color:var(--body);max-width:62ch">Both start free. Neither requires a commercial relationship to get value.</p>
+      <div class="pathway-grid">
+        <div class="pathway-card reveal">
+          <h3>Developer pathway</h3>
+          <p>You are building an AI agent, or integrating one, and need to show it behaves.</p>
+          <ol class="pathway-steps">
+            <li><b>Read the controls.</b> Five deterministic checks, each observable on a real call.</li>
+            <li><b>Run the conformance suite</b> against your engine and read the per-control verdicts.</li>
+            <li><b>Try the live API</b> — demo routes need no key. Send a VAPI or Twilio payload.</li>
+            <li><b>Wire it in</b> using the reference implementation, adapters, and trace schema.</li>
+            <li><b>List your implementation</b> in the self-attested registry when you are ready.</li>
+          </ol>
+          <a class="cta-button" href="/developers.html">Start building <span aria-hidden="true">→</span></a>
+        </div>
+        <div class="pathway-card is-enterprise reveal">
+          <h3>Enterprise pathway</h3>
+          <p>You are a payer, provider organization, or health system receiving or operating AI agent traffic.</p>
+          <ol class="pathway-steps">
+            <li><b>Run a shadow evaluation</b> on your own call logs. Observe-only, no vendor changes.</li>
+            <li><b>Measure your baseline</b> — how long is your impersonation latency today?</li>
+            <li><b>Review the evidence pack</b> and decide what to require of your vendors.</li>
+            <li><b>Register your agents</b> so identity, ownership, and scope are enumerable.</li>
+            <li><b>Operate continuously</b> with monitoring, evidence generation, and enterprise integration.</li>
+          </ol>
+          <a class="cta-button" href="/for-payers.html">Start a shadow evaluation <span aria-hidden="true">→</span></a>
         </div>
       </div>
     </div>

--- a/interoperability.html
+++ b/interoperability.html
@@ -30,44 +30,57 @@
       </span>
     </a>
     <div class="nav-links">
-      <a href="/">Home</a>
       <div class="nav-dropdown">
-        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Learn <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
+        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Framework <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
         <div class="nav-dropdown-menu">
+          <a href="/framework/">Framework overview</a>
           <a href="/specification.html">Specification</a>
+          <a href="/framework/controls.html">Controls</a>
+          <a href="/framework/nhid-auth.html">NHID-Auth</a>
+          <a href="/framework/reference-implementation.html">Reference Implementation</a>
+          <a href="/framework/conformance-suite.html">Conformance Test Suite</a>
           <a href="/technical-stack.html">Technical Stack</a>
           <a href="/regulatory-alignment.html">Regulatory Alignment</a>
-          <a href="/about.html">About</a>
         </div>
       </div>
       <div class="nav-dropdown">
-        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Evaluate <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
+        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Platform <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
         <div class="nav-dropdown-menu">
-          <a href="/simulator.html">Simulator</a>
-          <a href="/shadow-evaluation-guide.html">Shadow Evaluation</a>
-          <a href="/evidence-pack.html">Evidence Pack</a>
-          <a href="/for-payers.html">For Payers</a>
+          <a href="/platform/">TrustLayer overview</a>
+          <a href="/platform/agent-registry.html">Agent Registry</a>
+          <a href="/platform/trust-gateway.html">Trust Gateway</a>
+          <a href="/platform/evidence-center.html">Evidence Center</a>
+          <a href="/platform/continuous-conformance.html">Continuous Conformance</a>
+          <a href="/platform/enterprise.html">Enterprise Workflow</a>
         </div>
       </div>
+      <a href="/simulator.html">Simulator</a>
       <div class="nav-dropdown">
-        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Build <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
+        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Docs <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
         <div class="nav-dropdown-menu">
-          <a href="/developers.html">Developers</a>
+          <a href="/developers.html">Developer guide</a>
+          <a href="/docs.html">Live API explorer</a>
           <a href="/interoperability.html">Interoperability</a>
           <a href="/registry.html">Implementation Registry</a>
           <a href="/icon-system.html">Icon System</a>
         </div>
       </div>
       <div class="nav-dropdown">
-        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Community <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
+        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Resources <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
         <div class="nav-dropdown-menu">
-          <a href="/news.html">News</a>
+          <a href="/evidence-pack.html">Evidence Pack</a>
+          <a href="/shadow-evaluation-guide.html">Shadow Evaluation Guide</a>
+          <a href="/for-payers.html">For Payers</a>
+          <a href="/research-portfolio.html">Research Portfolio</a>
           <a href="/roadmap.html">Roadmap</a>
-          <a href="/research-portfolio.html">Portfolio</a>
-          <a href="https://github.com/NHID-Clinical/NHID-Clinical">GitHub &#x2197;</a>
+          <a href="/news.html">News</a>
+          <a href="/faq.html">FAQ</a>
+          <a href="https://ai-governance-map.vercel.app/" target="_blank" rel="noopener noreferrer">AI Governance Map &#x2197;</a>
         </div>
       </div>
-      <a href="https://ai-governance-map.vercel.app/" target="_blank" rel="noopener noreferrer">AI Map &#x2197;</a>
+      <a href="/pricing.html">Pricing</a>
+      <a href="/about.html">About</a>
+      <a href="https://github.com/NHID-Clinical" target="_blank" rel="noopener noreferrer">GitHub &#x2197;</a>
     </div>
     <div class="nav-actions">
       <button class="icon-button search-toggle" type="button" aria-label="Search" id="search-toggle">
@@ -99,27 +112,44 @@
 
 <nav class="mobile-nav" id="mobile-nav" aria-label="Mobile navigation">
   <a href="/">Home</a>
-  <strong class="mobile-nav-group">Learn</strong>
+  <strong class="mobile-nav-group">Framework</strong>
+  <a href="/framework/">Framework overview</a>
   <a href="/specification.html">Specification</a>
+  <a href="/framework/controls.html">Controls</a>
+  <a href="/framework/nhid-auth.html">NHID-Auth</a>
+  <a href="/framework/reference-implementation.html">Reference Implementation</a>
+  <a href="/framework/conformance-suite.html">Conformance Test Suite</a>
   <a href="/technical-stack.html">Technical Stack</a>
   <a href="/regulatory-alignment.html">Regulatory Alignment</a>
-  <a href="/about.html">About</a>
-  <strong class="mobile-nav-group">Evaluate</strong>
-  <a href="/simulator.html">Simulator</a>
-  <a href="/shadow-evaluation-guide.html">Shadow Evaluation</a>
-  <a href="/evidence-pack.html">Evidence Pack</a>
-  <a href="/for-payers.html">For Payers</a>
-  <strong class="mobile-nav-group">Build</strong>
-  <a href="/developers.html">Developers</a>
+  <strong class="mobile-nav-group">Platform</strong>
+  <a href="/platform/">TrustLayer overview</a>
+  <a href="/platform/agent-registry.html">Agent Registry</a>
+  <a href="/platform/trust-gateway.html">Trust Gateway</a>
+  <a href="/platform/evidence-center.html">Evidence Center</a>
+  <a href="/platform/continuous-conformance.html">Continuous Conformance</a>
+  <a href="/platform/enterprise.html">Enterprise Workflow</a>
+  <strong class="mobile-nav-group">Simulator</strong>
+  <a href="/simulator.html">Open the simulator</a>
+  <a href="/governance-simulator.html">Governance Simulator</a>
+  <strong class="mobile-nav-group">Docs</strong>
+  <a href="/developers.html">Developer guide</a>
+  <a href="/docs.html">Live API explorer</a>
   <a href="/interoperability.html">Interoperability</a>
   <a href="/registry.html">Implementation Registry</a>
   <a href="/icon-system.html">Icon System</a>
-  <strong class="mobile-nav-group">Community</strong>
-  <a href="/news.html">News</a>
+  <strong class="mobile-nav-group">Resources</strong>
+  <a href="/evidence-pack.html">Evidence Pack</a>
+  <a href="/shadow-evaluation-guide.html">Shadow Evaluation Guide</a>
+  <a href="/for-payers.html">For Payers</a>
+  <a href="/research-portfolio.html">Research Portfolio</a>
   <a href="/roadmap.html">Roadmap</a>
-  <a href="/research-portfolio.html">Portfolio</a>
-  <a href="https://github.com/NHID-Clinical/NHID-Clinical" target="_blank" rel="noopener noreferrer">GitHub &#x2197;</a>
-  <a href="https://ai-governance-map.vercel.app/" target="_blank" rel="noopener noreferrer">AI Map &#x2197;</a>
+  <a href="/news.html">News</a>
+  <a href="/faq.html">FAQ</a>
+  <a href="https://ai-governance-map.vercel.app/" target="_blank" rel="noopener noreferrer">AI Governance Map &#x2197;</a>
+  <strong class="mobile-nav-group">More</strong>
+  <a href="/pricing.html">Pricing</a>
+  <a href="/about.html">About</a>
+  <a href="https://github.com/NHID-Clinical" target="_blank" rel="noopener noreferrer">GitHub &#x2197;</a>
   <div class="mobile-nav-footer">
     <button class="theme-toggle mobile-theme-toggle" type="button" aria-label="Toggle dark mode">
       <svg class="sun-icon" viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M6.34 17.66l-1.41 1.41M19.07 4.93l-1.41 1.41"/></svg>

--- a/news.html
+++ b/news.html
@@ -31,44 +31,57 @@
       </span>
     </a>
                 <div class="nav-links">
-      <a href="/">Home</a>
       <div class="nav-dropdown">
-        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Learn <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
+        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Framework <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
         <div class="nav-dropdown-menu">
+          <a href="/framework/">Framework overview</a>
           <a href="/specification.html">Specification</a>
+          <a href="/framework/controls.html">Controls</a>
+          <a href="/framework/nhid-auth.html">NHID-Auth</a>
+          <a href="/framework/reference-implementation.html">Reference Implementation</a>
+          <a href="/framework/conformance-suite.html">Conformance Test Suite</a>
           <a href="/technical-stack.html">Technical Stack</a>
           <a href="/regulatory-alignment.html">Regulatory Alignment</a>
-          <a href="/about.html">About</a>
         </div>
       </div>
       <div class="nav-dropdown">
-        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Evaluate <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
+        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Platform <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
         <div class="nav-dropdown-menu">
-          <a href="/simulator.html">Simulator</a>
-          <a href="/shadow-evaluation-guide.html">Shadow Evaluation</a>
-          <a href="/evidence-pack.html">Evidence Pack</a>
-          <a href="/for-payers.html">For Payers</a>
+          <a href="/platform/">TrustLayer overview</a>
+          <a href="/platform/agent-registry.html">Agent Registry</a>
+          <a href="/platform/trust-gateway.html">Trust Gateway</a>
+          <a href="/platform/evidence-center.html">Evidence Center</a>
+          <a href="/platform/continuous-conformance.html">Continuous Conformance</a>
+          <a href="/platform/enterprise.html">Enterprise Workflow</a>
         </div>
       </div>
+      <a href="/simulator.html">Simulator</a>
       <div class="nav-dropdown">
-        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Build <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
+        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Docs <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
         <div class="nav-dropdown-menu">
-          <a href="/developers.html">Developers</a>
+          <a href="/developers.html">Developer guide</a>
+          <a href="/docs.html">Live API explorer</a>
           <a href="/interoperability.html">Interoperability</a>
           <a href="/registry.html">Implementation Registry</a>
           <a href="/icon-system.html">Icon System</a>
         </div>
       </div>
       <div class="nav-dropdown">
-        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Community <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
+        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Resources <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
         <div class="nav-dropdown-menu">
-          <a href="/news.html">News</a>
+          <a href="/evidence-pack.html">Evidence Pack</a>
+          <a href="/shadow-evaluation-guide.html">Shadow Evaluation Guide</a>
+          <a href="/for-payers.html">For Payers</a>
+          <a href="/research-portfolio.html">Research Portfolio</a>
           <a href="/roadmap.html">Roadmap</a>
-          <a href="/research-portfolio.html">Portfolio</a>
-          <a href="https://github.com/NHID-Clinical/NHID-Clinical">GitHub &#x2197;</a>
+          <a href="/news.html">News</a>
+          <a href="/faq.html">FAQ</a>
+          <a href="https://ai-governance-map.vercel.app/" target="_blank" rel="noopener noreferrer">AI Governance Map &#x2197;</a>
         </div>
       </div>
-      <a href="https://ai-governance-map.vercel.app/" target="_blank" rel="noopener noreferrer">AI Map &#x2197;</a>
+      <a href="/pricing.html">Pricing</a>
+      <a href="/about.html">About</a>
+      <a href="https://github.com/NHID-Clinical" target="_blank" rel="noopener noreferrer">GitHub &#x2197;</a>
     </div>
     <div class="nav-actions">
       <button class="icon-button search-toggle" type="button" aria-label="Search" id="search-toggle">
@@ -100,27 +113,44 @@
 
 <nav class="mobile-nav" id="mobile-nav" aria-label="Mobile navigation">
   <a href="/">Home</a>
-  <strong class="mobile-nav-group">Learn</strong>
+  <strong class="mobile-nav-group">Framework</strong>
+  <a href="/framework/">Framework overview</a>
   <a href="/specification.html">Specification</a>
+  <a href="/framework/controls.html">Controls</a>
+  <a href="/framework/nhid-auth.html">NHID-Auth</a>
+  <a href="/framework/reference-implementation.html">Reference Implementation</a>
+  <a href="/framework/conformance-suite.html">Conformance Test Suite</a>
   <a href="/technical-stack.html">Technical Stack</a>
   <a href="/regulatory-alignment.html">Regulatory Alignment</a>
-  <a href="/about.html">About</a>
-  <strong class="mobile-nav-group">Evaluate</strong>
-  <a href="/simulator.html">Simulator</a>
-  <a href="/shadow-evaluation-guide.html">Shadow Evaluation</a>
-  <a href="/evidence-pack.html">Evidence Pack</a>
-  <a href="/for-payers.html">For Payers</a>
-  <strong class="mobile-nav-group">Build</strong>
-  <a href="/developers.html">Developers</a>
+  <strong class="mobile-nav-group">Platform</strong>
+  <a href="/platform/">TrustLayer overview</a>
+  <a href="/platform/agent-registry.html">Agent Registry</a>
+  <a href="/platform/trust-gateway.html">Trust Gateway</a>
+  <a href="/platform/evidence-center.html">Evidence Center</a>
+  <a href="/platform/continuous-conformance.html">Continuous Conformance</a>
+  <a href="/platform/enterprise.html">Enterprise Workflow</a>
+  <strong class="mobile-nav-group">Simulator</strong>
+  <a href="/simulator.html">Open the simulator</a>
+  <a href="/governance-simulator.html">Governance Simulator</a>
+  <strong class="mobile-nav-group">Docs</strong>
+  <a href="/developers.html">Developer guide</a>
+  <a href="/docs.html">Live API explorer</a>
   <a href="/interoperability.html">Interoperability</a>
   <a href="/registry.html">Implementation Registry</a>
   <a href="/icon-system.html">Icon System</a>
-  <strong class="mobile-nav-group">Community</strong>
-  <a href="/news.html">News</a>
+  <strong class="mobile-nav-group">Resources</strong>
+  <a href="/evidence-pack.html">Evidence Pack</a>
+  <a href="/shadow-evaluation-guide.html">Shadow Evaluation Guide</a>
+  <a href="/for-payers.html">For Payers</a>
+  <a href="/research-portfolio.html">Research Portfolio</a>
   <a href="/roadmap.html">Roadmap</a>
-  <a href="/research-portfolio.html">Portfolio</a>
-  <a href="https://github.com/NHID-Clinical/NHID-Clinical" target="_blank" rel="noopener noreferrer">GitHub &#x2197;</a>
-  <a href="https://ai-governance-map.vercel.app/" target="_blank" rel="noopener noreferrer">AI Map &#x2197;</a>
+  <a href="/news.html">News</a>
+  <a href="/faq.html">FAQ</a>
+  <a href="https://ai-governance-map.vercel.app/" target="_blank" rel="noopener noreferrer">AI Governance Map &#x2197;</a>
+  <strong class="mobile-nav-group">More</strong>
+  <a href="/pricing.html">Pricing</a>
+  <a href="/about.html">About</a>
+  <a href="https://github.com/NHID-Clinical" target="_blank" rel="noopener noreferrer">GitHub &#x2197;</a>
   <div class="mobile-nav-footer">
     <button class="theme-toggle mobile-theme-toggle" type="button" aria-label="Toggle dark mode">
       <svg class="sun-icon" viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M6.34 17.66l-1.41 1.41M19.07 4.93l-1.41 1.41"/></svg>

--- a/nhid-clinical-ui.css
+++ b/nhid-clinical-ui.css
@@ -3374,3 +3374,475 @@ main p { line-height: 1.75; }
 .page-cta-card b { font-family: var(--display); font-weight: 700; font-size: 1rem; }
 .page-cta-card span { font-size: .85rem; color: var(--body); line-height: 1.5; }
 .page-cta-card .arr { color: var(--teal-bright); font-weight: 800; }
+
+/* ══════════════════════════════════════════════════════════════════════════
+   Information architecture layer — open framework / TrustLayer platform
+   Additive only. New class names, existing tokens, dark-theme aware.
+   ══════════════════════════════════════════════════════════════════════════ */
+
+/* Nav density — the IA nav carries 8 top-level items instead of 6, so it needs
+   more room than the original 1060px drawer breakpoint allowed. Below 1240px the
+   existing mobile drawer takes over (it lists every item, grouped); between 1180
+   and 1320px the links tighten rather than squeezing the brand or clipping the CTA. */
+.nav-links > a,
+.nav-dropdown-trigger { white-space: nowrap; }
+
+@media (max-width: 1240px) {
+  .nav-links { display: none; }
+  .menu-button { display: inline-flex; }
+}
+
+@media (max-width: 1380px) and (min-width: 1241px) {
+  .nav-links a,
+  .nav-dropdown-trigger { padding-inline: 0.5rem; font-size: 0.88rem; }
+  .nav-links { gap: 0; }
+}
+
+/* ── Dual-path (open framework vs platform) ──────────────────────────────── */
+.dual-path {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(19rem, 1fr));
+  gap: 1.5rem;
+  margin-top: 2rem;
+}
+.dual-path-card {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  padding: 2rem;
+  border: 1px solid var(--line);
+  border-radius: 1.1rem;
+  background: var(--paper);
+  box-shadow: 0 12px 40px rgba(20, 74, 105, 0.06);
+  transition: transform .28s ease, box-shadow .28s ease, border-color .28s ease;
+}
+.dual-path-card:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 20px 60px rgba(20, 74, 105, 0.1);
+  border-color: rgba(20, 184, 166, .45);
+}
+.dual-path-card .path-tag {
+  align-self: flex-start;
+  font-size: .68rem;
+  font-weight: 800;
+  letter-spacing: .13em;
+  text-transform: uppercase;
+  padding: .3rem .65rem;
+  border-radius: 999px;
+  background: var(--blue-soft);
+  color: var(--blue);
+  border: 1px solid rgba(11, 110, 188, .22);
+}
+.dual-path-card.is-platform .path-tag {
+  background: var(--teal-soft);
+  color: var(--teal);
+  border-color: rgba(20, 184, 166, .28);
+}
+.dual-path-card h3 { font-size: 1.25rem; margin: 0; }
+.dual-path-card > p { color: var(--body); font-size: .95rem; line-height: 1.7; margin: 0; }
+.dual-path-card ul {
+  list-style: none;
+  padding: 0;
+  margin: .25rem 0 0;
+  display: grid;
+  gap: .5rem;
+}
+.dual-path-card li {
+  color: var(--body);
+  font-size: .9rem;
+  line-height: 1.6;
+  padding-left: 1.15rem;
+  position: relative;
+}
+.dual-path-card li::before {
+  content: "";
+  position: absolute;
+  left: 0; top: .55em;
+  width: .4rem; height: .4rem;
+  border-radius: 50%;
+  background: var(--teal);
+}
+.dual-path-card .card-link { margin-top: auto; padding-top: .75rem; }
+
+/* ── Open Core vs Platform comparison matrix ─────────────────────────────── */
+.compare-matrix-wrap { overflow-x: auto; margin-top: 1.75rem; }
+.compare-matrix {
+  width: 100%;
+  min-width: 40rem;
+  border-collapse: collapse;
+  font-size: .92rem;
+}
+.compare-matrix th,
+.compare-matrix td {
+  padding: .8rem 1.1rem;
+  border: 1px solid var(--line);
+  text-align: left;
+  vertical-align: top;
+  line-height: 1.55;
+}
+.compare-matrix thead th {
+  background: var(--mist);
+  color: var(--ink);
+  font-family: var(--display);
+  font-weight: 700;
+  font-size: .78rem;
+  letter-spacing: .07em;
+  text-transform: uppercase;
+}
+.compare-matrix tbody th {
+  background: transparent;
+  color: var(--ink);
+  font-weight: 650;
+  font-size: .92rem;
+  white-space: nowrap;
+}
+.compare-matrix td { color: var(--body); }
+.compare-matrix .yes { color: var(--teal); font-weight: 800; }
+.compare-matrix .no  { color: var(--body); opacity: .6; font-weight: 700; }
+.compare-matrix tbody tr:hover td,
+.compare-matrix tbody tr:hover th { background: rgba(20, 184, 166, .04); }
+
+/* ── Platform module cards ───────────────────────────────────────────────── */
+.module-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(17rem, 1fr));
+  gap: 1.25rem;
+  margin-top: 1.75rem;
+}
+.module-card {
+  display: flex;
+  flex-direction: column;
+  gap: .55rem;
+  padding: 1.6rem;
+  border: 1px solid var(--line);
+  border-radius: 1rem;
+  background: var(--paper);
+  text-decoration: none;
+  transition: transform .28s ease, box-shadow .28s ease, border-color .28s ease;
+}
+.module-card:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 18px 42px -24px rgba(15, 23, 42, .3);
+  border-color: rgba(20, 184, 166, .45);
+}
+.module-card .module-num {
+  font-family: var(--display);
+  font-size: .72rem;
+  font-weight: 800;
+  letter-spacing: .12em;
+  color: var(--teal);
+}
+.module-card h3 { font-size: 1.06rem; margin: 0; }
+.module-card p { color: var(--body); font-size: .89rem; line-height: 1.65; margin: 0; }
+.module-card .arr { margin-top: auto; padding-top: .6rem; color: var(--teal); font-weight: 700; font-size: .85rem; }
+
+/* ── Trust Gateway flow ──────────────────────────────────────────────────── */
+.gateway-flow {
+  display: grid;
+  gap: 0;
+  max-width: 34rem;
+  margin: 1.75rem 0 0;
+  list-style: none;
+  padding: 0;
+  counter-reset: gw;
+}
+.gateway-step {
+  position: relative;
+  padding: 1rem 1.25rem 1rem 3.4rem;
+  border: 1px solid var(--line);
+  border-radius: .85rem;
+  background: var(--paper);
+}
+.gateway-step + .gateway-step { margin-top: 1.6rem; }
+.gateway-step + .gateway-step::before {
+  content: "";
+  position: absolute;
+  left: 1.85rem;
+  top: -1.35rem;
+  height: 1.1rem;
+  width: 2px;
+  background: linear-gradient(180deg, var(--teal), rgba(20, 184, 166, .25));
+}
+.gateway-step + .gateway-step::after {
+  content: "";
+  position: absolute;
+  left: 1.5rem;
+  top: -.42rem;
+  border-left: 5px solid transparent;
+  border-right: 5px solid transparent;
+  border-top: 6px solid var(--teal);
+}
+.gateway-step .gw-num {
+  counter-increment: gw;
+  position: absolute;
+  left: 1.1rem;
+  top: 1.05rem;
+  width: 1.55rem;
+  height: 1.55rem;
+  border-radius: 50%;
+  display: grid;
+  place-items: center;
+  background: var(--teal-soft);
+  border: 1px solid rgba(20, 184, 166, .32);
+  color: var(--teal);
+  font-family: var(--display);
+  font-size: .74rem;
+  font-weight: 800;
+}
+.gateway-step strong { display: block; color: var(--ink); font-family: var(--display); font-size: .98rem; }
+.gateway-step span { display: block; margin-top: .2rem; color: var(--body); font-size: .86rem; line-height: 1.6; }
+.gateway-step.is-endpoint { background: var(--mist); border-style: dashed; }
+
+/* ── Pricing plans ───────────────────────────────────────────────────────── */
+.plan-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(17.5rem, 1fr));
+  gap: 1.5rem;
+  margin-top: 2rem;
+  align-items: stretch;
+}
+.plan-card {
+  display: flex;
+  flex-direction: column;
+  padding: 2rem;
+  border: 1px solid var(--line);
+  border-radius: 1.1rem;
+  background: var(--paper);
+  box-shadow: 0 12px 40px rgba(20, 74, 105, .06);
+}
+.plan-card.is-highlight { border-color: rgba(20, 184, 166, .55); }
+.plan-card .plan-name {
+  font-family: var(--display);
+  font-size: 1.15rem;
+  font-weight: 700;
+  color: var(--ink);
+}
+.plan-card .plan-price {
+  font-family: var(--display);
+  font-size: 2.3rem;
+  font-weight: 800;
+  letter-spacing: -.04em;
+  color: var(--ink);
+  line-height: 1.1;
+  margin: .6rem 0 .1rem;
+  /* keeps the "$0" and "Contact for pricing" rows on the same baseline
+     so the descriptions below them align across all three cards */
+  min-height: 2.55rem;
+  display: flex;
+  align-items: flex-end;
+}
+.plan-card .plan-price small { font-size: .95rem; font-weight: 500; color: var(--body); letter-spacing: 0; }
+.plan-card .plan-for {
+  color: var(--body);
+  font-size: .88rem;
+  line-height: 1.6;
+  padding-bottom: 1.1rem;
+  margin-bottom: 1.1rem;
+  border-bottom: 1px solid var(--line);
+}
+.plan-card ul { list-style: none; padding: 0; margin: 0 0 1.6rem; display: grid; gap: .6rem; }
+.plan-card li {
+  position: relative;
+  padding-left: 1.4rem;
+  color: var(--body);
+  font-size: .9rem;
+  line-height: 1.55;
+}
+.plan-card li::before {
+  content: "";
+  position: absolute;
+  left: 0; top: .38em;
+  width: .62rem; height: .34rem;
+  border-left: 2px solid var(--teal);
+  border-bottom: 2px solid var(--teal);
+  transform: rotate(-45deg);
+}
+.plan-card .plan-cta { margin-top: auto; }
+
+/* ── Field reference table (agent registry etc.) ─────────────────────────── */
+.field-table-wrap { overflow-x: auto; margin-top: 1.5rem; }
+.field-table {
+  width: 100%;
+  min-width: 36rem;
+  border-collapse: collapse;
+  font-size: .91rem;
+}
+.field-table th,
+.field-table td {
+  padding: .7rem 1rem;
+  border: 1px solid var(--line);
+  text-align: left;
+  vertical-align: top;
+  line-height: 1.55;
+}
+.field-table thead th {
+  background: var(--mist);
+  color: var(--ink);
+  font-size: .74rem;
+  font-weight: 700;
+  letter-spacing: .07em;
+  text-transform: uppercase;
+}
+.field-table td { color: var(--body); }
+.field-table code {
+  font-family: "IBM Plex Mono", ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: .84rem;
+  color: var(--ink);
+  background: var(--blue-soft);
+  padding: .1rem .35rem;
+  border-radius: 4px;
+}
+
+/* ── Console panel (illustrative monitoring / evidence output) ───────────── */
+.console-panel {
+  margin-top: 1.5rem;
+  border: 1px solid var(--line);
+  border-radius: .9rem;
+  overflow: hidden;
+  background: var(--paper);
+  box-shadow: 0 12px 40px rgba(20, 74, 105, .06);
+}
+.console-bar {
+  display: flex;
+  align-items: center;
+  gap: .45rem;
+  padding: .65rem 1rem;
+  background: var(--mist);
+  border-bottom: 1px solid var(--line);
+}
+.console-bar .console-title {
+  font-family: "IBM Plex Mono", ui-monospace, monospace;
+  font-size: .76rem;
+  color: var(--body);
+  letter-spacing: .02em;
+}
+.console-body { padding: 1.15rem 1.25rem; }
+.console-line {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  align-items: baseline;
+  padding: .48rem 0;
+  border-bottom: 1px dashed var(--line);
+  font-size: .89rem;
+  color: var(--body);
+}
+.console-line:last-of-type { border-bottom: 0; }
+.console-line .k { font-family: "IBM Plex Mono", ui-monospace, monospace; font-size: .84rem; }
+.console-line .v { font-weight: 700; color: var(--ink); text-align: right; }
+.console-line .v.pass { color: var(--teal); }
+.console-line .v.fail { color: #c2410c; }
+[data-theme="dark"] .console-line .v.fail { color: #fb923c; }
+.console-verdict {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: .6rem;
+  margin-bottom: .9rem;
+  padding-bottom: .8rem;
+  border-bottom: 1px solid var(--line);
+}
+.console-verdict strong { font-family: var(--display); color: var(--ink); font-size: 1rem; }
+.console-pill {
+  font-size: .7rem;
+  font-weight: 800;
+  letter-spacing: .1em;
+  text-transform: uppercase;
+  padding: .3rem .7rem;
+  border-radius: 999px;
+  background: var(--teal-soft);
+  color: var(--teal);
+  border: 1px solid rgba(20, 184, 166, .3);
+}
+.console-pill.is-review {
+  background: rgba(234, 88, 12, .1);
+  color: #c2410c;
+  border-color: rgba(234, 88, 12, .28);
+}
+[data-theme="dark"] .console-pill.is-review { color: #fb923c; }
+.console-note {
+  margin-top: .9rem;
+  font-size: .78rem;
+  color: var(--body);
+  opacity: .85;
+  font-style: italic;
+}
+
+/* ── Audience pathway cards ──────────────────────────────────────────────── */
+.pathway-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(19rem, 1fr));
+  gap: 1.5rem;
+  margin-top: 1.75rem;
+}
+.pathway-card {
+  padding: 1.9rem;
+  border: 1px solid var(--line);
+  border-radius: 1.1rem;
+  background: var(--paper);
+}
+.pathway-card h3 { font-size: 1.15rem; margin: 0 0 .4rem; }
+.pathway-card > p { color: var(--body); font-size: .93rem; line-height: 1.65; margin: 0 0 1.1rem; }
+.pathway-steps { list-style: none; padding: 0; margin: 0 0 1.25rem; display: grid; gap: .8rem; counter-reset: pw; }
+.pathway-steps li {
+  counter-increment: pw;
+  position: relative;
+  padding-left: 2.1rem;
+  color: var(--body);
+  font-size: .9rem;
+  line-height: 1.6;
+}
+.pathway-steps li::before {
+  content: counter(pw);
+  position: absolute;
+  left: 0; top: -.05em;
+  width: 1.45rem; height: 1.45rem;
+  border-radius: 50%;
+  display: grid;
+  place-items: center;
+  background: var(--blue-soft);
+  color: var(--blue);
+  font-family: var(--display);
+  font-size: .72rem;
+  font-weight: 800;
+}
+.pathway-card.is-enterprise .pathway-steps li::before { background: var(--teal-soft); color: var(--teal); }
+.pathway-steps li b { color: var(--ink); font-weight: 650; }
+
+/* ── Status note (honest product-stage disclosure) ───────────────────────── */
+.status-note {
+  display: flex;
+  gap: .7rem;
+  align-items: flex-start;
+  margin-top: 1.5rem;
+  padding: .95rem 1.15rem;
+  border: 1px solid var(--line);
+  border-left: 3px solid var(--teal);
+  border-radius: .6rem;
+  background: var(--mist);
+  color: var(--body);
+  font-size: .87rem;
+  line-height: 1.65;
+}
+.status-note b { color: var(--ink); }
+
+/* ── Dark-theme surface corrections ──────────────────────────────────────── */
+[data-theme="dark"] .dual-path-card,
+[data-theme="dark"] .module-card,
+[data-theme="dark"] .plan-card,
+[data-theme="dark"] .pathway-card,
+[data-theme="dark"] .gateway-step,
+[data-theme="dark"] .console-panel { background: var(--surface); box-shadow: none; }
+[data-theme="dark"] .compare-matrix thead th,
+[data-theme="dark"] .field-table thead th,
+[data-theme="dark"] .console-bar,
+[data-theme="dark"] .gateway-step.is-endpoint,
+[data-theme="dark"] .status-note { background: var(--bg); }
+[data-theme="dark"] .compare-matrix tbody tr:hover td,
+[data-theme="dark"] .compare-matrix tbody tr:hover th { background: rgba(20, 184, 166, .07); }
+
+@media (max-width: 720px) {
+  .dual-path-card, .plan-card, .pathway-card { padding: 1.5rem; }
+  .gateway-flow { max-width: none; }
+}

--- a/platform/agent-registry.html
+++ b/platform/agent-registry.html
@@ -1,16 +1,18 @@
-﻿<!doctype html>
+<!doctype html>
 <html lang="en">
 <head>
   <meta charset="utf-8"/>
   <meta name="viewport" content="width=device-width, initial-scale=1"/>
-  <meta name="description" content="NHID-Clinical Implementation Registry — self-attested vendor implementations with live NHID-CAS badges."/>
-  <title>Implementation Registry | NHID-Clinical</title>
+  <meta name="description" content="The TrustLayer Agent Registry — a source of truth for AI agent identity: agent ID, organization, vendor, owner, purpose, permissions, expiration, and status."/>
+  <title>Agent Registry | TrustLayer by NHID-Clinical</title>
+  <link rel="canonical" href="https://nhid-clinical.org/platform/agent-registry.html"/>
   <link rel="icon" href="/assets/brand/favicon.svg" type="image/svg+xml"/>
   <link rel="icon" href="/assets/brand-icon.png" type="image/png"/>
   <link rel="preconnect" href="https://fonts.googleapis.com"/>
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
   <link href="https://fonts.googleapis.com/css2?family=Raleway:wght@600;700;800&family=Inter:wght@400;500;600;700;800&family=IBM+Plex+Mono:wght@400;500&display=swap" rel="stylesheet"/>
   <link rel="stylesheet" href="/nhid-clinical-ui.css"/>
+  <link rel="stylesheet" href="/assets/css/premium.css"/>
   <script>try{document.documentElement.setAttribute('data-theme',localStorage.getItem('nhid-theme')||'light')}catch(e){}</script>
   <script defer data-domain="nhid-clinical.org" src="https://plausible.io/js/script.js"></script>
 </head>
@@ -162,66 +164,80 @@
 <div class="nav-backdrop" id="nav-backdrop"></div>
 
 <main>
-  <section class="inner-hero" style="position:relative;overflow:clip">
+
+  <section class="inner-hero">
     <div class="hero-glow" aria-hidden="true"></div>
-    <div class="container" style="position:relative;z-index:1">
-      <div class="crumbs"><a href="/">Home</a><span>/</span><span>Implementation Registry</span></div>
-      <p class="eyebrow">Registry · June 2026</p>
-      <h1 class="reveal">Implementation Registry</h1>
-      <p class="lede reveal">Self-attested NHID-Clinical implementations, with live NHID-CAS conformance badges.</p>
+    <div class="container" style="position:relative;z-index:1;max-width:60rem">
+      <div class="crumbs"><a href="/">Home</a><span>/</span><a href="/platform/">Platform</a><span>/</span><span>Agent Registry</span></div>
+      <p class="eyebrow">TrustLayer &middot; Module 01</p>
+      <h1>Agent Registry</h1>
+      <p class="lede">A source of truth for AI agent identity. If you cannot enumerate your agents, you cannot govern them.</p>
     </div>
   </section>
 
   <section class="page-section">
-    <div class="container" style="max-width:52rem">
-      <div class="callout" role="note" style="margin-bottom:2rem">
-        <strong>This is a self-attestation list, not a certification.</strong> NHID-Clinical does not
-        certify, audit, or warrant any vendor's implementation. A listing means the vendor ran the
-        public conformance test suite (CTS) against their own integration and chose to publish the
-        result. Badge scores update from each vendor's own live <code>/v1/public/vendor/{id}/badge</code>
-        endpoint call — verify independently before relying on them for procurement decisions.
+    <div class="container" style="max-width:60rem">
+      <h2>The problem</h2>
+      <p style="color:var(--body);line-height:1.85;margin-top:.75rem">Agentic capability tends to arrive department by department. Revenue cycle stands up an eligibility agent; the pharmacy team pilots a different vendor; a business unit inherits three more through an acquisition. Six months later nobody can answer a simple question: how many AI agents call on our behalf, and who signed off on each one?</p>
+      <p style="color:var(--body);line-height:1.85;margin-top:.75rem">That is not a tooling gap. It is an accountability gap — overlapping agents, inconsistent controls, and no clear owner when something goes wrong.</p>
+      <p style="color:var(--body);line-height:1.8;margin-top:.85rem">TrustLayer runs the same deterministic controls as the <a href="/framework/" style="color:var(--teal-bright);font-weight:600">open framework</a> — this module adds operations around them, not different rules.</p>
+
+      <h2 style="margin-top:2.5rem">What the registry tracks</h2>
+      <div class="field-table-wrap">
+        <table class="field-table">
+          <thead><tr><th>Field</th><th>Purpose</th><th>Example</th></tr></thead>
+          <tbody>
+            <tr><td><code>agent_id</code></td><td>Stable identifier for the agent across its lifetime</td><td><code>claims-agent-prod-001</code></td></tr>
+            <tr><td><code>organization</code></td><td>The entity the agent acts on behalf of, bound to its NPI</td><td>Regional provider group</td></tr>
+            <tr><td><code>vendor</code></td><td>Who builds and operates the agent software</td><td>Voice-AI platform vendor</td></tr>
+            <tr><td><code>owner</code></td><td>The named internal person accountable for this agent</td><td>Director, revenue cycle operations</td></tr>
+            <tr><td><code>purpose</code></td><td>Why the agent exists — the business workflow it serves</td><td>Eligibility and benefits verification</td></tr>
+            <tr><td><code>permissions</code></td><td>The bounded scope of actions the agent may take</td><td><code>["eligibility", "claim_status"]</code></td></tr>
+            <tr><td><code>expiration</code></td><td>When delegated authority lapses without renewal</td><td>Fixed date, re-approval required</td></tr>
+            <tr><td><code>status</code></td><td>Active, suspended, expired, or revoked</td><td><code>active</code></td></tr>
+          </tbody>
+        </table>
       </div>
 
-      <h2>Listed Implementations</h2>
-      <div id="registry-list" style="margin:1.5rem 0">
-        <p style="color:var(--body)">Loading…</p>
-      </div>
+      <h2 style="margin-top:2.5rem">Why expiration is a field, not a policy</h2>
+      <p style="color:var(--body);line-height:1.85;margin-top:.75rem">Authority that never lapses is authority nobody reviews. Registry entries carry an expiration, so continued operation requires a deliberate act by a named owner. An agent that quietly outlived its business case stops working instead of quietly continuing.</p>
+      <p style="color:var(--body);line-height:1.85;margin-top:.75rem">The same principle underlies <a href="/framework/nhid-auth.html" style="color:var(--teal-bright);font-weight:600">NHID-Auth</a> in the open framework: scope and expiry are signed fields inside the agent passport, so an over-broad or stale credential fails verification rather than depending on someone remembering to revoke it.</p>
 
-      <h2 style="margin-top:2.5rem">How to Get Listed</h2>
-      <p style="margin-bottom:1rem">
-        Run the conformance test suite against your integration, then complete the
-        <a href="https://github.com/NHID-Clinical/NHID-Clinical/blob/main/docs/vendor-trust-questionnaire.md">vendor trust questionnaire</a>
-        and open a pull request adding your entry to
-        <a href="https://github.com/NHID-Clinical/NHID-Clinical/blob/main/content/registry_entries.json">content/registry_entries.json</a>.
-        Each entry needs a <code>vendor_id</code> matching the one used when recording conformance results
-        (see <code>record_conformance_result()</code> in <code>nhid_event_store.py</code>), so your badge
-        renders live CAS data instead of the unknown/grey default.
-      </p>
-      <div style="display:flex;gap:1rem;flex-wrap:wrap;margin-bottom:2rem">
-        <a href="https://github.com/NHID-Clinical/NHID-Clinical/blob/main/docs/vendor-trust-questionnaire.md"
-           class="secondary-button" style="display:inline-flex;align-items:center;gap:.4rem">
-          Vendor Trust Questionnaire →
-        </a>
-        <a href="/developers.html#adapters" class="secondary-button" style="display:inline-flex;align-items:center;gap:.4rem">
-          Adapter Reference →
-        </a>
+      <h2 style="margin-top:2.5rem">Illustrative entry</h2>
+      <div class="console-panel">
+        <div class="console-bar"><span class="mock-dot"></span><span class="mock-dot"></span><span class="mock-dot"></span><span class="console-title">registry / agents / claims-agent-prod-001</span></div>
+        <div class="console-body">
+          <div class="console-verdict"><strong>claims-agent-prod-001</strong><span class="console-pill">Active</span></div>
+          <div class="console-line"><span class="k">organization</span><span class="v">Regional provider group</span></div>
+          <div class="console-line"><span class="k">owner</span><span class="v">Director, revenue cycle ops</span></div>
+          <div class="console-line"><span class="k">purpose</span><span class="v">Eligibility verification</span></div>
+          <div class="console-line"><span class="k">permissions</span><span class="v">eligibility, claim_status</span></div>
+          <div class="console-line"><span class="k">expiration</span><span class="v">Renewal required</span></div>
+          <p class="console-note">Illustrative registry entry — not live product data.</p>
+        </div>
       </div>
+      <div class="status-note">
+        <span>&#9432;</span>
+        <span><b>Development status:</b> TrustLayer is being built with design partners and is not yet generally available. Screens and outputs on this page are illustrative, not live product data.</span>
+      </div>
+    </div>
+  </section>
+
+  <section class="page-cta">
+    <div class="container">
+      <h2>Related</h2>
+      <p>Identity is the input to enforcement and to evidence.</p>
+      <div class="page-cta-grid">
+        <a class="page-cta-card" href="/platform/trust-gateway.html"><b>Trust Gateway <span class="arr">&rarr;</span></b><span>Where registry identity gets enforced.</span></a>
+        <a class="page-cta-card" href="/framework/nhid-auth.html"><b>NHID-Auth <span class="arr">&rarr;</span></b><span>The open passport format underneath.</span></a>
+        <a class="page-cta-card" href="/platform/enterprise.html"><b>Approvals &amp; RBAC <span class="arr">&rarr;</span></b><span>Who may register or revoke an agent.</span></a>
+        <a class="page-cta-card" href="/pricing.html"><b>See plans <span class="arr">&rarr;</span></b><span>Community, Developer, Enterprise.</span></a>
+      </div>
+      <p class="disclaimer-small" style="margin-top:1.5rem">TrustLayer by NHID-Clinical is in active development. It is not an accredited standard, a certification, or a regulatory compliance guarantee. The open framework it enforces remains free under CC BY 4.0 and is never gated behind a plan.</p>
     </div>
   </section>
 </main>
 
-<section class="page-cta">
-  <div class="container">
-    <h2>Where to go next</h2>
-    <p>Four ways into NHID-Clinical, whatever you came to do.</p>
-    <div class="page-cta-grid">
-      <a class="page-cta-card" href="/specification.html"><b>Read the Specification <span class="arr">&rarr;</span></b><span>The v1.3 controls, in full.</span></a>
-      <a class="page-cta-card" href="/simulator.html"><b>Try the Simulator <span class="arr">&rarr;</span></b><span>Run the controls on call scenarios.</span></a>
-      <a class="page-cta-card" href="/evidence-pack.html"><b>Review the Evidence Pack <span class="arr">&rarr;</span></b><span>Guarantees, a failure trace, the audit model.</span></a>
-      <a class="page-cta-card" href="https://github.com/NHID-Clinical/NHID-Clinical/discussions" target="_blank" rel="noopener noreferrer"><b>Join the Community <span class="arr">&#x2197;</span></b><span>Questions and feedback on GitHub.</span></a>
-    </div>
-  </div>
-</section>
 <footer id="contact" class="site-footer">
   <div class="container footer-inner">
     <p>&copy; 2026 Brianna Baynard | NIST-2025-0035-0026 | CC BY 4.0</p>
@@ -231,50 +247,9 @@
       <a href="https://nhid-clinical.org">nhid-clinical.org</a>
     </div>
   </div>
+  <p class="footer-copy" style="margin-top:.4rem">This is an open, actively maintained framework — feedback and contributions welcome. <a href="https://github.com/NHID-Clinical/NHID-Clinical">GitHub</a> · NIST-2025-0035-0026 · CC BY 4.0</p>
 </footer>
 
 <script src="/site.js"></script>
-<script>
-(function () {
-  var listEl = document.getElementById('registry-list');
-  var BADGE_BASE = 'https://gfvq4swdtf.execute-api.us-east-1.amazonaws.com/prod/v1/public/vendor/';
-
-  function escapeHtml(str) {
-    return String(str).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
-  }
-
-  function renderEntries(entries) {
-    if (!entries.length) {
-      listEl.innerHTML = '<p style="color:var(--body)">No implementations are listed yet. ' +
-        'Be the first — see "How to Get Listed" below.</p>';
-      return;
-    }
-    var rows = entries.map(function (e) {
-      var badgeUrl = BADGE_BASE + encodeURIComponent(e.vendor_id) + '/badge';
-      return '<tr style="border-bottom:1px solid var(--border)">' +
-        '<td style="padding:.75rem">' + escapeHtml(e.name || e.vendor_id) + '</td>' +
-        '<td style="padding:.75rem">' + (e.website ? '<a href="' + escapeHtml(e.website) + '" target="_blank" rel="noopener noreferrer">' + escapeHtml(e.website) + '</a>' : '—') + '</td>' +
-        '<td style="padding:.75rem">' + escapeHtml(e.integration_type || '—') + '</td>' +
-        '<td style="padding:.75rem"><img src="' + badgeUrl + '" alt="NHID-CAS badge for ' + escapeHtml(e.vendor_id) + '" /></td>' +
-        '</tr>';
-    }).join('');
-    listEl.innerHTML = '<table style="width:100%;border-collapse:collapse">' +
-      '<thead><tr style="border-bottom:2px solid var(--border);text-align:left">' +
-      '<th style="padding:.75rem">Implementation</th>' +
-      '<th style="padding:.75rem">Website</th>' +
-      '<th style="padding:.75rem">Integration</th>' +
-      '<th style="padding:.75rem">NHID-CAS</th>' +
-      '</tr></thead><tbody>' + rows + '</tbody></table>';
-  }
-
-  fetch('/content/registry_entries.json')
-    .then(function (r) { return r.json(); })
-    .then(renderEntries)
-    .catch(function () {
-      listEl.innerHTML = '<p style="color:var(--body)">No implementations are listed yet. ' +
-        'Be the first — see "How to Get Listed" below.</p>';
-    });
-})();
-</script>
 </body>
 </html>

--- a/platform/continuous-conformance.html
+++ b/platform/continuous-conformance.html
@@ -1,16 +1,18 @@
-﻿<!doctype html>
+<!doctype html>
 <html lang="en">
 <head>
   <meta charset="utf-8"/>
   <meta name="viewport" content="width=device-width, initial-scale=1"/>
-  <meta name="description" content="NHID-Clinical Implementation Registry — self-attested vendor implementations with live NHID-CAS badges."/>
-  <title>Implementation Registry | NHID-Clinical</title>
+  <meta name="description" content="TrustLayer continuous conformance monitoring — turn static conformance tests into operational monitoring that re-runs when an AI agent changes."/>
+  <title>Continuous Conformance Monitoring | TrustLayer by NHID-Clinical</title>
+  <link rel="canonical" href="https://nhid-clinical.org/platform/continuous-conformance.html"/>
   <link rel="icon" href="/assets/brand/favicon.svg" type="image/svg+xml"/>
   <link rel="icon" href="/assets/brand-icon.png" type="image/png"/>
   <link rel="preconnect" href="https://fonts.googleapis.com"/>
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
   <link href="https://fonts.googleapis.com/css2?family=Raleway:wght@600;700;800&family=Inter:wght@400;500;600;700;800&family=IBM+Plex+Mono:wght@400;500&display=swap" rel="stylesheet"/>
   <link rel="stylesheet" href="/nhid-clinical-ui.css"/>
+  <link rel="stylesheet" href="/assets/css/premium.css"/>
   <script>try{document.documentElement.setAttribute('data-theme',localStorage.getItem('nhid-theme')||'light')}catch(e){}</script>
   <script defer data-domain="nhid-clinical.org" src="https://plausible.io/js/script.js"></script>
 </head>
@@ -162,66 +164,79 @@
 <div class="nav-backdrop" id="nav-backdrop"></div>
 
 <main>
-  <section class="inner-hero" style="position:relative;overflow:clip">
+
+  <section class="inner-hero">
     <div class="hero-glow" aria-hidden="true"></div>
-    <div class="container" style="position:relative;z-index:1">
-      <div class="crumbs"><a href="/">Home</a><span>/</span><span>Implementation Registry</span></div>
-      <p class="eyebrow">Registry · June 2026</p>
-      <h1 class="reveal">Implementation Registry</h1>
-      <p class="lede reveal">Self-attested NHID-Clinical implementations, with live NHID-CAS conformance badges.</p>
+    <div class="container" style="position:relative;z-index:1;max-width:60rem">
+      <div class="crumbs"><a href="/">Home</a><span>/</span><a href="/platform/">Platform</a><span>/</span><span>Continuous Conformance</span></div>
+      <p class="eyebrow">TrustLayer &middot; Module 04</p>
+      <h1>Continuous Conformance Monitoring</h1>
+      <p class="lede">A conformance test is a photograph. Agents change weekly — what you need is a video.</p>
     </div>
   </section>
 
   <section class="page-section">
-    <div class="container" style="max-width:52rem">
-      <div class="callout" role="note" style="margin-bottom:2rem">
-        <strong>This is a self-attestation list, not a certification.</strong> NHID-Clinical does not
-        certify, audit, or warrant any vendor's implementation. A listing means the vendor ran the
-        public conformance test suite (CTS) against their own integration and chose to publish the
-        result. Badge scores update from each vendor's own live <code>/v1/public/vendor/{id}/badge</code>
-        endpoint call — verify independently before relying on them for procurement decisions.
-      </div>
+    <div class="container" style="max-width:60rem">
+      <h2>Why a one-time test decays</h2>
+      <p style="color:var(--body);line-height:1.85;margin-top:.75rem">A vendor passes the conformance suite during procurement. Six weeks later they ship a prompt change to improve call completion rates, and the new opening line buries the disclosure two turns deeper. Nothing in a procurement-time test result would tell you.</p>
+      <p style="color:var(--body);line-height:1.85;margin-top:.75rem">Continuous conformance re-runs the same open test suite whenever an agent version changes, and treats a regression as an operational event with an owner — not a document that expires quietly.</p>
+      <p style="color:var(--body);line-height:1.8;margin-top:.85rem">TrustLayer runs the same deterministic controls as the <a href="/framework/" style="color:var(--teal-bright);font-weight:600">open framework</a> — this module adds operations around them, not different rules.</p>
 
-      <h2>Listed Implementations</h2>
-      <div id="registry-list" style="margin:1.5rem 0">
-        <p style="color:var(--body)">Loading…</p>
+      <h2 style="margin-top:2.5rem">Worked example</h2>
+      <p style="color:var(--body);line-height:1.8;margin-top:.75rem">An agent update is detected. The suite re-runs. Two controls hold; one regresses.</p>
+      <div class="console-panel">
+        <div class="console-bar"><span class="mock-dot"></span><span class="mock-dot"></span><span class="mock-dot"></span><span class="console-title">monitor / agent-update-detected</span></div>
+        <div class="console-body">
+          <div class="console-verdict"><strong>Claims Agent v2.4</strong><span class="console-pill is-review">Human review required</span></div>
+          <div class="console-line"><span class="k">IDG-01 &middot; Identity Disclosure Gate</span><span class="v pass">PASS</span></div>
+          <div class="console-line"><span class="k">PDX-01 &middot; Pre-Data Exchange Gate</span><span class="v pass">PASS</span></div>
+          <div class="console-line"><span class="k">DBC-01 &middot; Deceptive Behavior Check</span><span class="v fail">FAIL</span></div>
+          <p class="console-note">Illustrative monitoring output — not live product data.</p>
+        </div>
       </div>
+      <p style="color:var(--body);line-height:1.85;margin-top:1.1rem"><strong style="color:var(--ink)">Action: human review required.</strong> A DBC-01 regression is not an alert to be acknowledged and cleared. It routes to a named reviewer, with the failing case and the prior passing version attached, and the agent&rsquo;s status in the <a href="/platform/agent-registry.html" style="color:var(--teal-bright);font-weight:600">registry</a> reflects the open finding until someone resolves it.</p>
 
-      <h2 style="margin-top:2.5rem">How to Get Listed</h2>
-      <p style="margin-bottom:1rem">
-        Run the conformance test suite against your integration, then complete the
-        <a href="https://github.com/NHID-Clinical/NHID-Clinical/blob/main/docs/vendor-trust-questionnaire.md">vendor trust questionnaire</a>
-        and open a pull request adding your entry to
-        <a href="https://github.com/NHID-Clinical/NHID-Clinical/blob/main/content/registry_entries.json">content/registry_entries.json</a>.
-        Each entry needs a <code>vendor_id</code> matching the one used when recording conformance results
-        (see <code>record_conformance_result()</code> in <code>nhid_event_store.py</code>), so your badge
-        renders live CAS data instead of the unknown/grey default.
-      </p>
-      <div style="display:flex;gap:1rem;flex-wrap:wrap;margin-bottom:2rem">
-        <a href="https://github.com/NHID-Clinical/NHID-Clinical/blob/main/docs/vendor-trust-questionnaire.md"
-           class="secondary-button" style="display:inline-flex;align-items:center;gap:.4rem">
-          Vendor Trust Questionnaire →
-        </a>
-        <a href="/developers.html#adapters" class="secondary-button" style="display:inline-flex;align-items:center;gap:.4rem">
-          Adapter Reference →
-        </a>
+      <h2 style="margin-top:2.5rem">What triggers a re-run</h2>
+      <div class="content-cards" style="grid-template-columns:repeat(auto-fit,minmax(15rem,1fr));margin-top:1.25rem">
+        <div class="content-card">
+          <h3>Agent version change</h3>
+          <p>A new agent version registers, or a vendor reports an update to a deployed agent.</p>
+        </div>
+        <div class="content-card">
+          <h3>Scope or delegation change</h3>
+          <p>Permissions widen, an owner changes, or a delegation is renewed with different bounds.</p>
+        </div>
+        <div class="content-card">
+          <h3>Scheduled interval</h3>
+          <p>Periodic re-evaluation so an unchanged agent still produces a current result, not a stale one.</p>
+        </div>
+        <div class="content-card">
+          <h3>Suite update</h3>
+          <p>When the open conformance suite adds cases, existing agents are re-measured against the new bar.</p>
+        </div>
       </div>
+      <div class="status-note">
+        <span>&#9432;</span>
+        <span><b>Development status:</b> TrustLayer is being built with design partners and is not yet generally available. Screens and outputs on this page are illustrative, not live product data.</span>
+      </div>
+    </div>
+  </section>
+
+  <section class="page-cta">
+    <div class="container">
+      <h2>Related</h2>
+      <p>The same tests, run once or run continuously.</p>
+      <div class="page-cta-grid">
+        <a class="page-cta-card" href="/framework/conformance-suite.html"><b>The open suite <span class="arr">&rarr;</span></b><span>Run it yourself, free.</span></a>
+        <a class="page-cta-card" href="/platform/evidence-center.html"><b>Evidence Center <span class="arr">&rarr;</span></b><span>Monitoring history as evidence.</span></a>
+        <a class="page-cta-card" href="/shadow-evaluation-guide.html"><b>Shadow evaluation <span class="arr">&rarr;</span></b><span>Establish a baseline first.</span></a>
+        <a class="page-cta-card" href="/platform/enterprise.html"><b>Review workflows <span class="arr">&rarr;</span></b><span>Who owns a failing control.</span></a>
+      </div>
+      <p class="disclaimer-small" style="margin-top:1.5rem">TrustLayer by NHID-Clinical is in active development. It is not an accredited standard, a certification, or a regulatory compliance guarantee. The open framework it enforces remains free under CC BY 4.0 and is never gated behind a plan.</p>
     </div>
   </section>
 </main>
 
-<section class="page-cta">
-  <div class="container">
-    <h2>Where to go next</h2>
-    <p>Four ways into NHID-Clinical, whatever you came to do.</p>
-    <div class="page-cta-grid">
-      <a class="page-cta-card" href="/specification.html"><b>Read the Specification <span class="arr">&rarr;</span></b><span>The v1.3 controls, in full.</span></a>
-      <a class="page-cta-card" href="/simulator.html"><b>Try the Simulator <span class="arr">&rarr;</span></b><span>Run the controls on call scenarios.</span></a>
-      <a class="page-cta-card" href="/evidence-pack.html"><b>Review the Evidence Pack <span class="arr">&rarr;</span></b><span>Guarantees, a failure trace, the audit model.</span></a>
-      <a class="page-cta-card" href="https://github.com/NHID-Clinical/NHID-Clinical/discussions" target="_blank" rel="noopener noreferrer"><b>Join the Community <span class="arr">&#x2197;</span></b><span>Questions and feedback on GitHub.</span></a>
-    </div>
-  </div>
-</section>
 <footer id="contact" class="site-footer">
   <div class="container footer-inner">
     <p>&copy; 2026 Brianna Baynard | NIST-2025-0035-0026 | CC BY 4.0</p>
@@ -231,50 +246,9 @@
       <a href="https://nhid-clinical.org">nhid-clinical.org</a>
     </div>
   </div>
+  <p class="footer-copy" style="margin-top:.4rem">This is an open, actively maintained framework — feedback and contributions welcome. <a href="https://github.com/NHID-Clinical/NHID-Clinical">GitHub</a> · NIST-2025-0035-0026 · CC BY 4.0</p>
 </footer>
 
 <script src="/site.js"></script>
-<script>
-(function () {
-  var listEl = document.getElementById('registry-list');
-  var BADGE_BASE = 'https://gfvq4swdtf.execute-api.us-east-1.amazonaws.com/prod/v1/public/vendor/';
-
-  function escapeHtml(str) {
-    return String(str).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
-  }
-
-  function renderEntries(entries) {
-    if (!entries.length) {
-      listEl.innerHTML = '<p style="color:var(--body)">No implementations are listed yet. ' +
-        'Be the first — see "How to Get Listed" below.</p>';
-      return;
-    }
-    var rows = entries.map(function (e) {
-      var badgeUrl = BADGE_BASE + encodeURIComponent(e.vendor_id) + '/badge';
-      return '<tr style="border-bottom:1px solid var(--border)">' +
-        '<td style="padding:.75rem">' + escapeHtml(e.name || e.vendor_id) + '</td>' +
-        '<td style="padding:.75rem">' + (e.website ? '<a href="' + escapeHtml(e.website) + '" target="_blank" rel="noopener noreferrer">' + escapeHtml(e.website) + '</a>' : '—') + '</td>' +
-        '<td style="padding:.75rem">' + escapeHtml(e.integration_type || '—') + '</td>' +
-        '<td style="padding:.75rem"><img src="' + badgeUrl + '" alt="NHID-CAS badge for ' + escapeHtml(e.vendor_id) + '" /></td>' +
-        '</tr>';
-    }).join('');
-    listEl.innerHTML = '<table style="width:100%;border-collapse:collapse">' +
-      '<thead><tr style="border-bottom:2px solid var(--border);text-align:left">' +
-      '<th style="padding:.75rem">Implementation</th>' +
-      '<th style="padding:.75rem">Website</th>' +
-      '<th style="padding:.75rem">Integration</th>' +
-      '<th style="padding:.75rem">NHID-CAS</th>' +
-      '</tr></thead><tbody>' + rows + '</tbody></table>';
-  }
-
-  fetch('/content/registry_entries.json')
-    .then(function (r) { return r.json(); })
-    .then(renderEntries)
-    .catch(function () {
-      listEl.innerHTML = '<p style="color:var(--body)">No implementations are listed yet. ' +
-        'Be the first — see "How to Get Listed" below.</p>';
-    });
-})();
-</script>
 </body>
 </html>

--- a/platform/enterprise.html
+++ b/platform/enterprise.html
@@ -1,16 +1,18 @@
-﻿<!doctype html>
+<!doctype html>
 <html lang="en">
 <head>
   <meta charset="utf-8"/>
   <meta name="viewport" content="width=device-width, initial-scale=1"/>
-  <meta name="description" content="NHID-Clinical Implementation Registry — self-attested vendor implementations with live NHID-CAS badges."/>
-  <title>Implementation Registry | NHID-Clinical</title>
+  <meta name="description" content="TrustLayer enterprise workflow — SSO, role-based access control, approval workflows, integrations, and SIEM export for organizations operating AI agents at scale."/>
+  <title>Enterprise Workflow | TrustLayer by NHID-Clinical</title>
+  <link rel="canonical" href="https://nhid-clinical.org/platform/enterprise.html"/>
   <link rel="icon" href="/assets/brand/favicon.svg" type="image/svg+xml"/>
   <link rel="icon" href="/assets/brand-icon.png" type="image/png"/>
   <link rel="preconnect" href="https://fonts.googleapis.com"/>
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
   <link href="https://fonts.googleapis.com/css2?family=Raleway:wght@600;700;800&family=Inter:wght@400;500;600;700;800&family=IBM+Plex+Mono:wght@400;500&display=swap" rel="stylesheet"/>
   <link rel="stylesheet" href="/nhid-clinical-ui.css"/>
+  <link rel="stylesheet" href="/assets/css/premium.css"/>
   <script>try{document.documentElement.setAttribute('data-theme',localStorage.getItem('nhid-theme')||'light')}catch(e){}</script>
   <script defer data-domain="nhid-clinical.org" src="https://plausible.io/js/script.js"></script>
 </head>
@@ -162,66 +164,83 @@
 <div class="nav-backdrop" id="nav-backdrop"></div>
 
 <main>
-  <section class="inner-hero" style="position:relative;overflow:clip">
+
+  <section class="inner-hero">
     <div class="hero-glow" aria-hidden="true"></div>
-    <div class="container" style="position:relative;z-index:1">
-      <div class="crumbs"><a href="/">Home</a><span>/</span><span>Implementation Registry</span></div>
-      <p class="eyebrow">Registry · June 2026</p>
-      <h1 class="reveal">Implementation Registry</h1>
-      <p class="lede reveal">Self-attested NHID-Clinical implementations, with live NHID-CAS conformance badges.</p>
+    <div class="container" style="position:relative;z-index:1;max-width:60rem">
+      <div class="crumbs"><a href="/">Home</a><span>/</span><a href="/platform/">Platform</a><span>/</span><span>Enterprise Workflow</span></div>
+      <p class="eyebrow">TrustLayer &middot; Module 05</p>
+      <h1>Enterprise Workflow</h1>
+      <p class="lede">Governance that lives outside your identity, access, and monitoring stack is governance nobody follows.</p>
     </div>
   </section>
 
   <section class="page-section">
-    <div class="container" style="max-width:52rem">
-      <div class="callout" role="note" style="margin-bottom:2rem">
-        <strong>This is a self-attestation list, not a certification.</strong> NHID-Clinical does not
-        certify, audit, or warrant any vendor's implementation. A listing means the vendor ran the
-        public conformance test suite (CTS) against their own integration and chose to publish the
-        result. Badge scores update from each vendor's own live <code>/v1/public/vendor/{id}/badge</code>
-        endpoint call — verify independently before relying on them for procurement decisions.
+    <div class="container" style="max-width:60rem">
+      <h2>The operational surface</h2>
+      <p style="color:var(--body);line-height:1.85;margin-top:.85rem">Agent governance fails in practice for unglamorous reasons: a separate login nobody has, an approval that happens in a chat thread, an alert that never reaches the security team. This module is about removing those failure modes.</p>
+
+      <div class="module-grid">
+        <div class="module-card">
+          <span class="module-num">SSO</span>
+          <h3>Single sign-on</h3>
+          <p>Federated authentication through your existing identity provider. No standalone credential set to provision, rotate, or forget to deprovision.</p>
+        </div>
+        <div class="module-card">
+          <span class="module-num">RBAC</span>
+          <h3>Role-based access control</h3>
+          <p>Distinct roles for registering an agent, approving scope, reviewing a failed control, and reading evidence. Registering is not approving.</p>
+        </div>
+        <div class="module-card">
+          <span class="module-num">APPROVALS</span>
+          <h3>Approval workflows</h3>
+          <p>Scope grants, renewals, and exceptions move through a recorded approval path with a named approver and a timestamp — not an email thread.</p>
+        </div>
+        <div class="module-card">
+          <span class="module-num">INTEGRATIONS</span>
+          <h3>Integrations</h3>
+          <p>Connections into the voice platforms, ticketing, and GRC tooling your teams already operate, so findings land where work happens.</p>
+        </div>
+        <div class="module-card">
+          <span class="module-num">SIEM</span>
+          <h3>SIEM export</h3>
+          <p>Control decisions and audit events stream into your security monitoring stack as first-class events, correlatable with everything else.</p>
+        </div>
+        <div class="module-card">
+          <span class="module-num">POSTURE</span>
+          <h3>Revocation &amp; posture</h3>
+          <p>Revoke an agent&rsquo;s authority immediately across the registry and the gateway, with the revocation itself recorded as evidence.</p>
+        </div>
       </div>
 
-      <h2>Listed Implementations</h2>
-      <div id="registry-list" style="margin:1.5rem 0">
-        <p style="color:var(--body)">Loading…</p>
-      </div>
+      <h2 style="margin-top:2.75rem">Separation of duties</h2>
+      <p style="color:var(--body);line-height:1.85;margin-top:.75rem">The person who deploys an agent should not be the only person who can widen its scope. RBAC and approval workflows exist so that delegated authority has a reviewable provenance: who requested it, who approved it, against what business justification, and when it expires.</p>
+      <p style="color:var(--body);line-height:1.85;margin-top:.75rem">That provenance is what an auditor is actually asking for when they ask how an agent got its permissions — and it is the part that is hardest to reconstruct afterwards if it was never captured.</p>
 
-      <h2 style="margin-top:2.5rem">How to Get Listed</h2>
-      <p style="margin-bottom:1rem">
-        Run the conformance test suite against your integration, then complete the
-        <a href="https://github.com/NHID-Clinical/NHID-Clinical/blob/main/docs/vendor-trust-questionnaire.md">vendor trust questionnaire</a>
-        and open a pull request adding your entry to
-        <a href="https://github.com/NHID-Clinical/NHID-Clinical/blob/main/content/registry_entries.json">content/registry_entries.json</a>.
-        Each entry needs a <code>vendor_id</code> matching the one used when recording conformance results
-        (see <code>record_conformance_result()</code> in <code>nhid_event_store.py</code>), so your badge
-        renders live CAS data instead of the unknown/grey default.
-      </p>
-      <div style="display:flex;gap:1rem;flex-wrap:wrap;margin-bottom:2rem">
-        <a href="https://github.com/NHID-Clinical/NHID-Clinical/blob/main/docs/vendor-trust-questionnaire.md"
-           class="secondary-button" style="display:inline-flex;align-items:center;gap:.4rem">
-          Vendor Trust Questionnaire →
-        </a>
-        <a href="/developers.html#adapters" class="secondary-button" style="display:inline-flex;align-items:center;gap:.4rem">
-          Adapter Reference →
-        </a>
+      <h2 style="margin-top:2.5rem">Escalation has to reach a person</h2>
+      <p style="color:var(--body);line-height:1.85;margin-top:.75rem">EIT-01 in the open framework requires that a caller&rsquo;s request for a human be honored. The operational equivalent inside the platform is that a failing control reaches a named reviewer with the authority to act — not a dashboard nobody has open. Escalation paths, review queues, and ownership are configured per agent and recorded alongside the finding.</p>
+      <div class="status-note">
+        <span>&#9432;</span>
+        <span><b>Development status:</b> TrustLayer is being built with design partners and is not yet generally available. Capabilities on this page describe the intended enterprise surface, not shipped features.</span>
       </div>
+    </div>
+  </section>
+
+  <section class="page-cta">
+    <div class="container">
+      <h2>Related</h2>
+      <p>What the enterprise surface governs.</p>
+      <div class="page-cta-grid">
+        <a class="page-cta-card" href="/platform/agent-registry.html"><b>Agent Registry <span class="arr">&rarr;</span></b><span>What approvals apply to.</span></a>
+        <a class="page-cta-card" href="/platform/evidence-center.html"><b>Evidence Center <span class="arr">&rarr;</span></b><span>Approvals as audit evidence.</span></a>
+        <a class="page-cta-card" href="/platform/continuous-conformance.html"><b>Monitoring <span class="arr">&rarr;</span></b><span>What routes to a reviewer.</span></a>
+        <a class="page-cta-card" href="mailto:contact@nhid-clinical.org?subject=TrustLayer%20enterprise"><b>Talk to us <span class="arr">&rarr;</span></b><span>Design partner conversations.</span></a>
+      </div>
+      <p class="disclaimer-small" style="margin-top:1.5rem">TrustLayer by NHID-Clinical is in active development. It is not an accredited standard, a certification, or a regulatory compliance guarantee. The open framework it enforces remains free under CC BY 4.0 and is never gated behind a plan.</p>
     </div>
   </section>
 </main>
 
-<section class="page-cta">
-  <div class="container">
-    <h2>Where to go next</h2>
-    <p>Four ways into NHID-Clinical, whatever you came to do.</p>
-    <div class="page-cta-grid">
-      <a class="page-cta-card" href="/specification.html"><b>Read the Specification <span class="arr">&rarr;</span></b><span>The v1.3 controls, in full.</span></a>
-      <a class="page-cta-card" href="/simulator.html"><b>Try the Simulator <span class="arr">&rarr;</span></b><span>Run the controls on call scenarios.</span></a>
-      <a class="page-cta-card" href="/evidence-pack.html"><b>Review the Evidence Pack <span class="arr">&rarr;</span></b><span>Guarantees, a failure trace, the audit model.</span></a>
-      <a class="page-cta-card" href="https://github.com/NHID-Clinical/NHID-Clinical/discussions" target="_blank" rel="noopener noreferrer"><b>Join the Community <span class="arr">&#x2197;</span></b><span>Questions and feedback on GitHub.</span></a>
-    </div>
-  </div>
-</section>
 <footer id="contact" class="site-footer">
   <div class="container footer-inner">
     <p>&copy; 2026 Brianna Baynard | NIST-2025-0035-0026 | CC BY 4.0</p>
@@ -231,50 +250,9 @@
       <a href="https://nhid-clinical.org">nhid-clinical.org</a>
     </div>
   </div>
+  <p class="footer-copy" style="margin-top:.4rem">This is an open, actively maintained framework — feedback and contributions welcome. <a href="https://github.com/NHID-Clinical/NHID-Clinical">GitHub</a> · NIST-2025-0035-0026 · CC BY 4.0</p>
 </footer>
 
 <script src="/site.js"></script>
-<script>
-(function () {
-  var listEl = document.getElementById('registry-list');
-  var BADGE_BASE = 'https://gfvq4swdtf.execute-api.us-east-1.amazonaws.com/prod/v1/public/vendor/';
-
-  function escapeHtml(str) {
-    return String(str).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
-  }
-
-  function renderEntries(entries) {
-    if (!entries.length) {
-      listEl.innerHTML = '<p style="color:var(--body)">No implementations are listed yet. ' +
-        'Be the first — see "How to Get Listed" below.</p>';
-      return;
-    }
-    var rows = entries.map(function (e) {
-      var badgeUrl = BADGE_BASE + encodeURIComponent(e.vendor_id) + '/badge';
-      return '<tr style="border-bottom:1px solid var(--border)">' +
-        '<td style="padding:.75rem">' + escapeHtml(e.name || e.vendor_id) + '</td>' +
-        '<td style="padding:.75rem">' + (e.website ? '<a href="' + escapeHtml(e.website) + '" target="_blank" rel="noopener noreferrer">' + escapeHtml(e.website) + '</a>' : '—') + '</td>' +
-        '<td style="padding:.75rem">' + escapeHtml(e.integration_type || '—') + '</td>' +
-        '<td style="padding:.75rem"><img src="' + badgeUrl + '" alt="NHID-CAS badge for ' + escapeHtml(e.vendor_id) + '" /></td>' +
-        '</tr>';
-    }).join('');
-    listEl.innerHTML = '<table style="width:100%;border-collapse:collapse">' +
-      '<thead><tr style="border-bottom:2px solid var(--border);text-align:left">' +
-      '<th style="padding:.75rem">Implementation</th>' +
-      '<th style="padding:.75rem">Website</th>' +
-      '<th style="padding:.75rem">Integration</th>' +
-      '<th style="padding:.75rem">NHID-CAS</th>' +
-      '</tr></thead><tbody>' + rows + '</tbody></table>';
-  }
-
-  fetch('/content/registry_entries.json')
-    .then(function (r) { return r.json(); })
-    .then(renderEntries)
-    .catch(function () {
-      listEl.innerHTML = '<p style="color:var(--body)">No implementations are listed yet. ' +
-        'Be the first — see "How to Get Listed" below.</p>';
-    });
-})();
-</script>
 </body>
 </html>

--- a/platform/evidence-center.html
+++ b/platform/evidence-center.html
@@ -1,16 +1,18 @@
-﻿<!doctype html>
+<!doctype html>
 <html lang="en">
 <head>
   <meta charset="utf-8"/>
   <meta name="viewport" content="width=device-width, initial-scale=1"/>
-  <meta name="description" content="NHID-Clinical Implementation Registry — self-attested vendor implementations with live NHID-CAS badges."/>
-  <title>Implementation Registry | NHID-Clinical</title>
+  <meta name="description" content="The TrustLayer Evidence Center — generate audit-ready evidence: compliance reports, evidence packages, event history, and governance exports aligned to NIST AI RMF, ISO/IEC 42001, and HIPAA security documentation."/>
+  <title>Evidence Center | TrustLayer by NHID-Clinical</title>
+  <link rel="canonical" href="https://nhid-clinical.org/platform/evidence-center.html"/>
   <link rel="icon" href="/assets/brand/favicon.svg" type="image/svg+xml"/>
   <link rel="icon" href="/assets/brand-icon.png" type="image/png"/>
   <link rel="preconnect" href="https://fonts.googleapis.com"/>
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
   <link href="https://fonts.googleapis.com/css2?family=Raleway:wght@600;700;800&family=Inter:wght@400;500;600;700;800&family=IBM+Plex+Mono:wght@400;500&display=swap" rel="stylesheet"/>
   <link rel="stylesheet" href="/nhid-clinical-ui.css"/>
+  <link rel="stylesheet" href="/assets/css/premium.css"/>
   <script>try{document.documentElement.setAttribute('data-theme',localStorage.getItem('nhid-theme')||'light')}catch(e){}</script>
   <script defer data-domain="nhid-clinical.org" src="https://plausible.io/js/script.js"></script>
 </head>
@@ -162,66 +164,98 @@
 <div class="nav-backdrop" id="nav-backdrop"></div>
 
 <main>
-  <section class="inner-hero" style="position:relative;overflow:clip">
+
+  <section class="inner-hero">
     <div class="hero-glow" aria-hidden="true"></div>
-    <div class="container" style="position:relative;z-index:1">
-      <div class="crumbs"><a href="/">Home</a><span>/</span><span>Implementation Registry</span></div>
-      <p class="eyebrow">Registry · June 2026</p>
-      <h1 class="reveal">Implementation Registry</h1>
-      <p class="lede reveal">Self-attested NHID-Clinical implementations, with live NHID-CAS conformance badges.</p>
+    <div class="container" style="position:relative;z-index:1;max-width:60rem">
+      <div class="crumbs"><a href="/">Home</a><span>/</span><a href="/platform/">Platform</a><span>/</span><span>Evidence Center</span></div>
+      <p class="eyebrow">TrustLayer &middot; Module 03</p>
+      <h1>Evidence Center</h1>
+      <p class="lede">Generate audit-ready evidence. The question an auditor asks is not &ldquo;do you have controls?&rdquo; — it is &ldquo;show me what happened on 14 March.&rdquo;</p>
     </div>
   </section>
 
   <section class="page-section">
-    <div class="container" style="max-width:52rem">
-      <div class="callout" role="note" style="margin-bottom:2rem">
-        <strong>This is a self-attestation list, not a certification.</strong> NHID-Clinical does not
-        certify, audit, or warrant any vendor's implementation. A listing means the vendor ran the
-        public conformance test suite (CTS) against their own integration and chose to publish the
-        result. Badge scores update from each vendor's own live <code>/v1/public/vendor/{id}/badge</code>
-        endpoint call — verify independently before relying on them for procurement decisions.
+    <div class="container" style="max-width:60rem">
+      <h2>From audit events to evidence</h2>
+      <p style="color:var(--body);line-height:1.85;margin-top:.75rem">ATR-01 already requires that every event carry a complete, replayable envelope. The Evidence Center turns that raw stream into artifacts a governance function can actually use: scoped reports, packaged exports, and a queryable history that survives staff turnover.</p>
+      <p style="color:var(--body);line-height:1.8;margin-top:.85rem">TrustLayer runs the same deterministic controls as the <a href="/framework/" style="color:var(--teal-bright);font-weight:600">open framework</a> — this module adds operations around them, not different rules.</p>
+
+      <h2 style="margin-top:2.5rem">What it produces</h2>
+      <div class="module-grid">
+        <div class="module-card">
+          <span class="module-num">01</span>
+          <h3>Compliance reports</h3>
+          <p>Period-scoped summaries of control outcomes across an agent fleet, with the underlying events reachable from every figure.</p>
+        </div>
+        <div class="module-card">
+          <span class="module-num">02</span>
+          <h3>Evidence packages</h3>
+          <p>Self-contained exports for a specific review — agent inventory, control results, decision history, and the trace records behind them.</p>
+        </div>
+        <div class="module-card">
+          <span class="module-num">03</span>
+          <h3>Event history</h3>
+          <p>Queryable, replayable record of what each agent did and what the controls decided, retained on your schedule.</p>
+        </div>
+        <div class="module-card">
+          <span class="module-num">04</span>
+          <h3>Governance exports</h3>
+          <p>Structured output for internal audit, risk committees, and downstream GRC tooling — not a PDF you have to retype.</p>
+        </div>
       </div>
 
-      <h2>Listed Implementations</h2>
-      <div id="registry-list" style="margin:1.5rem 0">
-        <p style="color:var(--body)">Loading…</p>
+      <h2 style="margin-top:2.5rem">Framework alignment</h2>
+      <p style="color:var(--body);line-height:1.85;margin-top:.75rem">Evidence is organized so it maps onto documentation frameworks your organization already reports against. This is alignment, not certification — NHID-Clinical does not certify anyone against any of these, and no export constitutes a compliance determination.</p>
+      <div class="field-table-wrap">
+        <table class="field-table">
+          <thead><tr><th>Framework</th><th>What the evidence supports</th></tr></thead>
+          <tbody>
+            <tr><td><code>NIST AI RMF 1.0</code></td><td>Map and Measure functions — documented agent inventory, control outcomes, and measurement over time</td></tr>
+            <tr><td><code>ISO/IEC 42001</code></td><td>Annex A transparency and operational control evidence for an AI management system</td></tr>
+            <tr><td><code>HIPAA security documentation</code></td><td>Access and audit control documentation for systems handling protected health information</td></tr>
+            <tr><td><code>EU AI Act Art. 50</code></td><td>Transparency obligation evidence — disclosure occurred, when, and on which interactions</td></tr>
+            <tr><td><code>FHIR AuditEvent R4</code></td><td>Audit records emitted in a healthcare-native format your existing systems can ingest</td></tr>
+          </tbody>
+        </table>
       </div>
+      <p style="color:var(--body);line-height:1.8;margin-top:1rem;font-size:.93rem">The open framework&rsquo;s <a href="/regulatory-alignment.html" style="color:var(--teal-bright);font-weight:600">regulatory alignment</a> page documents these mappings in full, free of charge.</p>
 
-      <h2 style="margin-top:2.5rem">How to Get Listed</h2>
-      <p style="margin-bottom:1rem">
-        Run the conformance test suite against your integration, then complete the
-        <a href="https://github.com/NHID-Clinical/NHID-Clinical/blob/main/docs/vendor-trust-questionnaire.md">vendor trust questionnaire</a>
-        and open a pull request adding your entry to
-        <a href="https://github.com/NHID-Clinical/NHID-Clinical/blob/main/content/registry_entries.json">content/registry_entries.json</a>.
-        Each entry needs a <code>vendor_id</code> matching the one used when recording conformance results
-        (see <code>record_conformance_result()</code> in <code>nhid_event_store.py</code>), so your badge
-        renders live CAS data instead of the unknown/grey default.
-      </p>
-      <div style="display:flex;gap:1rem;flex-wrap:wrap;margin-bottom:2rem">
-        <a href="https://github.com/NHID-Clinical/NHID-Clinical/blob/main/docs/vendor-trust-questionnaire.md"
-           class="secondary-button" style="display:inline-flex;align-items:center;gap:.4rem">
-          Vendor Trust Questionnaire →
-        </a>
-        <a href="/developers.html#adapters" class="secondary-button" style="display:inline-flex;align-items:center;gap:.4rem">
-          Adapter Reference →
-        </a>
+      <h2 style="margin-top:2.5rem">Illustrative export summary</h2>
+      <div class="console-panel">
+        <div class="console-bar"><span class="mock-dot"></span><span class="mock-dot"></span><span class="mock-dot"></span><span class="console-title">evidence / export / period-summary</span></div>
+        <div class="console-body">
+          <div class="console-verdict"><strong>Evidence package</strong><span class="console-pill">Ready</span></div>
+          <div class="console-line"><span class="k">registered agents</span><span class="v">37</span></div>
+          <div class="console-line"><span class="k">evaluated calls</span><span class="v">142,832</span></div>
+          <div class="console-line"><span class="k">disclosure rate (IDG-01)</span><span class="v pass">99.7%</span></div>
+          <div class="console-line"><span class="k">authorization failures</span><span class="v fail">12</span></div>
+          <div class="console-line"><span class="k">envelope completeness (ATR-01)</span><span class="v pass">100%</span></div>
+          <p class="console-note">Illustrative figures for layout purposes — not live product data or a customer result.</p>
+        </div>
       </div>
+      <div class="status-note">
+        <span>&#9432;</span>
+        <span><b>Development status:</b> TrustLayer is being built with design partners and is not yet generally available. Screens and outputs on this page are illustrative, not live product data.</span>
+      </div>
+    </div>
+  </section>
+
+  <section class="page-cta">
+    <div class="container">
+      <h2>Related</h2>
+      <p>Where the evidence comes from, and what the open framework already gives you.</p>
+      <div class="page-cta-grid">
+        <a class="page-cta-card" href="/evidence-pack.html"><b>Open evidence pack <span class="arr">&rarr;</span></b><span>Free template for procurement.</span></a>
+        <a class="page-cta-card" href="/regulatory-alignment.html"><b>Regulatory alignment <span class="arr">&rarr;</span></b><span>The open control mappings.</span></a>
+        <a class="page-cta-card" href="/platform/trust-gateway.html"><b>Trust Gateway <span class="arr">&rarr;</span></b><span>Where audit events originate.</span></a>
+        <a class="page-cta-card" href="/platform/enterprise.html"><b>SIEM export <span class="arr">&rarr;</span></b><span>Streaming evidence to your stack.</span></a>
+      </div>
+      <p class="disclaimer-small" style="margin-top:1.5rem">TrustLayer by NHID-Clinical is in active development. It is not an accredited standard, a certification, or a regulatory compliance guarantee. The open framework it enforces remains free under CC BY 4.0 and is never gated behind a plan.</p>
     </div>
   </section>
 </main>
 
-<section class="page-cta">
-  <div class="container">
-    <h2>Where to go next</h2>
-    <p>Four ways into NHID-Clinical, whatever you came to do.</p>
-    <div class="page-cta-grid">
-      <a class="page-cta-card" href="/specification.html"><b>Read the Specification <span class="arr">&rarr;</span></b><span>The v1.3 controls, in full.</span></a>
-      <a class="page-cta-card" href="/simulator.html"><b>Try the Simulator <span class="arr">&rarr;</span></b><span>Run the controls on call scenarios.</span></a>
-      <a class="page-cta-card" href="/evidence-pack.html"><b>Review the Evidence Pack <span class="arr">&rarr;</span></b><span>Guarantees, a failure trace, the audit model.</span></a>
-      <a class="page-cta-card" href="https://github.com/NHID-Clinical/NHID-Clinical/discussions" target="_blank" rel="noopener noreferrer"><b>Join the Community <span class="arr">&#x2197;</span></b><span>Questions and feedback on GitHub.</span></a>
-    </div>
-  </div>
-</section>
 <footer id="contact" class="site-footer">
   <div class="container footer-inner">
     <p>&copy; 2026 Brianna Baynard | NIST-2025-0035-0026 | CC BY 4.0</p>
@@ -231,50 +265,9 @@
       <a href="https://nhid-clinical.org">nhid-clinical.org</a>
     </div>
   </div>
+  <p class="footer-copy" style="margin-top:.4rem">This is an open, actively maintained framework — feedback and contributions welcome. <a href="https://github.com/NHID-Clinical/NHID-Clinical">GitHub</a> · NIST-2025-0035-0026 · CC BY 4.0</p>
 </footer>
 
 <script src="/site.js"></script>
-<script>
-(function () {
-  var listEl = document.getElementById('registry-list');
-  var BADGE_BASE = 'https://gfvq4swdtf.execute-api.us-east-1.amazonaws.com/prod/v1/public/vendor/';
-
-  function escapeHtml(str) {
-    return String(str).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
-  }
-
-  function renderEntries(entries) {
-    if (!entries.length) {
-      listEl.innerHTML = '<p style="color:var(--body)">No implementations are listed yet. ' +
-        'Be the first — see "How to Get Listed" below.</p>';
-      return;
-    }
-    var rows = entries.map(function (e) {
-      var badgeUrl = BADGE_BASE + encodeURIComponent(e.vendor_id) + '/badge';
-      return '<tr style="border-bottom:1px solid var(--border)">' +
-        '<td style="padding:.75rem">' + escapeHtml(e.name || e.vendor_id) + '</td>' +
-        '<td style="padding:.75rem">' + (e.website ? '<a href="' + escapeHtml(e.website) + '" target="_blank" rel="noopener noreferrer">' + escapeHtml(e.website) + '</a>' : '—') + '</td>' +
-        '<td style="padding:.75rem">' + escapeHtml(e.integration_type || '—') + '</td>' +
-        '<td style="padding:.75rem"><img src="' + badgeUrl + '" alt="NHID-CAS badge for ' + escapeHtml(e.vendor_id) + '" /></td>' +
-        '</tr>';
-    }).join('');
-    listEl.innerHTML = '<table style="width:100%;border-collapse:collapse">' +
-      '<thead><tr style="border-bottom:2px solid var(--border);text-align:left">' +
-      '<th style="padding:.75rem">Implementation</th>' +
-      '<th style="padding:.75rem">Website</th>' +
-      '<th style="padding:.75rem">Integration</th>' +
-      '<th style="padding:.75rem">NHID-CAS</th>' +
-      '</tr></thead><tbody>' + rows + '</tbody></table>';
-  }
-
-  fetch('/content/registry_entries.json')
-    .then(function (r) { return r.json(); })
-    .then(renderEntries)
-    .catch(function () {
-      listEl.innerHTML = '<p style="color:var(--body)">No implementations are listed yet. ' +
-        'Be the first — see "How to Get Listed" below.</p>';
-    });
-})();
-</script>
 </body>
 </html>

--- a/platform/index.html
+++ b/platform/index.html
@@ -1,16 +1,18 @@
-﻿<!doctype html>
+<!doctype html>
 <html lang="en">
 <head>
   <meta charset="utf-8"/>
   <meta name="viewport" content="width=device-width, initial-scale=1"/>
-  <meta name="description" content="NHID-Clinical Implementation Registry — self-attested vendor implementations with live NHID-CAS badges."/>
-  <title>Implementation Registry | NHID-Clinical</title>
+  <meta name="description" content="TrustLayer by NHID-Clinical — operational trust infrastructure for healthcare AI agents. Runs the same deterministic controls as the open framework, with monitoring, evidence, identity management, authorization, and reporting."/>
+  <title>TrustLayer Platform | NHID-Clinical</title>
+  <link rel="canonical" href="https://nhid-clinical.org/platform/"/>
   <link rel="icon" href="/assets/brand/favicon.svg" type="image/svg+xml"/>
   <link rel="icon" href="/assets/brand-icon.png" type="image/png"/>
   <link rel="preconnect" href="https://fonts.googleapis.com"/>
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
   <link href="https://fonts.googleapis.com/css2?family=Raleway:wght@600;700;800&family=Inter:wght@400;500;600;700;800&family=IBM+Plex+Mono:wght@400;500&display=swap" rel="stylesheet"/>
   <link rel="stylesheet" href="/nhid-clinical-ui.css"/>
+  <link rel="stylesheet" href="/assets/css/premium.css"/>
   <script>try{document.documentElement.setAttribute('data-theme',localStorage.getItem('nhid-theme')||'light')}catch(e){}</script>
   <script defer data-domain="nhid-clinical.org" src="https://plausible.io/js/script.js"></script>
 </head>
@@ -162,66 +164,133 @@
 <div class="nav-backdrop" id="nav-backdrop"></div>
 
 <main>
-  <section class="inner-hero" style="position:relative;overflow:clip">
+
+  <section class="inner-hero">
     <div class="hero-glow" aria-hidden="true"></div>
-    <div class="container" style="position:relative;z-index:1">
-      <div class="crumbs"><a href="/">Home</a><span>/</span><span>Implementation Registry</span></div>
-      <p class="eyebrow">Registry · June 2026</p>
-      <h1 class="reveal">Implementation Registry</h1>
-      <p class="lede reveal">Self-attested NHID-Clinical implementations, with live NHID-CAS conformance badges.</p>
+    <div class="container inner-hero-grid" style="position:relative;z-index:1">
+      <div>
+        <div class="crumbs"><a href="/">Home</a><span>/</span><span>Platform</span></div>
+        <p class="eyebrow">TrustLayer by NHID-Clinical</p>
+        <h1>Operational trust infrastructure for healthcare AI agents.</h1>
+        <p class="lede">TrustLayer runs the same deterministic controls as the open framework — and adds the production operations that running agents at scale actually requires.</p>
+        <div class="hero-actions-premium">
+          <a href="/pricing.html" class="btn-premium">See plans</a>
+          <a href="/framework/" class="btn-ghost">Start with the open framework</a>
+        </div>
+      </div>
+      <aside class="hero-summary-card">
+        <div class="spec-badges">
+          <span class="spec-badge spec-badge-teal">In development</span>
+        </div>
+        <p style="font-size:.88rem;color:var(--body);line-height:1.65;margin:.75rem 0 1rem">The framework stays open. TrustLayer is optional. Nothing about adopting the specification, the controls, or the conformance suite requires a commercial relationship.</p>
+        <a class="primary-pill" href="mailto:contact@nhid-clinical.org?subject=TrustLayer%20design%20partner" style="width:100%;justify-content:center">Talk to us &rarr;</a>
+      </aside>
     </div>
   </section>
 
   <section class="page-section">
-    <div class="container" style="max-width:52rem">
-      <div class="callout" role="note" style="margin-bottom:2rem">
-        <strong>This is a self-attestation list, not a certification.</strong> NHID-Clinical does not
-        certify, audit, or warrant any vendor's implementation. A listing means the vendor ran the
-        public conformance test suite (CTS) against their own integration and chose to publish the
-        result. Badge scores update from each vendor's own live <code>/v1/public/vendor/{id}/badge</code>
-        endpoint call — verify independently before relying on them for procurement decisions.
+    <div class="container" style="max-width:58rem">
+      <p class="section-kicker">What it is</p>
+      <h2>The framework, operationalized</h2>
+      <p style="color:var(--body);line-height:1.85;margin-top:.85rem">The open framework answers a question about a single call: was the agent disclosed, authorized, in scope, and audited? That answer is deterministic and anyone can compute it.</p>
+      <p style="color:var(--body);line-height:1.85;margin-top:.85rem">Running hundreds of agents across vendors and business units raises a different set of questions. Which agents exist, and who owns them? Which ones changed last week? Can we produce evidence for an auditor without a two-week fire drill? Who approved this agent&rsquo;s scope, and when does it expire?</p>
+      <p style="color:var(--body);line-height:1.85;margin-top:.85rem">TrustLayer answers those. It provides monitoring, evidence, identity management, authorization, and reporting on top of the same control logic — not a different, proprietary standard.</p>
+      <div class="status-note">
+        <span>&#9432;</span>
+        <span><b>Development status:</b> TrustLayer is being built with design partners and is not yet generally available. Screens and outputs on this page are illustrative, not live product data.</span>
       </div>
+    </div>
+  </section>
 
-      <h2>Listed Implementations</h2>
-      <div id="registry-list" style="margin:1.5rem 0">
-        <p style="color:var(--body)">Loading…</p>
-      </div>
-
-      <h2 style="margin-top:2.5rem">How to Get Listed</h2>
-      <p style="margin-bottom:1rem">
-        Run the conformance test suite against your integration, then complete the
-        <a href="https://github.com/NHID-Clinical/NHID-Clinical/blob/main/docs/vendor-trust-questionnaire.md">vendor trust questionnaire</a>
-        and open a pull request adding your entry to
-        <a href="https://github.com/NHID-Clinical/NHID-Clinical/blob/main/content/registry_entries.json">content/registry_entries.json</a>.
-        Each entry needs a <code>vendor_id</code> matching the one used when recording conformance results
-        (see <code>record_conformance_result()</code> in <code>nhid_event_store.py</code>), so your badge
-        renders live CAS data instead of the unknown/grey default.
-      </p>
-      <div style="display:flex;gap:1rem;flex-wrap:wrap;margin-bottom:2rem">
-        <a href="https://github.com/NHID-Clinical/NHID-Clinical/blob/main/docs/vendor-trust-questionnaire.md"
-           class="secondary-button" style="display:inline-flex;align-items:center;gap:.4rem">
-          Vendor Trust Questionnaire →
+  <section class="page-section" style="background:var(--mist)">
+    <div class="container">
+      <p class="section-kicker">Platform modules</p>
+      <h2 style="margin-bottom:.35rem">Five modules</h2>
+      <p style="color:var(--body);max-width:60ch">Each addresses a distinct operational problem. They compose, but none of them requires the others to be useful.</p>
+      <div class="module-grid">
+        <a class="module-card" href="/platform/agent-registry.html">
+          <span class="module-num">MODULE 01</span>
+          <h3>Agent Registry</h3>
+          <p>Source of truth for AI agent identity — who the agent is, who owns it, what it may do, and when that authority expires.</p>
+          <span class="arr">Agent Registry &rarr;</span>
         </a>
-        <a href="/developers.html#adapters" class="secondary-button" style="display:inline-flex;align-items:center;gap:.4rem">
-          Adapter Reference →
+        <a class="module-card" href="/platform/trust-gateway.html">
+          <span class="module-num">MODULE 02</span>
+          <h3>Trust Gateway</h3>
+          <p>Runtime enforcement. Identity verification, authorization, disclosure check, scope enforcement, and an audit event — before the healthcare system is reached.</p>
+          <span class="arr">Trust Gateway &rarr;</span>
+        </a>
+        <a class="module-card" href="/platform/evidence-center.html">
+          <span class="module-num">MODULE 03</span>
+          <h3>Evidence Center</h3>
+          <p>Audit-ready evidence generation: compliance reports, evidence packages, event history, and governance exports.</p>
+          <span class="arr">Evidence Center &rarr;</span>
+        </a>
+        <a class="module-card" href="/platform/continuous-conformance.html">
+          <span class="module-num">MODULE 04</span>
+          <h3>Continuous Conformance</h3>
+          <p>Static tests become operational monitoring. When an agent changes, the controls re-run and a regression surfaces before it reaches a call.</p>
+          <span class="arr">Continuous Conformance &rarr;</span>
+        </a>
+        <a class="module-card" href="/platform/enterprise.html">
+          <span class="module-num">MODULE 05</span>
+          <h3>Enterprise Workflow</h3>
+          <p>SSO, role-based access control, approval workflows, integrations, and SIEM export — the operational surface a security team expects.</p>
+          <span class="arr">Enterprise Workflow &rarr;</span>
         </a>
       </div>
     </div>
   </section>
+
+  <section class="page-section">
+    <div class="container">
+      <p class="section-kicker">Open core vs platform</p>
+      <h2 style="margin-bottom:.35rem">What is open, and what is operated</h2>
+      <p style="color:var(--body);max-width:62ch">The left column is free forever under CC BY 4.0. The right column is what you would otherwise build and run yourself.</p>
+      
+      <div class="compare-matrix-wrap">
+        <table class="compare-matrix">
+          <thead>
+            <tr><th scope="col">Capability</th><th scope="col">Open framework</th><th scope="col">TrustLayer</th></tr>
+          </thead>
+          <tbody>
+            <tr><th scope="row">Specification</th><td><span class="yes">&#10003;</span> CC BY 4.0, always free</td><td><span class="yes">&#10003;</span> Same specification</td></tr>
+            <tr><th scope="row">Control logic</th><td><span class="yes">&#10003;</span> Open reference engine</td><td><span class="yes">&#10003;</span> The same deterministic controls</td></tr>
+            <tr><th scope="row">Conformance tests</th><td><span class="yes">&#10003;</span> Run them yourself</td><td><span class="yes">&#10003;</span> Hosted and scheduled</td></tr>
+            <tr><th scope="row">Simulator</th><td><span class="yes">&#10003;</span> Open, no account</td><td><span class="yes">&#10003;</span> Plus evaluation against your own agents</td></tr>
+            <tr><th scope="row">Documentation</th><td><span class="yes">&#10003;</span> Public</td><td><span class="yes">&#10003;</span> Public</td></tr>
+            <tr><th scope="row">Reference implementation</th><td><span class="yes">&#10003;</span> Fork it, vendor it, replace it</td><td><span class="yes">&#10003;</span> Managed and operated</td></tr>
+            <tr><th scope="row">Community</th><td><span class="yes">&#10003;</span> Issues, discussions, PRs</td><td><span class="yes">&#10003;</span> Same community</td></tr>
+            <tr><th scope="row">Continuous monitoring</th><td><span class="no">&mdash;</span> Run it yourself</td><td><span class="yes">&#10003;</span> Hosted, on every agent change</td></tr>
+            <tr><th scope="row">Dashboards</th><td><span class="no">&mdash;</span></td><td><span class="yes">&#10003;</span> Fleet-wide operational view</td></tr>
+            <tr><th scope="row">Agent registry</th><td><span class="no">&mdash;</span> Passport format only</td><td><span class="yes">&#10003;</span> Managed identity lifecycle</td></tr>
+            <tr><th scope="row">Evidence center</th><td><span class="no">&mdash;</span> Evidence pack template</td><td><span class="yes">&#10003;</span> Generated audit-ready packages</td></tr>
+            <tr><th scope="row">Enterprise integrations</th><td><span class="no">&mdash;</span></td><td><span class="yes">&#10003;</span> SSO, RBAC, SIEM, approvals</td></tr>
+          </tbody>
+        </table>
+      </div>
+      <div class="status-note">
+        <span>&#9432;</span>
+        <span><b>The specification is never paid.</b> No tier, plan, or contract gates the specification, the control catalog, or the conformance test suite. If TrustLayer disappeared tomorrow, every open component would keep working.</span>
+      </div>
+    </div>
+  </section>
+
+  <section class="page-cta">
+    <div class="container">
+      <h2>Two ways in</h2>
+      <p>Start free with the open framework, or talk to us about running agents at scale.</p>
+      <div class="page-cta-grid">
+        <a class="page-cta-card" href="/framework/"><b>Explore the framework <span class="arr">&rarr;</span></b><span>Spec, controls, tests, code — free.</span></a>
+        <a class="page-cta-card" href="/simulator.html"><b>Run a free evaluation <span class="arr">&rarr;</span></b><span>See the controls fire in the simulator.</span></a>
+        <a class="page-cta-card" href="/pricing.html"><b>See plans <span class="arr">&rarr;</span></b><span>Community, Developer, Enterprise.</span></a>
+        <a class="page-cta-card" href="mailto:contact@nhid-clinical.org?subject=TrustLayer%20design%20partner"><b>Become a design partner <span class="arr">&rarr;</span></b><span>Shape what gets built.</span></a>
+      </div>
+      <p class="disclaimer-small" style="margin-top:1.5rem">TrustLayer by NHID-Clinical is in active development. It is not an accredited standard, a certification, or a regulatory compliance guarantee. The open framework it enforces remains free under CC BY 4.0 and is never gated behind a plan.</p>
+    </div>
+  </section>
 </main>
 
-<section class="page-cta">
-  <div class="container">
-    <h2>Where to go next</h2>
-    <p>Four ways into NHID-Clinical, whatever you came to do.</p>
-    <div class="page-cta-grid">
-      <a class="page-cta-card" href="/specification.html"><b>Read the Specification <span class="arr">&rarr;</span></b><span>The v1.3 controls, in full.</span></a>
-      <a class="page-cta-card" href="/simulator.html"><b>Try the Simulator <span class="arr">&rarr;</span></b><span>Run the controls on call scenarios.</span></a>
-      <a class="page-cta-card" href="/evidence-pack.html"><b>Review the Evidence Pack <span class="arr">&rarr;</span></b><span>Guarantees, a failure trace, the audit model.</span></a>
-      <a class="page-cta-card" href="https://github.com/NHID-Clinical/NHID-Clinical/discussions" target="_blank" rel="noopener noreferrer"><b>Join the Community <span class="arr">&#x2197;</span></b><span>Questions and feedback on GitHub.</span></a>
-    </div>
-  </div>
-</section>
 <footer id="contact" class="site-footer">
   <div class="container footer-inner">
     <p>&copy; 2026 Brianna Baynard | NIST-2025-0035-0026 | CC BY 4.0</p>
@@ -231,50 +300,9 @@
       <a href="https://nhid-clinical.org">nhid-clinical.org</a>
     </div>
   </div>
+  <p class="footer-copy" style="margin-top:.4rem">This is an open, actively maintained framework — feedback and contributions welcome. <a href="https://github.com/NHID-Clinical/NHID-Clinical">GitHub</a> · NIST-2025-0035-0026 · CC BY 4.0</p>
 </footer>
 
 <script src="/site.js"></script>
-<script>
-(function () {
-  var listEl = document.getElementById('registry-list');
-  var BADGE_BASE = 'https://gfvq4swdtf.execute-api.us-east-1.amazonaws.com/prod/v1/public/vendor/';
-
-  function escapeHtml(str) {
-    return String(str).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
-  }
-
-  function renderEntries(entries) {
-    if (!entries.length) {
-      listEl.innerHTML = '<p style="color:var(--body)">No implementations are listed yet. ' +
-        'Be the first — see "How to Get Listed" below.</p>';
-      return;
-    }
-    var rows = entries.map(function (e) {
-      var badgeUrl = BADGE_BASE + encodeURIComponent(e.vendor_id) + '/badge';
-      return '<tr style="border-bottom:1px solid var(--border)">' +
-        '<td style="padding:.75rem">' + escapeHtml(e.name || e.vendor_id) + '</td>' +
-        '<td style="padding:.75rem">' + (e.website ? '<a href="' + escapeHtml(e.website) + '" target="_blank" rel="noopener noreferrer">' + escapeHtml(e.website) + '</a>' : '—') + '</td>' +
-        '<td style="padding:.75rem">' + escapeHtml(e.integration_type || '—') + '</td>' +
-        '<td style="padding:.75rem"><img src="' + badgeUrl + '" alt="NHID-CAS badge for ' + escapeHtml(e.vendor_id) + '" /></td>' +
-        '</tr>';
-    }).join('');
-    listEl.innerHTML = '<table style="width:100%;border-collapse:collapse">' +
-      '<thead><tr style="border-bottom:2px solid var(--border);text-align:left">' +
-      '<th style="padding:.75rem">Implementation</th>' +
-      '<th style="padding:.75rem">Website</th>' +
-      '<th style="padding:.75rem">Integration</th>' +
-      '<th style="padding:.75rem">NHID-CAS</th>' +
-      '</tr></thead><tbody>' + rows + '</tbody></table>';
-  }
-
-  fetch('/content/registry_entries.json')
-    .then(function (r) { return r.json(); })
-    .then(renderEntries)
-    .catch(function () {
-      listEl.innerHTML = '<p style="color:var(--body)">No implementations are listed yet. ' +
-        'Be the first — see "How to Get Listed" below.</p>';
-    });
-})();
-</script>
 </body>
 </html>

--- a/platform/trust-gateway.html
+++ b/platform/trust-gateway.html
@@ -1,16 +1,18 @@
-﻿<!doctype html>
+<!doctype html>
 <html lang="en">
 <head>
   <meta charset="utf-8"/>
   <meta name="viewport" content="width=device-width, initial-scale=1"/>
-  <meta name="description" content="NHID-Clinical Implementation Registry — self-attested vendor implementations with live NHID-CAS badges."/>
-  <title>Implementation Registry | NHID-Clinical</title>
+  <meta name="description" content="The TrustLayer Trust Gateway — runtime enforcement of identity verification, authorization, disclosure, scope, and audit before an AI agent reaches a healthcare system."/>
+  <title>Trust Gateway | TrustLayer by NHID-Clinical</title>
+  <link rel="canonical" href="https://nhid-clinical.org/platform/trust-gateway.html"/>
   <link rel="icon" href="/assets/brand/favicon.svg" type="image/svg+xml"/>
   <link rel="icon" href="/assets/brand-icon.png" type="image/png"/>
   <link rel="preconnect" href="https://fonts.googleapis.com"/>
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
   <link href="https://fonts.googleapis.com/css2?family=Raleway:wght@600;700;800&family=Inter:wght@400;500;600;700;800&family=IBM+Plex+Mono:wght@400;500&display=swap" rel="stylesheet"/>
   <link rel="stylesheet" href="/nhid-clinical-ui.css"/>
+  <link rel="stylesheet" href="/assets/css/premium.css"/>
   <script>try{document.documentElement.setAttribute('data-theme',localStorage.getItem('nhid-theme')||'light')}catch(e){}</script>
   <script defer data-domain="nhid-clinical.org" src="https://plausible.io/js/script.js"></script>
 </head>
@@ -162,66 +164,73 @@
 <div class="nav-backdrop" id="nav-backdrop"></div>
 
 <main>
-  <section class="inner-hero" style="position:relative;overflow:clip">
+
+  <section class="inner-hero">
     <div class="hero-glow" aria-hidden="true"></div>
-    <div class="container" style="position:relative;z-index:1">
-      <div class="crumbs"><a href="/">Home</a><span>/</span><span>Implementation Registry</span></div>
-      <p class="eyebrow">Registry · June 2026</p>
-      <h1 class="reveal">Implementation Registry</h1>
-      <p class="lede reveal">Self-attested NHID-Clinical implementations, with live NHID-CAS conformance badges.</p>
+    <div class="container" style="position:relative;z-index:1;max-width:60rem">
+      <div class="crumbs"><a href="/">Home</a><span>/</span><a href="/platform/">Platform</a><span>/</span><span>Trust Gateway</span></div>
+      <p class="eyebrow">TrustLayer &middot; Module 02</p>
+      <h1>Trust Gateway</h1>
+      <p class="lede">Runtime enforcement. Controls that only run in a test suite describe intentions; controls in the request path describe behavior.</p>
     </div>
   </section>
 
   <section class="page-section">
-    <div class="container" style="max-width:52rem">
-      <div class="callout" role="note" style="margin-bottom:2rem">
-        <strong>This is a self-attestation list, not a certification.</strong> NHID-Clinical does not
-        certify, audit, or warrant any vendor's implementation. A listing means the vendor ran the
-        public conformance test suite (CTS) against their own integration and chose to publish the
-        result. Badge scores update from each vendor's own live <code>/v1/public/vendor/{id}/badge</code>
-        endpoint call — verify independently before relying on them for procurement decisions.
-      </div>
+    <div class="container" style="max-width:60rem">
+      <h2>The verification sequence</h2>
+      <p style="color:var(--body);line-height:1.85;margin-top:.75rem">Every step is a precondition for the next. A failure at any stage stops the call from reaching the healthcare system — and produces an audit event either way.</p>
+      <p style="color:var(--body);line-height:1.8;margin-top:.85rem">TrustLayer runs the same deterministic controls as the <a href="/framework/" style="color:var(--teal-bright);font-weight:600">open framework</a> — this module adds operations around them, not different rules.</p>
+      <ol class="gateway-flow">
+        <li class="gateway-step is-endpoint"><span class="gw-num">&#9679;</span><strong>AI Agent</strong><span>An automated caller initiates contact on behalf of a claimed organization.</span></li>
+        <li class="gateway-step"><span class="gw-num">1</span><strong>Identity verification</strong><span>Is this agent registered, and does its presented credential verify? An unregistered or unverifiable agent goes no further.</span></li>
+        <li class="gateway-step"><span class="gw-num">2</span><strong>Authorization</strong><span>Was this agent delegated authority by the organization it names — and is that delegation still valid, not expired or revoked?</span></li>
+        <li class="gateway-step"><span class="gw-num">3</span><strong>Disclosure check</strong><span>IDG-01 and DBC-01: did the agent disclose itself as automated before any operational exchange, without deceptive human-presence cues?</span></li>
+        <li class="gateway-step"><span class="gw-num">4</span><strong>Scope enforcement</strong><span>PDX-01: is this specific request inside the agent&rsquo;s delegated scope? An eligibility agent does not get to pursue a claims appeal.</span></li>
+        <li class="gateway-step"><span class="gw-num">5</span><strong>Audit event</strong><span>ATR-01: a complete, replayable envelope is written for the decision — including decisions to block.</span></li>
+        <li class="gateway-step is-endpoint"><span class="gw-num">&#9679;</span><strong>Healthcare system</strong><span>Only requests that cleared every preceding step reach the payer or provider system.</span></li>
+      </ol>
 
-      <h2>Listed Implementations</h2>
-      <div id="registry-list" style="margin:1.5rem 0">
-        <p style="color:var(--body)">Loading…</p>
+      <h2 style="margin-top:2.5rem">Design commitments</h2>
+      <div class="content-cards" style="grid-template-columns:repeat(auto-fit,minmax(15rem,1fr));margin-top:1.25rem">
+        <div class="content-card">
+          <h3>Deterministic in the control path</h3>
+          <p>No model calls decide whether a request passes. Same inputs, same verdict — which is what makes a gateway decision defensible after the fact.</p>
+        </div>
+        <div class="content-card">
+          <h3>Blocks are evidence too</h3>
+          <p>A blocked request produces the same quality of audit envelope as an allowed one. Silent drops are how incidents become unreconstructable.</p>
+        </div>
+        <div class="content-card">
+          <h3>Fail closed on the data path</h3>
+          <p>When authorization cannot be established, protected data does not move. Ambiguity resolves toward not disclosing.</p>
+        </div>
+        <div class="content-card">
+          <h3>Same controls as the open engine</h3>
+          <p>The gateway does not introduce private rules. If the open reference engine would fail a call, so does the gateway.</p>
+        </div>
       </div>
+      <div class="status-note">
+        <span>&#9432;</span>
+        <span><b>Development status:</b> TrustLayer is being built with design partners and is not yet generally available. Screens and outputs on this page are illustrative, not live product data.</span>
+      </div>
+    </div>
+  </section>
 
-      <h2 style="margin-top:2.5rem">How to Get Listed</h2>
-      <p style="margin-bottom:1rem">
-        Run the conformance test suite against your integration, then complete the
-        <a href="https://github.com/NHID-Clinical/NHID-Clinical/blob/main/docs/vendor-trust-questionnaire.md">vendor trust questionnaire</a>
-        and open a pull request adding your entry to
-        <a href="https://github.com/NHID-Clinical/NHID-Clinical/blob/main/content/registry_entries.json">content/registry_entries.json</a>.
-        Each entry needs a <code>vendor_id</code> matching the one used when recording conformance results
-        (see <code>record_conformance_result()</code> in <code>nhid_event_store.py</code>), so your badge
-        renders live CAS data instead of the unknown/grey default.
-      </p>
-      <div style="display:flex;gap:1rem;flex-wrap:wrap;margin-bottom:2rem">
-        <a href="https://github.com/NHID-Clinical/NHID-Clinical/blob/main/docs/vendor-trust-questionnaire.md"
-           class="secondary-button" style="display:inline-flex;align-items:center;gap:.4rem">
-          Vendor Trust Questionnaire →
-        </a>
-        <a href="/developers.html#adapters" class="secondary-button" style="display:inline-flex;align-items:center;gap:.4rem">
-          Adapter Reference →
-        </a>
+  <section class="page-cta">
+    <div class="container">
+      <h2>Related</h2>
+      <p>What feeds the gateway, and what it produces.</p>
+      <div class="page-cta-grid">
+        <a class="page-cta-card" href="/platform/agent-registry.html"><b>Agent Registry <span class="arr">&rarr;</span></b><span>The identity the gateway verifies against.</span></a>
+        <a class="page-cta-card" href="/platform/evidence-center.html"><b>Evidence Center <span class="arr">&rarr;</span></b><span>What the audit events become.</span></a>
+        <a class="page-cta-card" href="/framework/controls.html"><b>The controls <span class="arr">&rarr;</span></b><span>Open definitions of each check.</span></a>
+        <a class="page-cta-card" href="/technical-stack.html"><b>Five-layer stack <span class="arr">&rarr;</span></b><span>Where the gateway sits.</span></a>
       </div>
+      <p class="disclaimer-small" style="margin-top:1.5rem">TrustLayer by NHID-Clinical is in active development. It is not an accredited standard, a certification, or a regulatory compliance guarantee. The open framework it enforces remains free under CC BY 4.0 and is never gated behind a plan.</p>
     </div>
   </section>
 </main>
 
-<section class="page-cta">
-  <div class="container">
-    <h2>Where to go next</h2>
-    <p>Four ways into NHID-Clinical, whatever you came to do.</p>
-    <div class="page-cta-grid">
-      <a class="page-cta-card" href="/specification.html"><b>Read the Specification <span class="arr">&rarr;</span></b><span>The v1.3 controls, in full.</span></a>
-      <a class="page-cta-card" href="/simulator.html"><b>Try the Simulator <span class="arr">&rarr;</span></b><span>Run the controls on call scenarios.</span></a>
-      <a class="page-cta-card" href="/evidence-pack.html"><b>Review the Evidence Pack <span class="arr">&rarr;</span></b><span>Guarantees, a failure trace, the audit model.</span></a>
-      <a class="page-cta-card" href="https://github.com/NHID-Clinical/NHID-Clinical/discussions" target="_blank" rel="noopener noreferrer"><b>Join the Community <span class="arr">&#x2197;</span></b><span>Questions and feedback on GitHub.</span></a>
-    </div>
-  </div>
-</section>
 <footer id="contact" class="site-footer">
   <div class="container footer-inner">
     <p>&copy; 2026 Brianna Baynard | NIST-2025-0035-0026 | CC BY 4.0</p>
@@ -231,50 +240,9 @@
       <a href="https://nhid-clinical.org">nhid-clinical.org</a>
     </div>
   </div>
+  <p class="footer-copy" style="margin-top:.4rem">This is an open, actively maintained framework — feedback and contributions welcome. <a href="https://github.com/NHID-Clinical/NHID-Clinical">GitHub</a> · NIST-2025-0035-0026 · CC BY 4.0</p>
 </footer>
 
 <script src="/site.js"></script>
-<script>
-(function () {
-  var listEl = document.getElementById('registry-list');
-  var BADGE_BASE = 'https://gfvq4swdtf.execute-api.us-east-1.amazonaws.com/prod/v1/public/vendor/';
-
-  function escapeHtml(str) {
-    return String(str).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
-  }
-
-  function renderEntries(entries) {
-    if (!entries.length) {
-      listEl.innerHTML = '<p style="color:var(--body)">No implementations are listed yet. ' +
-        'Be the first — see "How to Get Listed" below.</p>';
-      return;
-    }
-    var rows = entries.map(function (e) {
-      var badgeUrl = BADGE_BASE + encodeURIComponent(e.vendor_id) + '/badge';
-      return '<tr style="border-bottom:1px solid var(--border)">' +
-        '<td style="padding:.75rem">' + escapeHtml(e.name || e.vendor_id) + '</td>' +
-        '<td style="padding:.75rem">' + (e.website ? '<a href="' + escapeHtml(e.website) + '" target="_blank" rel="noopener noreferrer">' + escapeHtml(e.website) + '</a>' : '—') + '</td>' +
-        '<td style="padding:.75rem">' + escapeHtml(e.integration_type || '—') + '</td>' +
-        '<td style="padding:.75rem"><img src="' + badgeUrl + '" alt="NHID-CAS badge for ' + escapeHtml(e.vendor_id) + '" /></td>' +
-        '</tr>';
-    }).join('');
-    listEl.innerHTML = '<table style="width:100%;border-collapse:collapse">' +
-      '<thead><tr style="border-bottom:2px solid var(--border);text-align:left">' +
-      '<th style="padding:.75rem">Implementation</th>' +
-      '<th style="padding:.75rem">Website</th>' +
-      '<th style="padding:.75rem">Integration</th>' +
-      '<th style="padding:.75rem">NHID-CAS</th>' +
-      '</tr></thead><tbody>' + rows + '</tbody></table>';
-  }
-
-  fetch('/content/registry_entries.json')
-    .then(function (r) { return r.json(); })
-    .then(renderEntries)
-    .catch(function () {
-      listEl.innerHTML = '<p style="color:var(--body)">No implementations are listed yet. ' +
-        'Be the first — see "How to Get Listed" below.</p>';
-    });
-})();
-</script>
 </body>
 </html>

--- a/privacy.html
+++ b/privacy.html
@@ -30,44 +30,57 @@
       </span>
     </a>
     <div class="nav-links">
-      <a href="/">Home</a>
       <div class="nav-dropdown">
-        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Learn <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
+        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Framework <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
         <div class="nav-dropdown-menu">
+          <a href="/framework/">Framework overview</a>
           <a href="/specification.html">Specification</a>
+          <a href="/framework/controls.html">Controls</a>
+          <a href="/framework/nhid-auth.html">NHID-Auth</a>
+          <a href="/framework/reference-implementation.html">Reference Implementation</a>
+          <a href="/framework/conformance-suite.html">Conformance Test Suite</a>
           <a href="/technical-stack.html">Technical Stack</a>
           <a href="/regulatory-alignment.html">Regulatory Alignment</a>
-          <a href="/about.html">About</a>
         </div>
       </div>
       <div class="nav-dropdown">
-        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Evaluate <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
+        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Platform <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
         <div class="nav-dropdown-menu">
-          <a href="/simulator.html">Simulator</a>
-          <a href="/shadow-evaluation-guide.html">Shadow Evaluation</a>
-          <a href="/evidence-pack.html">Evidence Pack</a>
-          <a href="/for-payers.html">For Payers</a>
+          <a href="/platform/">TrustLayer overview</a>
+          <a href="/platform/agent-registry.html">Agent Registry</a>
+          <a href="/platform/trust-gateway.html">Trust Gateway</a>
+          <a href="/platform/evidence-center.html">Evidence Center</a>
+          <a href="/platform/continuous-conformance.html">Continuous Conformance</a>
+          <a href="/platform/enterprise.html">Enterprise Workflow</a>
         </div>
       </div>
+      <a href="/simulator.html">Simulator</a>
       <div class="nav-dropdown">
-        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Build <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
+        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Docs <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
         <div class="nav-dropdown-menu">
-          <a href="/developers.html">Developers</a>
+          <a href="/developers.html">Developer guide</a>
+          <a href="/docs.html">Live API explorer</a>
           <a href="/interoperability.html">Interoperability</a>
           <a href="/registry.html">Implementation Registry</a>
           <a href="/icon-system.html">Icon System</a>
         </div>
       </div>
       <div class="nav-dropdown">
-        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Community <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
+        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Resources <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
         <div class="nav-dropdown-menu">
-          <a href="/news.html">News</a>
+          <a href="/evidence-pack.html">Evidence Pack</a>
+          <a href="/shadow-evaluation-guide.html">Shadow Evaluation Guide</a>
+          <a href="/for-payers.html">For Payers</a>
+          <a href="/research-portfolio.html">Research Portfolio</a>
           <a href="/roadmap.html">Roadmap</a>
-          <a href="/research-portfolio.html">Portfolio</a>
-          <a href="https://github.com/NHID-Clinical/NHID-Clinical">GitHub &#x2197;</a>
+          <a href="/news.html">News</a>
+          <a href="/faq.html">FAQ</a>
+          <a href="https://ai-governance-map.vercel.app/" target="_blank" rel="noopener noreferrer">AI Governance Map &#x2197;</a>
         </div>
       </div>
-      <a href="https://ai-governance-map.vercel.app/" target="_blank" rel="noopener noreferrer">AI Map &#x2197;</a>
+      <a href="/pricing.html">Pricing</a>
+      <a href="/about.html">About</a>
+      <a href="https://github.com/NHID-Clinical" target="_blank" rel="noopener noreferrer">GitHub &#x2197;</a>
     </div>
     <div class="nav-actions">
       <button class="icon-button search-toggle" type="button" aria-label="Search" id="search-toggle">
@@ -99,27 +112,44 @@
 
 <nav class="mobile-nav" id="mobile-nav" aria-label="Mobile navigation">
   <a href="/">Home</a>
-  <strong class="mobile-nav-group">Learn</strong>
+  <strong class="mobile-nav-group">Framework</strong>
+  <a href="/framework/">Framework overview</a>
   <a href="/specification.html">Specification</a>
+  <a href="/framework/controls.html">Controls</a>
+  <a href="/framework/nhid-auth.html">NHID-Auth</a>
+  <a href="/framework/reference-implementation.html">Reference Implementation</a>
+  <a href="/framework/conformance-suite.html">Conformance Test Suite</a>
   <a href="/technical-stack.html">Technical Stack</a>
   <a href="/regulatory-alignment.html">Regulatory Alignment</a>
-  <a href="/about.html">About</a>
-  <strong class="mobile-nav-group">Evaluate</strong>
-  <a href="/simulator.html">Simulator</a>
-  <a href="/shadow-evaluation-guide.html">Shadow Evaluation</a>
-  <a href="/evidence-pack.html">Evidence Pack</a>
-  <a href="/for-payers.html">For Payers</a>
-  <strong class="mobile-nav-group">Build</strong>
-  <a href="/developers.html">Developers</a>
+  <strong class="mobile-nav-group">Platform</strong>
+  <a href="/platform/">TrustLayer overview</a>
+  <a href="/platform/agent-registry.html">Agent Registry</a>
+  <a href="/platform/trust-gateway.html">Trust Gateway</a>
+  <a href="/platform/evidence-center.html">Evidence Center</a>
+  <a href="/platform/continuous-conformance.html">Continuous Conformance</a>
+  <a href="/platform/enterprise.html">Enterprise Workflow</a>
+  <strong class="mobile-nav-group">Simulator</strong>
+  <a href="/simulator.html">Open the simulator</a>
+  <a href="/governance-simulator.html">Governance Simulator</a>
+  <strong class="mobile-nav-group">Docs</strong>
+  <a href="/developers.html">Developer guide</a>
+  <a href="/docs.html">Live API explorer</a>
   <a href="/interoperability.html">Interoperability</a>
   <a href="/registry.html">Implementation Registry</a>
   <a href="/icon-system.html">Icon System</a>
-  <strong class="mobile-nav-group">Community</strong>
-  <a href="/news.html">News</a>
+  <strong class="mobile-nav-group">Resources</strong>
+  <a href="/evidence-pack.html">Evidence Pack</a>
+  <a href="/shadow-evaluation-guide.html">Shadow Evaluation Guide</a>
+  <a href="/for-payers.html">For Payers</a>
+  <a href="/research-portfolio.html">Research Portfolio</a>
   <a href="/roadmap.html">Roadmap</a>
-  <a href="/research-portfolio.html">Portfolio</a>
-  <a href="https://github.com/NHID-Clinical/NHID-Clinical" target="_blank" rel="noopener noreferrer">GitHub &#x2197;</a>
-  <a href="https://ai-governance-map.vercel.app/" target="_blank" rel="noopener noreferrer">AI Map &#x2197;</a>
+  <a href="/news.html">News</a>
+  <a href="/faq.html">FAQ</a>
+  <a href="https://ai-governance-map.vercel.app/" target="_blank" rel="noopener noreferrer">AI Governance Map &#x2197;</a>
+  <strong class="mobile-nav-group">More</strong>
+  <a href="/pricing.html">Pricing</a>
+  <a href="/about.html">About</a>
+  <a href="https://github.com/NHID-Clinical" target="_blank" rel="noopener noreferrer">GitHub &#x2197;</a>
   <div class="mobile-nav-footer">
     <button class="theme-toggle mobile-theme-toggle" type="button" aria-label="Toggle dark mode">
       <svg class="sun-icon" viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M6.34 17.66l-1.41 1.41M19.07 4.93l-1.41 1.41"/></svg>

--- a/proof.html
+++ b/proof.html
@@ -31,44 +31,57 @@
       </span>
     </a>
     <div class="nav-links">
-      <a href="/">Home</a>
       <div class="nav-dropdown">
-        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Learn <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
+        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Framework <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
         <div class="nav-dropdown-menu">
+          <a href="/framework/">Framework overview</a>
           <a href="/specification.html">Specification</a>
+          <a href="/framework/controls.html">Controls</a>
+          <a href="/framework/nhid-auth.html">NHID-Auth</a>
+          <a href="/framework/reference-implementation.html">Reference Implementation</a>
+          <a href="/framework/conformance-suite.html">Conformance Test Suite</a>
           <a href="/technical-stack.html">Technical Stack</a>
           <a href="/regulatory-alignment.html">Regulatory Alignment</a>
-          <a href="/about.html">About</a>
         </div>
       </div>
       <div class="nav-dropdown">
-        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Evaluate <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
+        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Platform <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
         <div class="nav-dropdown-menu">
-          <a href="/simulator.html">Simulator</a>
-          <a href="/shadow-evaluation-guide.html">Shadow Evaluation</a>
-          <a href="/evidence-pack.html">Evidence Pack</a>
-          <a href="/for-payers.html">For Payers</a>
+          <a href="/platform/">TrustLayer overview</a>
+          <a href="/platform/agent-registry.html">Agent Registry</a>
+          <a href="/platform/trust-gateway.html">Trust Gateway</a>
+          <a href="/platform/evidence-center.html">Evidence Center</a>
+          <a href="/platform/continuous-conformance.html">Continuous Conformance</a>
+          <a href="/platform/enterprise.html">Enterprise Workflow</a>
         </div>
       </div>
+      <a href="/simulator.html">Simulator</a>
       <div class="nav-dropdown">
-        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Build <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
+        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Docs <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
         <div class="nav-dropdown-menu">
-          <a href="/developers.html">Developers</a>
+          <a href="/developers.html">Developer guide</a>
+          <a href="/docs.html">Live API explorer</a>
           <a href="/interoperability.html">Interoperability</a>
           <a href="/registry.html">Implementation Registry</a>
           <a href="/icon-system.html">Icon System</a>
         </div>
       </div>
       <div class="nav-dropdown">
-        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Community <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
+        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Resources <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
         <div class="nav-dropdown-menu">
-          <a href="/news.html">News</a>
+          <a href="/evidence-pack.html">Evidence Pack</a>
+          <a href="/shadow-evaluation-guide.html">Shadow Evaluation Guide</a>
+          <a href="/for-payers.html">For Payers</a>
+          <a href="/research-portfolio.html">Research Portfolio</a>
           <a href="/roadmap.html">Roadmap</a>
-          <a href="/research-portfolio.html">Portfolio</a>
-          <a href="https://github.com/NHID-Clinical/NHID-Clinical">GitHub &#x2197;</a>
+          <a href="/news.html">News</a>
+          <a href="/faq.html">FAQ</a>
+          <a href="https://ai-governance-map.vercel.app/" target="_blank" rel="noopener noreferrer">AI Governance Map &#x2197;</a>
         </div>
       </div>
-      <a href="https://ai-governance-map.vercel.app/" target="_blank" rel="noopener noreferrer">AI Map &#x2197;</a>
+      <a href="/pricing.html">Pricing</a>
+      <a href="/about.html">About</a>
+      <a href="https://github.com/NHID-Clinical" target="_blank" rel="noopener noreferrer">GitHub &#x2197;</a>
     </div>
     <div class="nav-actions">
       <button class="icon-button search-toggle" type="button" aria-label="Search" id="search-toggle">
@@ -100,27 +113,44 @@
 
 <nav class="mobile-nav" id="mobile-nav" aria-label="Mobile navigation">
   <a href="/">Home</a>
-  <strong class="mobile-nav-group">Learn</strong>
+  <strong class="mobile-nav-group">Framework</strong>
+  <a href="/framework/">Framework overview</a>
   <a href="/specification.html">Specification</a>
+  <a href="/framework/controls.html">Controls</a>
+  <a href="/framework/nhid-auth.html">NHID-Auth</a>
+  <a href="/framework/reference-implementation.html">Reference Implementation</a>
+  <a href="/framework/conformance-suite.html">Conformance Test Suite</a>
   <a href="/technical-stack.html">Technical Stack</a>
   <a href="/regulatory-alignment.html">Regulatory Alignment</a>
-  <a href="/about.html">About</a>
-  <strong class="mobile-nav-group">Evaluate</strong>
-  <a href="/simulator.html">Simulator</a>
-  <a href="/shadow-evaluation-guide.html">Shadow Evaluation</a>
-  <a href="/evidence-pack.html">Evidence Pack</a>
-  <a href="/for-payers.html">For Payers</a>
-  <strong class="mobile-nav-group">Build</strong>
-  <a href="/developers.html">Developers</a>
+  <strong class="mobile-nav-group">Platform</strong>
+  <a href="/platform/">TrustLayer overview</a>
+  <a href="/platform/agent-registry.html">Agent Registry</a>
+  <a href="/platform/trust-gateway.html">Trust Gateway</a>
+  <a href="/platform/evidence-center.html">Evidence Center</a>
+  <a href="/platform/continuous-conformance.html">Continuous Conformance</a>
+  <a href="/platform/enterprise.html">Enterprise Workflow</a>
+  <strong class="mobile-nav-group">Simulator</strong>
+  <a href="/simulator.html">Open the simulator</a>
+  <a href="/governance-simulator.html">Governance Simulator</a>
+  <strong class="mobile-nav-group">Docs</strong>
+  <a href="/developers.html">Developer guide</a>
+  <a href="/docs.html">Live API explorer</a>
   <a href="/interoperability.html">Interoperability</a>
   <a href="/registry.html">Implementation Registry</a>
   <a href="/icon-system.html">Icon System</a>
-  <strong class="mobile-nav-group">Community</strong>
-  <a href="/news.html">News</a>
+  <strong class="mobile-nav-group">Resources</strong>
+  <a href="/evidence-pack.html">Evidence Pack</a>
+  <a href="/shadow-evaluation-guide.html">Shadow Evaluation Guide</a>
+  <a href="/for-payers.html">For Payers</a>
+  <a href="/research-portfolio.html">Research Portfolio</a>
   <a href="/roadmap.html">Roadmap</a>
-  <a href="/research-portfolio.html">Portfolio</a>
-  <a href="https://github.com/NHID-Clinical/NHID-Clinical" target="_blank" rel="noopener noreferrer">GitHub &#x2197;</a>
-  <a href="https://ai-governance-map.vercel.app/" target="_blank" rel="noopener noreferrer">AI Map &#x2197;</a>
+  <a href="/news.html">News</a>
+  <a href="/faq.html">FAQ</a>
+  <a href="https://ai-governance-map.vercel.app/" target="_blank" rel="noopener noreferrer">AI Governance Map &#x2197;</a>
+  <strong class="mobile-nav-group">More</strong>
+  <a href="/pricing.html">Pricing</a>
+  <a href="/about.html">About</a>
+  <a href="https://github.com/NHID-Clinical" target="_blank" rel="noopener noreferrer">GitHub &#x2197;</a>
   <div class="mobile-nav-footer">
     <button class="theme-toggle mobile-theme-toggle" type="button" aria-label="Toggle dark mode">
       <svg class="sun-icon" viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M6.34 17.66l-1.41 1.41M19.07 4.93l-1.41 1.41"/></svg>

--- a/regulatory-alignment.html
+++ b/regulatory-alignment.html
@@ -31,44 +31,57 @@
       </span>
     </a>
     <div class="nav-links">
-      <a href="/">Home</a>
       <div class="nav-dropdown">
-        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Learn <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
+        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Framework <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
         <div class="nav-dropdown-menu">
+          <a href="/framework/">Framework overview</a>
           <a href="/specification.html">Specification</a>
+          <a href="/framework/controls.html">Controls</a>
+          <a href="/framework/nhid-auth.html">NHID-Auth</a>
+          <a href="/framework/reference-implementation.html">Reference Implementation</a>
+          <a href="/framework/conformance-suite.html">Conformance Test Suite</a>
           <a href="/technical-stack.html">Technical Stack</a>
           <a href="/regulatory-alignment.html">Regulatory Alignment</a>
-          <a href="/about.html">About</a>
         </div>
       </div>
       <div class="nav-dropdown">
-        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Evaluate <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
+        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Platform <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
         <div class="nav-dropdown-menu">
-          <a href="/simulator.html">Simulator</a>
-          <a href="/shadow-evaluation-guide.html">Shadow Evaluation</a>
-          <a href="/evidence-pack.html">Evidence Pack</a>
-          <a href="/for-payers.html">For Payers</a>
+          <a href="/platform/">TrustLayer overview</a>
+          <a href="/platform/agent-registry.html">Agent Registry</a>
+          <a href="/platform/trust-gateway.html">Trust Gateway</a>
+          <a href="/platform/evidence-center.html">Evidence Center</a>
+          <a href="/platform/continuous-conformance.html">Continuous Conformance</a>
+          <a href="/platform/enterprise.html">Enterprise Workflow</a>
         </div>
       </div>
+      <a href="/simulator.html">Simulator</a>
       <div class="nav-dropdown">
-        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Build <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
+        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Docs <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
         <div class="nav-dropdown-menu">
-          <a href="/developers.html">Developers</a>
+          <a href="/developers.html">Developer guide</a>
+          <a href="/docs.html">Live API explorer</a>
           <a href="/interoperability.html">Interoperability</a>
           <a href="/registry.html">Implementation Registry</a>
           <a href="/icon-system.html">Icon System</a>
         </div>
       </div>
       <div class="nav-dropdown">
-        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Community <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
+        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Resources <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
         <div class="nav-dropdown-menu">
-          <a href="/news.html">News</a>
+          <a href="/evidence-pack.html">Evidence Pack</a>
+          <a href="/shadow-evaluation-guide.html">Shadow Evaluation Guide</a>
+          <a href="/for-payers.html">For Payers</a>
+          <a href="/research-portfolio.html">Research Portfolio</a>
           <a href="/roadmap.html">Roadmap</a>
-          <a href="/research-portfolio.html">Portfolio</a>
-          <a href="https://github.com/NHID-Clinical/NHID-Clinical">GitHub &#x2197;</a>
+          <a href="/news.html">News</a>
+          <a href="/faq.html">FAQ</a>
+          <a href="https://ai-governance-map.vercel.app/" target="_blank" rel="noopener noreferrer">AI Governance Map &#x2197;</a>
         </div>
       </div>
-      <a href="https://ai-governance-map.vercel.app/" target="_blank" rel="noopener noreferrer">AI Map &#x2197;</a>
+      <a href="/pricing.html">Pricing</a>
+      <a href="/about.html">About</a>
+      <a href="https://github.com/NHID-Clinical" target="_blank" rel="noopener noreferrer">GitHub &#x2197;</a>
     </div>
     <div class="nav-actions">
       <button class="icon-button search-toggle" type="button" aria-label="Search" id="search-toggle">
@@ -100,27 +113,44 @@
 
 <nav class="mobile-nav" id="mobile-nav" aria-label="Mobile navigation">
   <a href="/">Home</a>
-  <strong class="mobile-nav-group">Learn</strong>
+  <strong class="mobile-nav-group">Framework</strong>
+  <a href="/framework/">Framework overview</a>
   <a href="/specification.html">Specification</a>
+  <a href="/framework/controls.html">Controls</a>
+  <a href="/framework/nhid-auth.html">NHID-Auth</a>
+  <a href="/framework/reference-implementation.html">Reference Implementation</a>
+  <a href="/framework/conformance-suite.html">Conformance Test Suite</a>
   <a href="/technical-stack.html">Technical Stack</a>
   <a href="/regulatory-alignment.html">Regulatory Alignment</a>
-  <a href="/about.html">About</a>
-  <strong class="mobile-nav-group">Evaluate</strong>
-  <a href="/simulator.html">Simulator</a>
-  <a href="/shadow-evaluation-guide.html">Shadow Evaluation</a>
-  <a href="/evidence-pack.html">Evidence Pack</a>
-  <a href="/for-payers.html">For Payers</a>
-  <strong class="mobile-nav-group">Build</strong>
-  <a href="/developers.html">Developers</a>
+  <strong class="mobile-nav-group">Platform</strong>
+  <a href="/platform/">TrustLayer overview</a>
+  <a href="/platform/agent-registry.html">Agent Registry</a>
+  <a href="/platform/trust-gateway.html">Trust Gateway</a>
+  <a href="/platform/evidence-center.html">Evidence Center</a>
+  <a href="/platform/continuous-conformance.html">Continuous Conformance</a>
+  <a href="/platform/enterprise.html">Enterprise Workflow</a>
+  <strong class="mobile-nav-group">Simulator</strong>
+  <a href="/simulator.html">Open the simulator</a>
+  <a href="/governance-simulator.html">Governance Simulator</a>
+  <strong class="mobile-nav-group">Docs</strong>
+  <a href="/developers.html">Developer guide</a>
+  <a href="/docs.html">Live API explorer</a>
   <a href="/interoperability.html">Interoperability</a>
   <a href="/registry.html">Implementation Registry</a>
   <a href="/icon-system.html">Icon System</a>
-  <strong class="mobile-nav-group">Community</strong>
-  <a href="/news.html">News</a>
+  <strong class="mobile-nav-group">Resources</strong>
+  <a href="/evidence-pack.html">Evidence Pack</a>
+  <a href="/shadow-evaluation-guide.html">Shadow Evaluation Guide</a>
+  <a href="/for-payers.html">For Payers</a>
+  <a href="/research-portfolio.html">Research Portfolio</a>
   <a href="/roadmap.html">Roadmap</a>
-  <a href="/research-portfolio.html">Portfolio</a>
-  <a href="https://github.com/NHID-Clinical/NHID-Clinical" target="_blank" rel="noopener noreferrer">GitHub &#x2197;</a>
-  <a href="https://ai-governance-map.vercel.app/" target="_blank" rel="noopener noreferrer">AI Map &#x2197;</a>
+  <a href="/news.html">News</a>
+  <a href="/faq.html">FAQ</a>
+  <a href="https://ai-governance-map.vercel.app/" target="_blank" rel="noopener noreferrer">AI Governance Map &#x2197;</a>
+  <strong class="mobile-nav-group">More</strong>
+  <a href="/pricing.html">Pricing</a>
+  <a href="/about.html">About</a>
+  <a href="https://github.com/NHID-Clinical" target="_blank" rel="noopener noreferrer">GitHub &#x2197;</a>
   <div class="mobile-nav-footer">
     <button class="theme-toggle mobile-theme-toggle" type="button" aria-label="Toggle dark mode">
       <svg class="sun-icon" viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M6.34 17.66l-1.41 1.41M19.07 4.93l-1.41 1.41"/></svg>

--- a/research-portfolio.html
+++ b/research-portfolio.html
@@ -31,44 +31,57 @@
       </span>
     </a>
     <div class="nav-links">
-      <a href="/">Home</a>
       <div class="nav-dropdown">
-        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Learn <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
+        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Framework <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
         <div class="nav-dropdown-menu">
+          <a href="/framework/">Framework overview</a>
           <a href="/specification.html">Specification</a>
+          <a href="/framework/controls.html">Controls</a>
+          <a href="/framework/nhid-auth.html">NHID-Auth</a>
+          <a href="/framework/reference-implementation.html">Reference Implementation</a>
+          <a href="/framework/conformance-suite.html">Conformance Test Suite</a>
           <a href="/technical-stack.html">Technical Stack</a>
           <a href="/regulatory-alignment.html">Regulatory Alignment</a>
-          <a href="/about.html">About</a>
         </div>
       </div>
       <div class="nav-dropdown">
-        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Evaluate <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
+        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Platform <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
         <div class="nav-dropdown-menu">
-          <a href="/simulator.html">Simulator</a>
-          <a href="/shadow-evaluation-guide.html">Shadow Evaluation</a>
-          <a href="/evidence-pack.html">Evidence Pack</a>
-          <a href="/for-payers.html">For Payers</a>
+          <a href="/platform/">TrustLayer overview</a>
+          <a href="/platform/agent-registry.html">Agent Registry</a>
+          <a href="/platform/trust-gateway.html">Trust Gateway</a>
+          <a href="/platform/evidence-center.html">Evidence Center</a>
+          <a href="/platform/continuous-conformance.html">Continuous Conformance</a>
+          <a href="/platform/enterprise.html">Enterprise Workflow</a>
         </div>
       </div>
+      <a href="/simulator.html">Simulator</a>
       <div class="nav-dropdown">
-        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Build <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
+        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Docs <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
         <div class="nav-dropdown-menu">
-          <a href="/developers.html">Developers</a>
+          <a href="/developers.html">Developer guide</a>
+          <a href="/docs.html">Live API explorer</a>
           <a href="/interoperability.html">Interoperability</a>
           <a href="/registry.html">Implementation Registry</a>
           <a href="/icon-system.html">Icon System</a>
         </div>
       </div>
       <div class="nav-dropdown">
-        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Community <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
+        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Resources <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
         <div class="nav-dropdown-menu">
-          <a href="/news.html">News</a>
+          <a href="/evidence-pack.html">Evidence Pack</a>
+          <a href="/shadow-evaluation-guide.html">Shadow Evaluation Guide</a>
+          <a href="/for-payers.html">For Payers</a>
+          <a href="/research-portfolio.html">Research Portfolio</a>
           <a href="/roadmap.html">Roadmap</a>
-          <a href="/research-portfolio.html">Portfolio</a>
-          <a href="https://github.com/NHID-Clinical/NHID-Clinical">GitHub &#x2197;</a>
+          <a href="/news.html">News</a>
+          <a href="/faq.html">FAQ</a>
+          <a href="https://ai-governance-map.vercel.app/" target="_blank" rel="noopener noreferrer">AI Governance Map &#x2197;</a>
         </div>
       </div>
-      <a href="https://ai-governance-map.vercel.app/" target="_blank" rel="noopener noreferrer">AI Map &#x2197;</a>
+      <a href="/pricing.html">Pricing</a>
+      <a href="/about.html">About</a>
+      <a href="https://github.com/NHID-Clinical" target="_blank" rel="noopener noreferrer">GitHub &#x2197;</a>
     </div>
     <div class="nav-actions">
       <button class="icon-button search-toggle" type="button" aria-label="Search" id="search-toggle">
@@ -100,27 +113,44 @@
 
 <nav class="mobile-nav" id="mobile-nav" aria-label="Mobile navigation">
   <a href="/">Home</a>
-  <strong class="mobile-nav-group">Learn</strong>
+  <strong class="mobile-nav-group">Framework</strong>
+  <a href="/framework/">Framework overview</a>
   <a href="/specification.html">Specification</a>
+  <a href="/framework/controls.html">Controls</a>
+  <a href="/framework/nhid-auth.html">NHID-Auth</a>
+  <a href="/framework/reference-implementation.html">Reference Implementation</a>
+  <a href="/framework/conformance-suite.html">Conformance Test Suite</a>
   <a href="/technical-stack.html">Technical Stack</a>
   <a href="/regulatory-alignment.html">Regulatory Alignment</a>
-  <a href="/about.html">About</a>
-  <strong class="mobile-nav-group">Evaluate</strong>
-  <a href="/simulator.html">Simulator</a>
-  <a href="/shadow-evaluation-guide.html">Shadow Evaluation</a>
-  <a href="/evidence-pack.html">Evidence Pack</a>
-  <a href="/for-payers.html">For Payers</a>
-  <strong class="mobile-nav-group">Build</strong>
-  <a href="/developers.html">Developers</a>
+  <strong class="mobile-nav-group">Platform</strong>
+  <a href="/platform/">TrustLayer overview</a>
+  <a href="/platform/agent-registry.html">Agent Registry</a>
+  <a href="/platform/trust-gateway.html">Trust Gateway</a>
+  <a href="/platform/evidence-center.html">Evidence Center</a>
+  <a href="/platform/continuous-conformance.html">Continuous Conformance</a>
+  <a href="/platform/enterprise.html">Enterprise Workflow</a>
+  <strong class="mobile-nav-group">Simulator</strong>
+  <a href="/simulator.html">Open the simulator</a>
+  <a href="/governance-simulator.html">Governance Simulator</a>
+  <strong class="mobile-nav-group">Docs</strong>
+  <a href="/developers.html">Developer guide</a>
+  <a href="/docs.html">Live API explorer</a>
   <a href="/interoperability.html">Interoperability</a>
   <a href="/registry.html">Implementation Registry</a>
   <a href="/icon-system.html">Icon System</a>
-  <strong class="mobile-nav-group">Community</strong>
-  <a href="/news.html">News</a>
+  <strong class="mobile-nav-group">Resources</strong>
+  <a href="/evidence-pack.html">Evidence Pack</a>
+  <a href="/shadow-evaluation-guide.html">Shadow Evaluation Guide</a>
+  <a href="/for-payers.html">For Payers</a>
+  <a href="/research-portfolio.html">Research Portfolio</a>
   <a href="/roadmap.html">Roadmap</a>
-  <a href="/research-portfolio.html">Portfolio</a>
-  <a href="https://github.com/NHID-Clinical/NHID-Clinical" target="_blank" rel="noopener noreferrer">GitHub &#x2197;</a>
-  <a href="https://ai-governance-map.vercel.app/" target="_blank" rel="noopener noreferrer">AI Map &#x2197;</a>
+  <a href="/news.html">News</a>
+  <a href="/faq.html">FAQ</a>
+  <a href="https://ai-governance-map.vercel.app/" target="_blank" rel="noopener noreferrer">AI Governance Map &#x2197;</a>
+  <strong class="mobile-nav-group">More</strong>
+  <a href="/pricing.html">Pricing</a>
+  <a href="/about.html">About</a>
+  <a href="https://github.com/NHID-Clinical" target="_blank" rel="noopener noreferrer">GitHub &#x2197;</a>
   <div class="mobile-nav-footer">
     <button class="theme-toggle mobile-theme-toggle" type="button" aria-label="Toggle dark mode">
       <svg class="sun-icon" viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M6.34 17.66l-1.41 1.41M19.07 4.93l-1.41 1.41"/></svg>

--- a/roadmap.html
+++ b/roadmap.html
@@ -31,44 +31,57 @@
       </span>
     </a>
     <div class="nav-links">
-      <a href="/">Home</a>
       <div class="nav-dropdown">
-        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Learn <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
+        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Framework <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
         <div class="nav-dropdown-menu">
+          <a href="/framework/">Framework overview</a>
           <a href="/specification.html">Specification</a>
+          <a href="/framework/controls.html">Controls</a>
+          <a href="/framework/nhid-auth.html">NHID-Auth</a>
+          <a href="/framework/reference-implementation.html">Reference Implementation</a>
+          <a href="/framework/conformance-suite.html">Conformance Test Suite</a>
           <a href="/technical-stack.html">Technical Stack</a>
           <a href="/regulatory-alignment.html">Regulatory Alignment</a>
-          <a href="/about.html">About</a>
         </div>
       </div>
       <div class="nav-dropdown">
-        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Evaluate <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
+        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Platform <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
         <div class="nav-dropdown-menu">
-          <a href="/simulator.html">Simulator</a>
-          <a href="/shadow-evaluation-guide.html">Shadow Evaluation</a>
-          <a href="/evidence-pack.html">Evidence Pack</a>
-          <a href="/for-payers.html">For Payers</a>
+          <a href="/platform/">TrustLayer overview</a>
+          <a href="/platform/agent-registry.html">Agent Registry</a>
+          <a href="/platform/trust-gateway.html">Trust Gateway</a>
+          <a href="/platform/evidence-center.html">Evidence Center</a>
+          <a href="/platform/continuous-conformance.html">Continuous Conformance</a>
+          <a href="/platform/enterprise.html">Enterprise Workflow</a>
         </div>
       </div>
+      <a href="/simulator.html">Simulator</a>
       <div class="nav-dropdown">
-        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Build <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
+        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Docs <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
         <div class="nav-dropdown-menu">
-          <a href="/developers.html">Developers</a>
+          <a href="/developers.html">Developer guide</a>
+          <a href="/docs.html">Live API explorer</a>
           <a href="/interoperability.html">Interoperability</a>
           <a href="/registry.html">Implementation Registry</a>
           <a href="/icon-system.html">Icon System</a>
         </div>
       </div>
       <div class="nav-dropdown">
-        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Community <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
+        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Resources <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
         <div class="nav-dropdown-menu">
-          <a href="/news.html">News</a>
+          <a href="/evidence-pack.html">Evidence Pack</a>
+          <a href="/shadow-evaluation-guide.html">Shadow Evaluation Guide</a>
+          <a href="/for-payers.html">For Payers</a>
+          <a href="/research-portfolio.html">Research Portfolio</a>
           <a href="/roadmap.html">Roadmap</a>
-          <a href="/research-portfolio.html">Portfolio</a>
-          <a href="https://github.com/NHID-Clinical/NHID-Clinical">GitHub &#x2197;</a>
+          <a href="/news.html">News</a>
+          <a href="/faq.html">FAQ</a>
+          <a href="https://ai-governance-map.vercel.app/" target="_blank" rel="noopener noreferrer">AI Governance Map &#x2197;</a>
         </div>
       </div>
-      <a href="https://ai-governance-map.vercel.app/" target="_blank" rel="noopener noreferrer">AI Map &#x2197;</a>
+      <a href="/pricing.html">Pricing</a>
+      <a href="/about.html">About</a>
+      <a href="https://github.com/NHID-Clinical" target="_blank" rel="noopener noreferrer">GitHub &#x2197;</a>
     </div>
     <div class="nav-actions">
       <button class="icon-button search-toggle" type="button" aria-label="Search" id="search-toggle">
@@ -100,27 +113,44 @@
 
 <nav class="mobile-nav" id="mobile-nav" aria-label="Mobile navigation">
   <a href="/">Home</a>
-  <strong class="mobile-nav-group">Learn</strong>
+  <strong class="mobile-nav-group">Framework</strong>
+  <a href="/framework/">Framework overview</a>
   <a href="/specification.html">Specification</a>
+  <a href="/framework/controls.html">Controls</a>
+  <a href="/framework/nhid-auth.html">NHID-Auth</a>
+  <a href="/framework/reference-implementation.html">Reference Implementation</a>
+  <a href="/framework/conformance-suite.html">Conformance Test Suite</a>
   <a href="/technical-stack.html">Technical Stack</a>
   <a href="/regulatory-alignment.html">Regulatory Alignment</a>
-  <a href="/about.html">About</a>
-  <strong class="mobile-nav-group">Evaluate</strong>
-  <a href="/simulator.html">Simulator</a>
-  <a href="/shadow-evaluation-guide.html">Shadow Evaluation</a>
-  <a href="/evidence-pack.html">Evidence Pack</a>
-  <a href="/for-payers.html">For Payers</a>
-  <strong class="mobile-nav-group">Build</strong>
-  <a href="/developers.html">Developers</a>
+  <strong class="mobile-nav-group">Platform</strong>
+  <a href="/platform/">TrustLayer overview</a>
+  <a href="/platform/agent-registry.html">Agent Registry</a>
+  <a href="/platform/trust-gateway.html">Trust Gateway</a>
+  <a href="/platform/evidence-center.html">Evidence Center</a>
+  <a href="/platform/continuous-conformance.html">Continuous Conformance</a>
+  <a href="/platform/enterprise.html">Enterprise Workflow</a>
+  <strong class="mobile-nav-group">Simulator</strong>
+  <a href="/simulator.html">Open the simulator</a>
+  <a href="/governance-simulator.html">Governance Simulator</a>
+  <strong class="mobile-nav-group">Docs</strong>
+  <a href="/developers.html">Developer guide</a>
+  <a href="/docs.html">Live API explorer</a>
   <a href="/interoperability.html">Interoperability</a>
   <a href="/registry.html">Implementation Registry</a>
   <a href="/icon-system.html">Icon System</a>
-  <strong class="mobile-nav-group">Community</strong>
-  <a href="/news.html">News</a>
+  <strong class="mobile-nav-group">Resources</strong>
+  <a href="/evidence-pack.html">Evidence Pack</a>
+  <a href="/shadow-evaluation-guide.html">Shadow Evaluation Guide</a>
+  <a href="/for-payers.html">For Payers</a>
+  <a href="/research-portfolio.html">Research Portfolio</a>
   <a href="/roadmap.html">Roadmap</a>
-  <a href="/research-portfolio.html">Portfolio</a>
-  <a href="https://github.com/NHID-Clinical/NHID-Clinical" target="_blank" rel="noopener noreferrer">GitHub &#x2197;</a>
-  <a href="https://ai-governance-map.vercel.app/" target="_blank" rel="noopener noreferrer">AI Map &#x2197;</a>
+  <a href="/news.html">News</a>
+  <a href="/faq.html">FAQ</a>
+  <a href="https://ai-governance-map.vercel.app/" target="_blank" rel="noopener noreferrer">AI Governance Map &#x2197;</a>
+  <strong class="mobile-nav-group">More</strong>
+  <a href="/pricing.html">Pricing</a>
+  <a href="/about.html">About</a>
+  <a href="https://github.com/NHID-Clinical" target="_blank" rel="noopener noreferrer">GitHub &#x2197;</a>
   <div class="mobile-nav-footer">
     <button class="theme-toggle mobile-theme-toggle" type="button" aria-label="Toggle dark mode">
       <svg class="sun-icon" viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M6.34 17.66l-1.41 1.41M19.07 4.93l-1.41 1.41"/></svg>

--- a/script-examples.html
+++ b/script-examples.html
@@ -31,44 +31,57 @@
       </span>
     </a>
     <div class="nav-links">
-      <a href="/">Home</a>
       <div class="nav-dropdown">
-        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Learn <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
+        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Framework <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
         <div class="nav-dropdown-menu">
+          <a href="/framework/">Framework overview</a>
           <a href="/specification.html">Specification</a>
+          <a href="/framework/controls.html">Controls</a>
+          <a href="/framework/nhid-auth.html">NHID-Auth</a>
+          <a href="/framework/reference-implementation.html">Reference Implementation</a>
+          <a href="/framework/conformance-suite.html">Conformance Test Suite</a>
           <a href="/technical-stack.html">Technical Stack</a>
           <a href="/regulatory-alignment.html">Regulatory Alignment</a>
-          <a href="/about.html">About</a>
         </div>
       </div>
       <div class="nav-dropdown">
-        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Evaluate <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
+        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Platform <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
         <div class="nav-dropdown-menu">
-          <a href="/simulator.html">Simulator</a>
-          <a href="/shadow-evaluation-guide.html">Shadow Evaluation</a>
-          <a href="/evidence-pack.html">Evidence Pack</a>
-          <a href="/for-payers.html">For Payers</a>
+          <a href="/platform/">TrustLayer overview</a>
+          <a href="/platform/agent-registry.html">Agent Registry</a>
+          <a href="/platform/trust-gateway.html">Trust Gateway</a>
+          <a href="/platform/evidence-center.html">Evidence Center</a>
+          <a href="/platform/continuous-conformance.html">Continuous Conformance</a>
+          <a href="/platform/enterprise.html">Enterprise Workflow</a>
         </div>
       </div>
+      <a href="/simulator.html">Simulator</a>
       <div class="nav-dropdown">
-        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Build <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
+        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Docs <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
         <div class="nav-dropdown-menu">
-          <a href="/developers.html">Developers</a>
+          <a href="/developers.html">Developer guide</a>
+          <a href="/docs.html">Live API explorer</a>
           <a href="/interoperability.html">Interoperability</a>
           <a href="/registry.html">Implementation Registry</a>
           <a href="/icon-system.html">Icon System</a>
         </div>
       </div>
       <div class="nav-dropdown">
-        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Community <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
+        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Resources <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
         <div class="nav-dropdown-menu">
-          <a href="/news.html">News</a>
+          <a href="/evidence-pack.html">Evidence Pack</a>
+          <a href="/shadow-evaluation-guide.html">Shadow Evaluation Guide</a>
+          <a href="/for-payers.html">For Payers</a>
+          <a href="/research-portfolio.html">Research Portfolio</a>
           <a href="/roadmap.html">Roadmap</a>
-          <a href="/research-portfolio.html">Portfolio</a>
-          <a href="https://github.com/NHID-Clinical/NHID-Clinical">GitHub &#x2197;</a>
+          <a href="/news.html">News</a>
+          <a href="/faq.html">FAQ</a>
+          <a href="https://ai-governance-map.vercel.app/" target="_blank" rel="noopener noreferrer">AI Governance Map &#x2197;</a>
         </div>
       </div>
-      <a href="https://ai-governance-map.vercel.app/" target="_blank" rel="noopener noreferrer">AI Map &#x2197;</a>
+      <a href="/pricing.html">Pricing</a>
+      <a href="/about.html">About</a>
+      <a href="https://github.com/NHID-Clinical" target="_blank" rel="noopener noreferrer">GitHub &#x2197;</a>
     </div>
     <div class="nav-actions">
       <button class="icon-button search-toggle" type="button" aria-label="Search" id="search-toggle">
@@ -100,27 +113,44 @@
 
 <nav class="mobile-nav" id="mobile-nav" aria-label="Mobile navigation">
   <a href="/">Home</a>
-  <strong class="mobile-nav-group">Learn</strong>
+  <strong class="mobile-nav-group">Framework</strong>
+  <a href="/framework/">Framework overview</a>
   <a href="/specification.html">Specification</a>
+  <a href="/framework/controls.html">Controls</a>
+  <a href="/framework/nhid-auth.html">NHID-Auth</a>
+  <a href="/framework/reference-implementation.html">Reference Implementation</a>
+  <a href="/framework/conformance-suite.html">Conformance Test Suite</a>
   <a href="/technical-stack.html">Technical Stack</a>
   <a href="/regulatory-alignment.html">Regulatory Alignment</a>
-  <a href="/about.html">About</a>
-  <strong class="mobile-nav-group">Evaluate</strong>
-  <a href="/simulator.html">Simulator</a>
-  <a href="/shadow-evaluation-guide.html">Shadow Evaluation</a>
-  <a href="/evidence-pack.html">Evidence Pack</a>
-  <a href="/for-payers.html">For Payers</a>
-  <strong class="mobile-nav-group">Build</strong>
-  <a href="/developers.html">Developers</a>
+  <strong class="mobile-nav-group">Platform</strong>
+  <a href="/platform/">TrustLayer overview</a>
+  <a href="/platform/agent-registry.html">Agent Registry</a>
+  <a href="/platform/trust-gateway.html">Trust Gateway</a>
+  <a href="/platform/evidence-center.html">Evidence Center</a>
+  <a href="/platform/continuous-conformance.html">Continuous Conformance</a>
+  <a href="/platform/enterprise.html">Enterprise Workflow</a>
+  <strong class="mobile-nav-group">Simulator</strong>
+  <a href="/simulator.html">Open the simulator</a>
+  <a href="/governance-simulator.html">Governance Simulator</a>
+  <strong class="mobile-nav-group">Docs</strong>
+  <a href="/developers.html">Developer guide</a>
+  <a href="/docs.html">Live API explorer</a>
   <a href="/interoperability.html">Interoperability</a>
   <a href="/registry.html">Implementation Registry</a>
   <a href="/icon-system.html">Icon System</a>
-  <strong class="mobile-nav-group">Community</strong>
-  <a href="/news.html">News</a>
+  <strong class="mobile-nav-group">Resources</strong>
+  <a href="/evidence-pack.html">Evidence Pack</a>
+  <a href="/shadow-evaluation-guide.html">Shadow Evaluation Guide</a>
+  <a href="/for-payers.html">For Payers</a>
+  <a href="/research-portfolio.html">Research Portfolio</a>
   <a href="/roadmap.html">Roadmap</a>
-  <a href="/research-portfolio.html">Portfolio</a>
-  <a href="https://github.com/NHID-Clinical/NHID-Clinical" target="_blank" rel="noopener noreferrer">GitHub &#x2197;</a>
-  <a href="https://ai-governance-map.vercel.app/" target="_blank" rel="noopener noreferrer">AI Map &#x2197;</a>
+  <a href="/news.html">News</a>
+  <a href="/faq.html">FAQ</a>
+  <a href="https://ai-governance-map.vercel.app/" target="_blank" rel="noopener noreferrer">AI Governance Map &#x2197;</a>
+  <strong class="mobile-nav-group">More</strong>
+  <a href="/pricing.html">Pricing</a>
+  <a href="/about.html">About</a>
+  <a href="https://github.com/NHID-Clinical" target="_blank" rel="noopener noreferrer">GitHub &#x2197;</a>
   <div class="mobile-nav-footer">
     <button class="theme-toggle mobile-theme-toggle" type="button" aria-label="Toggle dark mode">
       <svg class="sun-icon" viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M6.34 17.66l-1.41 1.41M19.07 4.93l-1.41 1.41"/></svg>

--- a/scripts/build_pages_site.sh
+++ b/scripts/build_pages_site.sh
@@ -41,6 +41,8 @@ copy_tree "$ROOT/assets" "$OUT/assets" \
 
 copy_tree "$ROOT/alignment" "$OUT/alignment"
 copy_tree "$ROOT/conformance" "$OUT/conformance"
+copy_tree "$ROOT/framework" "$OUT/framework"
+copy_tree "$ROOT/platform" "$OUT/platform"
 copy_tree "$ROOT/simulator" "$OUT/simulator"
 copy_tree "$ROOT/specs" "$OUT/specs"
 

--- a/shadow-evaluation-guide.html
+++ b/shadow-evaluation-guide.html
@@ -42,44 +42,57 @@
       </span>
     </a>
     <div class="nav-links">
-      <a href="/">Home</a>
       <div class="nav-dropdown">
-        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Learn <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
+        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Framework <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
         <div class="nav-dropdown-menu">
+          <a href="/framework/">Framework overview</a>
           <a href="/specification.html">Specification</a>
+          <a href="/framework/controls.html">Controls</a>
+          <a href="/framework/nhid-auth.html">NHID-Auth</a>
+          <a href="/framework/reference-implementation.html">Reference Implementation</a>
+          <a href="/framework/conformance-suite.html">Conformance Test Suite</a>
           <a href="/technical-stack.html">Technical Stack</a>
           <a href="/regulatory-alignment.html">Regulatory Alignment</a>
-          <a href="/about.html">About</a>
         </div>
       </div>
       <div class="nav-dropdown">
-        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Evaluate <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
+        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Platform <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
         <div class="nav-dropdown-menu">
-          <a href="/simulator.html">Simulator</a>
-          <a href="/shadow-evaluation-guide.html">Shadow Evaluation</a>
-          <a href="/evidence-pack.html">Evidence Pack</a>
-          <a href="/for-payers.html">For Payers</a>
+          <a href="/platform/">TrustLayer overview</a>
+          <a href="/platform/agent-registry.html">Agent Registry</a>
+          <a href="/platform/trust-gateway.html">Trust Gateway</a>
+          <a href="/platform/evidence-center.html">Evidence Center</a>
+          <a href="/platform/continuous-conformance.html">Continuous Conformance</a>
+          <a href="/platform/enterprise.html">Enterprise Workflow</a>
         </div>
       </div>
+      <a href="/simulator.html">Simulator</a>
       <div class="nav-dropdown">
-        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Build <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
+        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Docs <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
         <div class="nav-dropdown-menu">
-          <a href="/developers.html">Developers</a>
+          <a href="/developers.html">Developer guide</a>
+          <a href="/docs.html">Live API explorer</a>
           <a href="/interoperability.html">Interoperability</a>
           <a href="/registry.html">Implementation Registry</a>
           <a href="/icon-system.html">Icon System</a>
         </div>
       </div>
       <div class="nav-dropdown">
-        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Community <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
+        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Resources <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
         <div class="nav-dropdown-menu">
-          <a href="/news.html">News</a>
+          <a href="/evidence-pack.html">Evidence Pack</a>
+          <a href="/shadow-evaluation-guide.html">Shadow Evaluation Guide</a>
+          <a href="/for-payers.html">For Payers</a>
+          <a href="/research-portfolio.html">Research Portfolio</a>
           <a href="/roadmap.html">Roadmap</a>
-          <a href="/research-portfolio.html">Portfolio</a>
-          <a href="https://github.com/NHID-Clinical/NHID-Clinical">GitHub &#x2197;</a>
+          <a href="/news.html">News</a>
+          <a href="/faq.html">FAQ</a>
+          <a href="https://ai-governance-map.vercel.app/" target="_blank" rel="noopener noreferrer">AI Governance Map &#x2197;</a>
         </div>
       </div>
-      <a href="https://ai-governance-map.vercel.app/" target="_blank" rel="noopener noreferrer">AI Map &#x2197;</a>
+      <a href="/pricing.html">Pricing</a>
+      <a href="/about.html">About</a>
+      <a href="https://github.com/NHID-Clinical" target="_blank" rel="noopener noreferrer">GitHub &#x2197;</a>
     </div>
     <div class="nav-actions">
       <button class="icon-button search-toggle" type="button" aria-label="Search" id="search-toggle">
@@ -111,27 +124,44 @@
 
 <nav class="mobile-nav" id="mobile-nav" aria-label="Mobile navigation">
   <a href="/">Home</a>
-  <strong class="mobile-nav-group">Learn</strong>
+  <strong class="mobile-nav-group">Framework</strong>
+  <a href="/framework/">Framework overview</a>
   <a href="/specification.html">Specification</a>
+  <a href="/framework/controls.html">Controls</a>
+  <a href="/framework/nhid-auth.html">NHID-Auth</a>
+  <a href="/framework/reference-implementation.html">Reference Implementation</a>
+  <a href="/framework/conformance-suite.html">Conformance Test Suite</a>
   <a href="/technical-stack.html">Technical Stack</a>
   <a href="/regulatory-alignment.html">Regulatory Alignment</a>
-  <a href="/about.html">About</a>
-  <strong class="mobile-nav-group">Evaluate</strong>
-  <a href="/simulator.html">Simulator</a>
-  <a href="/shadow-evaluation-guide.html">Shadow Evaluation</a>
-  <a href="/evidence-pack.html">Evidence Pack</a>
-  <a href="/for-payers.html">For Payers</a>
-  <strong class="mobile-nav-group">Build</strong>
-  <a href="/developers.html">Developers</a>
+  <strong class="mobile-nav-group">Platform</strong>
+  <a href="/platform/">TrustLayer overview</a>
+  <a href="/platform/agent-registry.html">Agent Registry</a>
+  <a href="/platform/trust-gateway.html">Trust Gateway</a>
+  <a href="/platform/evidence-center.html">Evidence Center</a>
+  <a href="/platform/continuous-conformance.html">Continuous Conformance</a>
+  <a href="/platform/enterprise.html">Enterprise Workflow</a>
+  <strong class="mobile-nav-group">Simulator</strong>
+  <a href="/simulator.html">Open the simulator</a>
+  <a href="/governance-simulator.html">Governance Simulator</a>
+  <strong class="mobile-nav-group">Docs</strong>
+  <a href="/developers.html">Developer guide</a>
+  <a href="/docs.html">Live API explorer</a>
   <a href="/interoperability.html">Interoperability</a>
   <a href="/registry.html">Implementation Registry</a>
   <a href="/icon-system.html">Icon System</a>
-  <strong class="mobile-nav-group">Community</strong>
-  <a href="/news.html">News</a>
+  <strong class="mobile-nav-group">Resources</strong>
+  <a href="/evidence-pack.html">Evidence Pack</a>
+  <a href="/shadow-evaluation-guide.html">Shadow Evaluation Guide</a>
+  <a href="/for-payers.html">For Payers</a>
+  <a href="/research-portfolio.html">Research Portfolio</a>
   <a href="/roadmap.html">Roadmap</a>
-  <a href="/research-portfolio.html">Portfolio</a>
-  <a href="https://github.com/NHID-Clinical/NHID-Clinical" target="_blank" rel="noopener noreferrer">GitHub &#x2197;</a>
-  <a href="https://ai-governance-map.vercel.app/" target="_blank" rel="noopener noreferrer">AI Map &#x2197;</a>
+  <a href="/news.html">News</a>
+  <a href="/faq.html">FAQ</a>
+  <a href="https://ai-governance-map.vercel.app/" target="_blank" rel="noopener noreferrer">AI Governance Map &#x2197;</a>
+  <strong class="mobile-nav-group">More</strong>
+  <a href="/pricing.html">Pricing</a>
+  <a href="/about.html">About</a>
+  <a href="https://github.com/NHID-Clinical" target="_blank" rel="noopener noreferrer">GitHub &#x2197;</a>
   <div class="mobile-nav-footer">
     <button class="theme-toggle mobile-theme-toggle" type="button" aria-label="Toggle dark mode">
       <svg class="sun-icon" viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M6.34 17.66l-1.41 1.41M19.07 4.93l-1.41 1.41"/></svg>

--- a/site.js
+++ b/site.js
@@ -151,6 +151,78 @@
       url: '/registry.html',
       keywords: 'registry implementations vendors self-attestation cas badge nhid-cas listed conformance certified',
       excerpt: 'Self-attested NHID-Clinical implementations, with live NHID-CAS conformance badges.'
+    },
+    {
+      title: 'Framework',
+      url: '/framework/',
+      keywords: 'framework open core specification controls nhid-auth reference implementation conformance test suite technical stack regulatory alignment cc by 4.0 open source free',
+      excerpt: 'The open framework: specification, control catalog, NHID-Auth, reference implementation, conformance tests, technical stack, and regulatory alignment.'
+    },
+    {
+      title: 'Controls',
+      url: '/framework/controls.html',
+      keywords: 'controls catalog idg-01 identity disclosure gate pdx-01 pre-data exchange gate dbc-01 deceptive behavior check eit-01 escalation implementation test atr-01 audit trail requirements cas call authorization score',
+      excerpt: 'The control catalog — IDG-01, PDX-01, DBC-01, EIT-01, and ATR-01 — with what each control checks and what conformance looks like.'
+    },
+    {
+      title: 'NHID-Auth',
+      url: '/framework/nhid-auth.html',
+      keywords: 'nhid-auth v2 cryptographic authorization ed25519 agent passport signed delegation npi binding offline verification revocation scope expiration',
+      excerpt: 'The v2 cryptographic authorization layer: Ed25519 agent passports, provider-signed delegation, and offline verification with no registry or gatekeeper.'
+    },
+    {
+      title: 'Reference Implementation',
+      url: '/framework/reference-implementation.html',
+      keywords: 'reference implementation policy engine python typescript middleware vapi twilio adapters powershell module openapi postman trace schema deterministic open source',
+      excerpt: 'A dependency-free Python policy engine, TypeScript middleware, voice-platform adapters, trace schema, and tooling — all open under CC BY 4.0.'
+    },
+    {
+      title: 'Conformance Test Suite',
+      url: '/framework/conformance-suite.html',
+      keywords: 'conformance test suite cts yaml deterministic pass fail machine readable runner verify implementation self attestation procurement evidence',
+      excerpt: 'Machine-readable, deterministic pass/fail conformance tests anyone can run against any implementation.'
+    },
+    {
+      title: 'TrustLayer Platform',
+      url: '/platform/',
+      keywords: 'trustlayer platform operational trust infrastructure healthcare ai agents saas monitoring evidence identity authorization reporting modules enterprise open core comparison',
+      excerpt: 'TrustLayer by NHID-Clinical — operational trust infrastructure that runs the same deterministic controls as the open framework.'
+    },
+    {
+      title: 'Agent Registry',
+      url: '/platform/agent-registry.html',
+      keywords: 'agent registry identity source of truth agent id organization vendor owner purpose permissions expiration status inventory agent sprawl lifecycle',
+      excerpt: 'A source of truth for AI agent identity — agent ID, organization, vendor, owner, purpose, permissions, expiration, and status.'
+    },
+    {
+      title: 'Trust Gateway',
+      url: '/platform/trust-gateway.html',
+      keywords: 'trust gateway runtime enforcement identity verification authorization disclosure check scope enforcement audit event proxy block allow escalate fail closed',
+      excerpt: 'Runtime enforcement: identity verification, authorization, disclosure check, scope enforcement, and audit event before the healthcare system is reached.'
+    },
+    {
+      title: 'Evidence Center',
+      url: '/platform/evidence-center.html',
+      keywords: 'evidence center compliance reports evidence packages event history governance exports nist ai rmf iso 42001 hipaa security documentation fhir auditevent audit ready',
+      excerpt: 'Audit-ready evidence generation — compliance reports, evidence packages, event history, and governance exports.'
+    },
+    {
+      title: 'Continuous Conformance Monitoring',
+      url: '/platform/continuous-conformance.html',
+      keywords: 'continuous conformance monitoring operational regression agent update detected human review required version change scheduled re-run drift',
+      excerpt: 'Turn static conformance tests into operational monitoring that re-runs whenever an agent changes.'
+    },
+    {
+      title: 'Enterprise Workflow',
+      url: '/platform/enterprise.html',
+      keywords: 'enterprise workflow sso single sign on rbac role based access control approvals integrations siem export revocation separation of duties posture',
+      excerpt: 'SSO, RBAC, approval workflows, integrations, and SIEM export for organizations operating AI agents at scale.'
+    },
+    {
+      title: 'Pricing',
+      url: '/pricing.html',
+      keywords: 'pricing plans community developer enterprise free open cc by 4.0 specification never paid hosted sandbox api access conformance reports trust gateway evidence center sso support',
+      excerpt: 'The open framework is free under CC BY 4.0. TrustLayer plans for developers and enterprises operating agents at scale.'
     }
   ];
 

--- a/sms-opt-in.html
+++ b/sms-opt-in.html
@@ -31,44 +31,57 @@
       </span>
     </a>
     <div class="nav-links">
-      <a href="/">Home</a>
       <div class="nav-dropdown">
-        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Learn <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
+        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Framework <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
         <div class="nav-dropdown-menu">
+          <a href="/framework/">Framework overview</a>
           <a href="/specification.html">Specification</a>
+          <a href="/framework/controls.html">Controls</a>
+          <a href="/framework/nhid-auth.html">NHID-Auth</a>
+          <a href="/framework/reference-implementation.html">Reference Implementation</a>
+          <a href="/framework/conformance-suite.html">Conformance Test Suite</a>
           <a href="/technical-stack.html">Technical Stack</a>
           <a href="/regulatory-alignment.html">Regulatory Alignment</a>
-          <a href="/about.html">About</a>
         </div>
       </div>
       <div class="nav-dropdown">
-        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Evaluate <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
+        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Platform <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
         <div class="nav-dropdown-menu">
-          <a href="/simulator.html">Simulator</a>
-          <a href="/shadow-evaluation-guide.html">Shadow Evaluation</a>
-          <a href="/evidence-pack.html">Evidence Pack</a>
-          <a href="/for-payers.html">For Payers</a>
+          <a href="/platform/">TrustLayer overview</a>
+          <a href="/platform/agent-registry.html">Agent Registry</a>
+          <a href="/platform/trust-gateway.html">Trust Gateway</a>
+          <a href="/platform/evidence-center.html">Evidence Center</a>
+          <a href="/platform/continuous-conformance.html">Continuous Conformance</a>
+          <a href="/platform/enterprise.html">Enterprise Workflow</a>
         </div>
       </div>
+      <a href="/simulator.html">Simulator</a>
       <div class="nav-dropdown">
-        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Build <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
+        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Docs <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
         <div class="nav-dropdown-menu">
-          <a href="/developers.html">Developers</a>
+          <a href="/developers.html">Developer guide</a>
+          <a href="/docs.html">Live API explorer</a>
           <a href="/interoperability.html">Interoperability</a>
           <a href="/registry.html">Implementation Registry</a>
           <a href="/icon-system.html">Icon System</a>
         </div>
       </div>
       <div class="nav-dropdown">
-        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Community <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
+        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Resources <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
         <div class="nav-dropdown-menu">
-          <a href="/news.html">News</a>
+          <a href="/evidence-pack.html">Evidence Pack</a>
+          <a href="/shadow-evaluation-guide.html">Shadow Evaluation Guide</a>
+          <a href="/for-payers.html">For Payers</a>
+          <a href="/research-portfolio.html">Research Portfolio</a>
           <a href="/roadmap.html">Roadmap</a>
-          <a href="/research-portfolio.html">Portfolio</a>
-          <a href="https://github.com/NHID-Clinical/NHID-Clinical">GitHub &#x2197;</a>
+          <a href="/news.html">News</a>
+          <a href="/faq.html">FAQ</a>
+          <a href="https://ai-governance-map.vercel.app/" target="_blank" rel="noopener noreferrer">AI Governance Map &#x2197;</a>
         </div>
       </div>
-      <a href="https://ai-governance-map.vercel.app/" target="_blank" rel="noopener noreferrer">AI Map &#x2197;</a>
+      <a href="/pricing.html">Pricing</a>
+      <a href="/about.html">About</a>
+      <a href="https://github.com/NHID-Clinical" target="_blank" rel="noopener noreferrer">GitHub &#x2197;</a>
     </div>
     <div class="nav-actions">
       <button class="icon-button search-toggle" type="button" aria-label="Search" id="search-toggle">
@@ -100,27 +113,44 @@
 
 <nav class="mobile-nav" id="mobile-nav" aria-label="Mobile navigation">
   <a href="/">Home</a>
-  <strong class="mobile-nav-group">Learn</strong>
+  <strong class="mobile-nav-group">Framework</strong>
+  <a href="/framework/">Framework overview</a>
   <a href="/specification.html">Specification</a>
+  <a href="/framework/controls.html">Controls</a>
+  <a href="/framework/nhid-auth.html">NHID-Auth</a>
+  <a href="/framework/reference-implementation.html">Reference Implementation</a>
+  <a href="/framework/conformance-suite.html">Conformance Test Suite</a>
   <a href="/technical-stack.html">Technical Stack</a>
   <a href="/regulatory-alignment.html">Regulatory Alignment</a>
-  <a href="/about.html">About</a>
-  <strong class="mobile-nav-group">Evaluate</strong>
-  <a href="/simulator.html">Simulator</a>
-  <a href="/shadow-evaluation-guide.html">Shadow Evaluation</a>
-  <a href="/evidence-pack.html">Evidence Pack</a>
-  <a href="/for-payers.html">For Payers</a>
-  <strong class="mobile-nav-group">Build</strong>
-  <a href="/developers.html">Developers</a>
+  <strong class="mobile-nav-group">Platform</strong>
+  <a href="/platform/">TrustLayer overview</a>
+  <a href="/platform/agent-registry.html">Agent Registry</a>
+  <a href="/platform/trust-gateway.html">Trust Gateway</a>
+  <a href="/platform/evidence-center.html">Evidence Center</a>
+  <a href="/platform/continuous-conformance.html">Continuous Conformance</a>
+  <a href="/platform/enterprise.html">Enterprise Workflow</a>
+  <strong class="mobile-nav-group">Simulator</strong>
+  <a href="/simulator.html">Open the simulator</a>
+  <a href="/governance-simulator.html">Governance Simulator</a>
+  <strong class="mobile-nav-group">Docs</strong>
+  <a href="/developers.html">Developer guide</a>
+  <a href="/docs.html">Live API explorer</a>
   <a href="/interoperability.html">Interoperability</a>
   <a href="/registry.html">Implementation Registry</a>
   <a href="/icon-system.html">Icon System</a>
-  <strong class="mobile-nav-group">Community</strong>
-  <a href="/news.html">News</a>
+  <strong class="mobile-nav-group">Resources</strong>
+  <a href="/evidence-pack.html">Evidence Pack</a>
+  <a href="/shadow-evaluation-guide.html">Shadow Evaluation Guide</a>
+  <a href="/for-payers.html">For Payers</a>
+  <a href="/research-portfolio.html">Research Portfolio</a>
   <a href="/roadmap.html">Roadmap</a>
-  <a href="/research-portfolio.html">Portfolio</a>
-  <a href="https://github.com/NHID-Clinical/NHID-Clinical" target="_blank" rel="noopener noreferrer">GitHub &#x2197;</a>
-  <a href="https://ai-governance-map.vercel.app/" target="_blank" rel="noopener noreferrer">AI Map &#x2197;</a>
+  <a href="/news.html">News</a>
+  <a href="/faq.html">FAQ</a>
+  <a href="https://ai-governance-map.vercel.app/" target="_blank" rel="noopener noreferrer">AI Governance Map &#x2197;</a>
+  <strong class="mobile-nav-group">More</strong>
+  <a href="/pricing.html">Pricing</a>
+  <a href="/about.html">About</a>
+  <a href="https://github.com/NHID-Clinical" target="_blank" rel="noopener noreferrer">GitHub &#x2197;</a>
   <div class="mobile-nav-footer">
     <button class="theme-toggle mobile-theme-toggle" type="button" aria-label="Toggle dark mode">
       <svg class="sun-icon" viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M6.34 17.66l-1.41 1.41M19.07 4.93l-1.41 1.41"/></svg>

--- a/specification.html
+++ b/specification.html
@@ -34,44 +34,57 @@
       </span>
     </a>
     <div class="nav-links">
-      <a href="/">Home</a>
       <div class="nav-dropdown">
-        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Learn <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
+        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Framework <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
         <div class="nav-dropdown-menu">
+          <a href="/framework/">Framework overview</a>
           <a href="/specification.html">Specification</a>
+          <a href="/framework/controls.html">Controls</a>
+          <a href="/framework/nhid-auth.html">NHID-Auth</a>
+          <a href="/framework/reference-implementation.html">Reference Implementation</a>
+          <a href="/framework/conformance-suite.html">Conformance Test Suite</a>
           <a href="/technical-stack.html">Technical Stack</a>
           <a href="/regulatory-alignment.html">Regulatory Alignment</a>
-          <a href="/about.html">About</a>
         </div>
       </div>
       <div class="nav-dropdown">
-        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Evaluate <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
+        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Platform <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
         <div class="nav-dropdown-menu">
-          <a href="/simulator.html">Simulator</a>
-          <a href="/shadow-evaluation-guide.html">Shadow Evaluation</a>
-          <a href="/evidence-pack.html">Evidence Pack</a>
-          <a href="/for-payers.html">For Payers</a>
+          <a href="/platform/">TrustLayer overview</a>
+          <a href="/platform/agent-registry.html">Agent Registry</a>
+          <a href="/platform/trust-gateway.html">Trust Gateway</a>
+          <a href="/platform/evidence-center.html">Evidence Center</a>
+          <a href="/platform/continuous-conformance.html">Continuous Conformance</a>
+          <a href="/platform/enterprise.html">Enterprise Workflow</a>
         </div>
       </div>
+      <a href="/simulator.html">Simulator</a>
       <div class="nav-dropdown">
-        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Build <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
+        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Docs <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
         <div class="nav-dropdown-menu">
-          <a href="/developers.html">Developers</a>
+          <a href="/developers.html">Developer guide</a>
+          <a href="/docs.html">Live API explorer</a>
           <a href="/interoperability.html">Interoperability</a>
           <a href="/registry.html">Implementation Registry</a>
           <a href="/icon-system.html">Icon System</a>
         </div>
       </div>
       <div class="nav-dropdown">
-        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Community <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
+        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Resources <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
         <div class="nav-dropdown-menu">
-          <a href="/news.html">News</a>
+          <a href="/evidence-pack.html">Evidence Pack</a>
+          <a href="/shadow-evaluation-guide.html">Shadow Evaluation Guide</a>
+          <a href="/for-payers.html">For Payers</a>
+          <a href="/research-portfolio.html">Research Portfolio</a>
           <a href="/roadmap.html">Roadmap</a>
-          <a href="/research-portfolio.html">Portfolio</a>
-          <a href="https://github.com/NHID-Clinical/NHID-Clinical">GitHub &#x2197;</a>
+          <a href="/news.html">News</a>
+          <a href="/faq.html">FAQ</a>
+          <a href="https://ai-governance-map.vercel.app/" target="_blank" rel="noopener noreferrer">AI Governance Map &#x2197;</a>
         </div>
       </div>
-      <a href="https://ai-governance-map.vercel.app/" target="_blank" rel="noopener noreferrer">AI Map &#x2197;</a>
+      <a href="/pricing.html">Pricing</a>
+      <a href="/about.html">About</a>
+      <a href="https://github.com/NHID-Clinical" target="_blank" rel="noopener noreferrer">GitHub &#x2197;</a>
     </div>
     <div class="nav-actions">
       <button class="icon-button search-toggle" type="button" aria-label="Search" id="search-toggle">
@@ -103,27 +116,44 @@
 
 <nav class="mobile-nav" id="mobile-nav" aria-label="Mobile navigation">
   <a href="/">Home</a>
-  <strong class="mobile-nav-group">Learn</strong>
+  <strong class="mobile-nav-group">Framework</strong>
+  <a href="/framework/">Framework overview</a>
   <a href="/specification.html">Specification</a>
+  <a href="/framework/controls.html">Controls</a>
+  <a href="/framework/nhid-auth.html">NHID-Auth</a>
+  <a href="/framework/reference-implementation.html">Reference Implementation</a>
+  <a href="/framework/conformance-suite.html">Conformance Test Suite</a>
   <a href="/technical-stack.html">Technical Stack</a>
   <a href="/regulatory-alignment.html">Regulatory Alignment</a>
-  <a href="/about.html">About</a>
-  <strong class="mobile-nav-group">Evaluate</strong>
-  <a href="/simulator.html">Simulator</a>
-  <a href="/shadow-evaluation-guide.html">Shadow Evaluation</a>
-  <a href="/evidence-pack.html">Evidence Pack</a>
-  <a href="/for-payers.html">For Payers</a>
-  <strong class="mobile-nav-group">Build</strong>
-  <a href="/developers.html">Developers</a>
+  <strong class="mobile-nav-group">Platform</strong>
+  <a href="/platform/">TrustLayer overview</a>
+  <a href="/platform/agent-registry.html">Agent Registry</a>
+  <a href="/platform/trust-gateway.html">Trust Gateway</a>
+  <a href="/platform/evidence-center.html">Evidence Center</a>
+  <a href="/platform/continuous-conformance.html">Continuous Conformance</a>
+  <a href="/platform/enterprise.html">Enterprise Workflow</a>
+  <strong class="mobile-nav-group">Simulator</strong>
+  <a href="/simulator.html">Open the simulator</a>
+  <a href="/governance-simulator.html">Governance Simulator</a>
+  <strong class="mobile-nav-group">Docs</strong>
+  <a href="/developers.html">Developer guide</a>
+  <a href="/docs.html">Live API explorer</a>
   <a href="/interoperability.html">Interoperability</a>
   <a href="/registry.html">Implementation Registry</a>
   <a href="/icon-system.html">Icon System</a>
-  <strong class="mobile-nav-group">Community</strong>
-  <a href="/news.html">News</a>
+  <strong class="mobile-nav-group">Resources</strong>
+  <a href="/evidence-pack.html">Evidence Pack</a>
+  <a href="/shadow-evaluation-guide.html">Shadow Evaluation Guide</a>
+  <a href="/for-payers.html">For Payers</a>
+  <a href="/research-portfolio.html">Research Portfolio</a>
   <a href="/roadmap.html">Roadmap</a>
-  <a href="/research-portfolio.html">Portfolio</a>
-  <a href="https://github.com/NHID-Clinical/NHID-Clinical" target="_blank" rel="noopener noreferrer">GitHub &#x2197;</a>
-  <a href="https://ai-governance-map.vercel.app/" target="_blank" rel="noopener noreferrer">AI Map &#x2197;</a>
+  <a href="/news.html">News</a>
+  <a href="/faq.html">FAQ</a>
+  <a href="https://ai-governance-map.vercel.app/" target="_blank" rel="noopener noreferrer">AI Governance Map &#x2197;</a>
+  <strong class="mobile-nav-group">More</strong>
+  <a href="/pricing.html">Pricing</a>
+  <a href="/about.html">About</a>
+  <a href="https://github.com/NHID-Clinical" target="_blank" rel="noopener noreferrer">GitHub &#x2197;</a>
   <div class="mobile-nav-footer">
     <button class="theme-toggle mobile-theme-toggle" type="button" aria-label="Toggle dark mode">
       <svg class="sun-icon" viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M6.34 17.66l-1.41 1.41M19.07 4.93l-1.41 1.41"/></svg>

--- a/specs/index.html
+++ b/specs/index.html
@@ -25,16 +25,57 @@
       </span>
     </a>
     <div class="nav-links">
-      <a href="/">Home</a>
+      <div class="nav-dropdown">
+        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Framework <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
+        <div class="nav-dropdown-menu">
+          <a href="/framework/">Framework overview</a>
+          <a href="/specification.html">Specification</a>
+          <a href="/framework/controls.html">Controls</a>
+          <a href="/framework/nhid-auth.html">NHID-Auth</a>
+          <a href="/framework/reference-implementation.html">Reference Implementation</a>
+          <a href="/framework/conformance-suite.html">Conformance Test Suite</a>
+          <a href="/technical-stack.html">Technical Stack</a>
+          <a href="/regulatory-alignment.html">Regulatory Alignment</a>
+        </div>
+      </div>
+      <div class="nav-dropdown">
+        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Platform <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
+        <div class="nav-dropdown-menu">
+          <a href="/platform/">TrustLayer overview</a>
+          <a href="/platform/agent-registry.html">Agent Registry</a>
+          <a href="/platform/trust-gateway.html">Trust Gateway</a>
+          <a href="/platform/evidence-center.html">Evidence Center</a>
+          <a href="/platform/continuous-conformance.html">Continuous Conformance</a>
+          <a href="/platform/enterprise.html">Enterprise Workflow</a>
+        </div>
+      </div>
+      <a href="/simulator.html">Simulator</a>
+      <div class="nav-dropdown">
+        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Docs <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
+        <div class="nav-dropdown-menu">
+          <a href="/developers.html">Developer guide</a>
+          <a href="/docs.html">Live API explorer</a>
+          <a href="/interoperability.html">Interoperability</a>
+          <a href="/registry.html">Implementation Registry</a>
+          <a href="/icon-system.html">Icon System</a>
+        </div>
+      </div>
+      <div class="nav-dropdown">
+        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Resources <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
+        <div class="nav-dropdown-menu">
+          <a href="/evidence-pack.html">Evidence Pack</a>
+          <a href="/shadow-evaluation-guide.html">Shadow Evaluation Guide</a>
+          <a href="/for-payers.html">For Payers</a>
+          <a href="/research-portfolio.html">Research Portfolio</a>
+          <a href="/roadmap.html">Roadmap</a>
+          <a href="/news.html">News</a>
+          <a href="/faq.html">FAQ</a>
+          <a href="https://ai-governance-map.vercel.app/" target="_blank" rel="noopener noreferrer">AI Governance Map &#x2197;</a>
+        </div>
+      </div>
+      <a href="/pricing.html">Pricing</a>
       <a href="/about.html">About</a>
-      <a href="/research-portfolio.html">Portfolio</a>
-      <a href="/governance-simulator.html">Governance Simulator</a>
-      <a href="/for-payers.html">For Payers</a>
-      <a href="/specification.html">Specification</a>
-      <a href="/developers.html">Developers</a>
-      <a href="/regulatory-alignment.html">Regulatory Alignment</a>
-      <a href="/technical-stack.html">Technical Stack</a>
-      <a href="https://ai-governance-map.vercel.app/" target="_blank" rel="noopener noreferrer">AI Governance Map ↗</a>
+      <a href="https://github.com/NHID-Clinical" target="_blank" rel="noopener noreferrer">GitHub &#x2197;</a>
     </div>
     <div class="nav-actions">
       <button class="icon-button search-toggle" type="button" aria-label="Search" id="search-toggle">
@@ -66,15 +107,44 @@
 
 <nav class="mobile-nav" id="mobile-nav" aria-label="Mobile navigation">
   <a href="/">Home</a>
-  <a href="/about.html">About</a>
-  <a href="/research-portfolio.html">Portfolio</a>
-  <a href="/governance-simulator.html">Governance Simulator</a>
-  <a href="/for-payers.html">For Payers</a>
+  <strong class="mobile-nav-group">Framework</strong>
+  <a href="/framework/">Framework overview</a>
   <a href="/specification.html">Specification</a>
-  <a href="/developers.html">Developers</a>
-  <a href="/regulatory-alignment.html">Regulatory Alignment</a>
+  <a href="/framework/controls.html">Controls</a>
+  <a href="/framework/nhid-auth.html">NHID-Auth</a>
+  <a href="/framework/reference-implementation.html">Reference Implementation</a>
+  <a href="/framework/conformance-suite.html">Conformance Test Suite</a>
   <a href="/technical-stack.html">Technical Stack</a>
-  <a href="https://ai-governance-map.vercel.app/" target="_blank" rel="noopener noreferrer">AI Governance Map ↗</a>
+  <a href="/regulatory-alignment.html">Regulatory Alignment</a>
+  <strong class="mobile-nav-group">Platform</strong>
+  <a href="/platform/">TrustLayer overview</a>
+  <a href="/platform/agent-registry.html">Agent Registry</a>
+  <a href="/platform/trust-gateway.html">Trust Gateway</a>
+  <a href="/platform/evidence-center.html">Evidence Center</a>
+  <a href="/platform/continuous-conformance.html">Continuous Conformance</a>
+  <a href="/platform/enterprise.html">Enterprise Workflow</a>
+  <strong class="mobile-nav-group">Simulator</strong>
+  <a href="/simulator.html">Open the simulator</a>
+  <a href="/governance-simulator.html">Governance Simulator</a>
+  <strong class="mobile-nav-group">Docs</strong>
+  <a href="/developers.html">Developer guide</a>
+  <a href="/docs.html">Live API explorer</a>
+  <a href="/interoperability.html">Interoperability</a>
+  <a href="/registry.html">Implementation Registry</a>
+  <a href="/icon-system.html">Icon System</a>
+  <strong class="mobile-nav-group">Resources</strong>
+  <a href="/evidence-pack.html">Evidence Pack</a>
+  <a href="/shadow-evaluation-guide.html">Shadow Evaluation Guide</a>
+  <a href="/for-payers.html">For Payers</a>
+  <a href="/research-portfolio.html">Research Portfolio</a>
+  <a href="/roadmap.html">Roadmap</a>
+  <a href="/news.html">News</a>
+  <a href="/faq.html">FAQ</a>
+  <a href="https://ai-governance-map.vercel.app/" target="_blank" rel="noopener noreferrer">AI Governance Map &#x2197;</a>
+  <strong class="mobile-nav-group">More</strong>
+  <a href="/pricing.html">Pricing</a>
+  <a href="/about.html">About</a>
+  <a href="https://github.com/NHID-Clinical" target="_blank" rel="noopener noreferrer">GitHub &#x2197;</a>
   <div class="mobile-nav-footer">
     <button class="theme-toggle mobile-theme-toggle" type="button" aria-label="Toggle dark mode">
       <svg class="sun-icon" viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M6.34 17.66l-1.41 1.41M19.07 4.93l-1.41 1.41"/></svg>

--- a/technical-stack.html
+++ b/technical-stack.html
@@ -31,44 +31,57 @@
       </span>
     </a>
     <div class="nav-links">
-      <a href="/">Home</a>
       <div class="nav-dropdown">
-        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Learn <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
+        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Framework <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
         <div class="nav-dropdown-menu">
+          <a href="/framework/">Framework overview</a>
           <a href="/specification.html">Specification</a>
+          <a href="/framework/controls.html">Controls</a>
+          <a href="/framework/nhid-auth.html">NHID-Auth</a>
+          <a href="/framework/reference-implementation.html">Reference Implementation</a>
+          <a href="/framework/conformance-suite.html">Conformance Test Suite</a>
           <a href="/technical-stack.html">Technical Stack</a>
           <a href="/regulatory-alignment.html">Regulatory Alignment</a>
-          <a href="/about.html">About</a>
         </div>
       </div>
       <div class="nav-dropdown">
-        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Evaluate <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
+        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Platform <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
         <div class="nav-dropdown-menu">
-          <a href="/simulator.html">Simulator</a>
-          <a href="/shadow-evaluation-guide.html">Shadow Evaluation</a>
-          <a href="/evidence-pack.html">Evidence Pack</a>
-          <a href="/for-payers.html">For Payers</a>
+          <a href="/platform/">TrustLayer overview</a>
+          <a href="/platform/agent-registry.html">Agent Registry</a>
+          <a href="/platform/trust-gateway.html">Trust Gateway</a>
+          <a href="/platform/evidence-center.html">Evidence Center</a>
+          <a href="/platform/continuous-conformance.html">Continuous Conformance</a>
+          <a href="/platform/enterprise.html">Enterprise Workflow</a>
         </div>
       </div>
+      <a href="/simulator.html">Simulator</a>
       <div class="nav-dropdown">
-        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Build <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
+        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Docs <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
         <div class="nav-dropdown-menu">
-          <a href="/developers.html">Developers</a>
+          <a href="/developers.html">Developer guide</a>
+          <a href="/docs.html">Live API explorer</a>
           <a href="/interoperability.html">Interoperability</a>
           <a href="/registry.html">Implementation Registry</a>
           <a href="/icon-system.html">Icon System</a>
         </div>
       </div>
       <div class="nav-dropdown">
-        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Community <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
+        <button class="nav-dropdown-trigger" type="button" aria-haspopup="true" aria-expanded="false">Resources <svg class="chev" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg></button>
         <div class="nav-dropdown-menu">
-          <a href="/news.html">News</a>
+          <a href="/evidence-pack.html">Evidence Pack</a>
+          <a href="/shadow-evaluation-guide.html">Shadow Evaluation Guide</a>
+          <a href="/for-payers.html">For Payers</a>
+          <a href="/research-portfolio.html">Research Portfolio</a>
           <a href="/roadmap.html">Roadmap</a>
-          <a href="/research-portfolio.html">Portfolio</a>
-          <a href="https://github.com/NHID-Clinical/NHID-Clinical">GitHub &#x2197;</a>
+          <a href="/news.html">News</a>
+          <a href="/faq.html">FAQ</a>
+          <a href="https://ai-governance-map.vercel.app/" target="_blank" rel="noopener noreferrer">AI Governance Map &#x2197;</a>
         </div>
       </div>
-      <a href="https://ai-governance-map.vercel.app/" target="_blank" rel="noopener noreferrer">AI Map &#x2197;</a>
+      <a href="/pricing.html">Pricing</a>
+      <a href="/about.html">About</a>
+      <a href="https://github.com/NHID-Clinical" target="_blank" rel="noopener noreferrer">GitHub &#x2197;</a>
     </div>
     <div class="nav-actions">
       <button class="icon-button search-toggle" type="button" aria-label="Search" id="search-toggle">
@@ -100,27 +113,44 @@
 
 <nav class="mobile-nav" id="mobile-nav" aria-label="Mobile navigation">
   <a href="/">Home</a>
-  <strong class="mobile-nav-group">Learn</strong>
+  <strong class="mobile-nav-group">Framework</strong>
+  <a href="/framework/">Framework overview</a>
   <a href="/specification.html">Specification</a>
+  <a href="/framework/controls.html">Controls</a>
+  <a href="/framework/nhid-auth.html">NHID-Auth</a>
+  <a href="/framework/reference-implementation.html">Reference Implementation</a>
+  <a href="/framework/conformance-suite.html">Conformance Test Suite</a>
   <a href="/technical-stack.html">Technical Stack</a>
   <a href="/regulatory-alignment.html">Regulatory Alignment</a>
-  <a href="/about.html">About</a>
-  <strong class="mobile-nav-group">Evaluate</strong>
-  <a href="/simulator.html">Simulator</a>
-  <a href="/shadow-evaluation-guide.html">Shadow Evaluation</a>
-  <a href="/evidence-pack.html">Evidence Pack</a>
-  <a href="/for-payers.html">For Payers</a>
-  <strong class="mobile-nav-group">Build</strong>
-  <a href="/developers.html">Developers</a>
+  <strong class="mobile-nav-group">Platform</strong>
+  <a href="/platform/">TrustLayer overview</a>
+  <a href="/platform/agent-registry.html">Agent Registry</a>
+  <a href="/platform/trust-gateway.html">Trust Gateway</a>
+  <a href="/platform/evidence-center.html">Evidence Center</a>
+  <a href="/platform/continuous-conformance.html">Continuous Conformance</a>
+  <a href="/platform/enterprise.html">Enterprise Workflow</a>
+  <strong class="mobile-nav-group">Simulator</strong>
+  <a href="/simulator.html">Open the simulator</a>
+  <a href="/governance-simulator.html">Governance Simulator</a>
+  <strong class="mobile-nav-group">Docs</strong>
+  <a href="/developers.html">Developer guide</a>
+  <a href="/docs.html">Live API explorer</a>
   <a href="/interoperability.html">Interoperability</a>
   <a href="/registry.html">Implementation Registry</a>
   <a href="/icon-system.html">Icon System</a>
-  <strong class="mobile-nav-group">Community</strong>
-  <a href="/news.html">News</a>
+  <strong class="mobile-nav-group">Resources</strong>
+  <a href="/evidence-pack.html">Evidence Pack</a>
+  <a href="/shadow-evaluation-guide.html">Shadow Evaluation Guide</a>
+  <a href="/for-payers.html">For Payers</a>
+  <a href="/research-portfolio.html">Research Portfolio</a>
   <a href="/roadmap.html">Roadmap</a>
-  <a href="/research-portfolio.html">Portfolio</a>
-  <a href="https://github.com/NHID-Clinical/NHID-Clinical" target="_blank" rel="noopener noreferrer">GitHub &#x2197;</a>
-  <a href="https://ai-governance-map.vercel.app/" target="_blank" rel="noopener noreferrer">AI Map &#x2197;</a>
+  <a href="/news.html">News</a>
+  <a href="/faq.html">FAQ</a>
+  <a href="https://ai-governance-map.vercel.app/" target="_blank" rel="noopener noreferrer">AI Governance Map &#x2197;</a>
+  <strong class="mobile-nav-group">More</strong>
+  <a href="/pricing.html">Pricing</a>
+  <a href="/about.html">About</a>
+  <a href="https://github.com/NHID-Clinical" target="_blank" rel="noopener noreferrer">GitHub &#x2197;</a>
   <div class="mobile-nav-footer">
     <button class="theme-toggle mobile-theme-toggle" type="button" aria-label="Toggle dark mode">
       <svg class="sun-icon" viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M6.34 17.66l-1.41 1.41M19.07 4.93l-1.41 1.41"/></svg>


### PR DESCRIPTION
## Summary

Restructures nhid-clinical.org around an **open framework first, separate commercial platform layer** architecture, replacing the `Learn / Evaluate / Build / Community` nav that grew organically with the project.

The open framework stays the source of legitimacy. TrustLayer operationalizes it — it does not replace it, and it never gates the specification. This is deliberately **not** a SaaS-landing-page redesign; the homepage is dual-path, not product-first.

Phases 1 and 2 of the four-phase plan. No SaaS dashboard mockups (Phase 3), no API/backend wiring (Phase 4). Core framework logic is untouched.

### Files changed — 32

**Pages added (11)**

| Path | Contents |
|---|---|
| `framework/index.html` | Framework hub — the seven open components |
| `framework/controls.html` | Control catalog: IDG-01, PDX-01, DBC-01, EIT-01, ATR-01 |
| `framework/nhid-auth.html` | v2 cryptographic authorization — Ed25519 passports, signed delegation |
| `framework/reference-implementation.html` | Policy engine, middleware, adapters, schema, tooling |
| `framework/conformance-suite.html` | Deterministic pass/fail test suite |
| `platform/index.html` | TrustLayer overview + open-core-vs-platform table |
| `platform/agent-registry.html` | Agent identity source of truth, field reference |
| `platform/trust-gateway.html` | Runtime enforcement sequence |
| `platform/evidence-center.html` | Audit-ready evidence, framework alignment |
| `platform/continuous-conformance.html` | Static tests → operational monitoring |
| `platform/enterprise.html` | SSO, RBAC, approvals, integrations, SIEM export |

Plus `docs/repository-architecture.md` (recommended open/commercial repo split).

**Pages modified (29)**

- **25 existing pages** — nav swap only. Verified: every one shows exactly the nav-block delta and no content change. `specs/index.html` had drifted to an older nav variant and is now consistent with the rest of the site.
- **`index.html`** — dual-path hero (*Explore the Open Framework* / *Try TrustLayer Platform*), new "why NHID exists" section carrying the impersonation-latency definition, open-core-vs-platform comparison, simulator demo, developer and enterprise pathways. All existing sections retained: standards bar, audience chips, stats strip, five-layer trust stack, latency split, control grid, live API mock, what-it-is/is-not, video, key tools, NIST provenance, closing CTA.
- **`pricing.html`** — rewritten onto the site design system. It was still on the pre-redesign nav with inline styles.
- **`nhid-clinical-ui.css`** — appended IA components with dark-theme variants.
- **`site.js`** — 12 new `SEARCH_INDEX` entries.
- **`scripts/build_pages_site.sh`** — adds `framework/` and `platform/` to the Pages allowlist.

Nothing was deleted, renamed, or repointed.

### Two decisions worth a reviewer's attention

**Pages build allowlist.** `build_pages_site.sh` copies root `*.html` plus a hardcoded directory list. `about/`, `community/`, `news/`, `docs/`, and `content/` already exist in-repo and are silently not deployed. Without the two added `copy_tree` lines, every new page would 404 in production. This is the single change that must not be reverted in isolation.

**Nav drawer breakpoint 1060px → 1240px.** Eight top-level items need more room than six. Measured at 1200px, the brand block wrapped to 87px tall and the CTA crowded the viewport edge. Below 1240px the existing mobile drawer now takes over — it lists all 33 links, grouped. Between 1240–1380px the links tighten instead. Verified brand height stays 60px at every inline width and the CTA never clips.

**Naming note:** `conformance/` (directory) and `conformance.html` (redirect) already exist, so the new page is `framework/conformance-suite.html`.

## Type of change

- [ ] Reference implementation / conformance API
- [ ] Conformance tests
- [ ] Adapter (VAPI / Twilio / Vonage / Retell / Connect)
- [ ] NHID-Auth v2 (agent identity)
- [x] Docs
- [x] Website
- [ ] Specification / control text

## Checklist

- [x] `python -m pytest tests/` passes locally — 343 passed, unchanged (no Python touched)
- [x] Guards pass: `validate_ci.py` (343 passed), `check_baseline.py` (IDG-01 70/70, PDX-01 41/41, DBC-01 183/200, EIT-01 168/171), `check_number_drift.py` (DRIFT PASS)
- [x] No new claims of certification, accredited-standard, or regulatory status
- [x] Control names and disclaimers unchanged
- [x] Public claims reviewed against `docs/claim-boundaries.md`

**Claims discipline applied to the new pages:**
- "Operational trust infrastructure for healthcare AI agents" throughout — never "AI compliance platform"
- Every platform page carries a development-status note: TrustLayer is not generally available, screens are illustrative
- Every illustrative figure is labelled as such
- Pricing has no dollar figures beyond `$0`; the specification, control catalog, and conformance suite are stated as never gated by a plan
- Evidence Center says *alignment* to NIST AI RMF / ISO/IEC 42001 / HIPAA, explicitly not a compliance determination

## Verification

| Check | Result |
|---|---|
| Pages build emits new dirs | ✅ `_site/framework/` 5 files, `_site/platform/` 6 files |
| Artifact size vs 40 MB CI gate | ✅ 38.03 MB |
| Broken root-relative links introduced | ✅ zero (8 pre-existing, all in unmodified files) |
| Nav variants across 37 pages | ✅ exactly 1 for both desktop and mobile |
| Orphaned nav targets | ✅ none — only the repo URL, intentionally replaced by the account URL |
| CI guards | ✅ all three pass |
| Nav layout 1600/1400/1300/1250px | ✅ single row, 8 items, brand 60px, no clipping |
| Drawer below 1240px | ✅ 33 links, opens correctly at 375px |
| Horizontal overflow, 1400 + 375px | ✅ none on any new or modified page |
| Dark theme | ✅ verified on all new components |

## Notes

**Risks**

1. **Pages allowlist is the critical path.** Reverting `build_pages_site.sh` alone un-deploys `/framework/` and `/platform/` while the nav still links to them — 404s across every page. Revert it together with the nav or not at all.
2. **Artifact size headroom is thin.** 38.03 MB against a 40 MB gate. This PR adds ~215 KB, but the margin was already small and the next large asset will trip the gate.
3. **Nav breakpoint change is site-wide.** The 1060–1240px band now shows the drawer on every page, including ones this PR did not otherwise touch.
4. **`/pricing.html` content is a placeholder architecture.** Developer and Enterprise tiers describe intended packaging, not committed offerings.
5. **Platform pages describe software that does not ship yet.** Mitigated by status notes on every page, but the copy should be re-reviewed before TrustLayer is announced.
6. **Repo split not executed.** `docs/repository-architecture.md` documents the recommended structure. Repo creation was attempted and failed — the GitHub App token cannot create repositories (`403 Resource not accessible by integration`), and `NHID-Clinical` is a user account rather than an organization. Creating them is a manual step; the doc says so rather than claiming they exist.

**Rollback**

`main` is untouched. Close this PR, or `git revert` the single commit — the 11 new pages are additive, so nothing else depends on them. Partial rollback is viable: reverting only `index.html` and `pricing.html` restores the previous homepage and pricing while leaving the new IA in place.

---
_Generated by [Claude Code](https://claude.ai/code/session_0173jPwxUgi5swPFeteSe5yU)_