### PR TITLE
Update CI workflow job names and improve docker test portability

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   unit-invariant:
-    name: "Unit invariant: 343 passed"
+    name: "Unit invariant: 446 passed"
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/nightly-verify.yml
+++ b/.github/workflows/nightly-verify.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Install dependencies
         run: pip install -r requirements.txt
 
-      - name: Test-count invariant (343 expected via validate_ci.py)
+      - name: Test-count invariant (446 expected via validate_ci.py)
         run: python scripts/validate_ci.py
 
       - name: Confusion-matrix baseline guard

--- a/tests/test_docker_smoke.py
+++ b/tests/test_docker_smoke.py
@@ -6,6 +6,14 @@ import subprocess
 import json
 import time
 import httpx
+from pathlib import Path
+import shutil
+
+# Resolve repository root relative to this test file (tests/ -> repo root)
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+# Optional helper: skip docker-heavy tests if docker isn't available in the runner
+DOCKER_AVAILABLE = shutil.which("docker") is not None
 
 
 class TestDockerBuildAndHealthCheck:
@@ -14,9 +22,12 @@ class TestDockerBuildAndHealthCheck:
     @pytest.fixture(scope="class")
     def docker_image_built(self):
         """Build Docker image for testing."""
+        if not DOCKER_AVAILABLE:
+            pytest.skip("docker not available in this environment")
+
         result = subprocess.run(
             ["docker", "build", "-t", "nhid-clinical:test", "."],
-            cwd="/home/user/NHID-Clinical",
+            cwd=str(REPO_ROOT),
             capture_output=True,
             text=True,
             timeout=300
@@ -31,8 +42,8 @@ class TestDockerBuildAndHealthCheck:
 
     def test_dockerfile_syntax_valid(self):
         """Verify Dockerfile is valid."""
-        dockerfile_path = "/home/user/NHID-Clinical/Dockerfile"
-        assert os.path.exists(dockerfile_path), "Dockerfile not found"
+        dockerfile_path = REPO_ROOT / "Dockerfile"
+        assert dockerfile_path.exists(), "Dockerfile not found"
 
         with open(dockerfile_path) as f:
             content = f.read()
@@ -44,8 +55,8 @@ class TestDockerBuildAndHealthCheck:
     def test_docker_compose_syntax_valid(self):
         """Verify docker-compose.yml is valid YAML."""
         import yaml
-        compose_path = "/home/user/NHID-Clinical/docker-compose.yml"
-        assert os.path.exists(compose_path), "docker-compose.yml not found"
+        compose_path = REPO_ROOT / "docker-compose.yml"
+        assert compose_path.exists(), "docker-compose.yml not found"
 
         # Parse YAML to validate syntax
         with open(compose_path) as f:
@@ -57,8 +68,8 @@ class TestDockerBuildAndHealthCheck:
 
     def test_dockerignore_exists(self):
         """Verify .dockerignore exists to reduce image size."""
-        dockerignore_path = "/home/user/NHID-Clinical/.dockerignore"
-        assert os.path.exists(dockerignore_path), ".dockerignore not found"
+        dockerignore_path = REPO_ROOT / ".dockerignore"
+        assert dockerignore_path.exists(), ".dockerignore not found"
 
         with open(dockerignore_path) as f:
             content = f.read()
@@ -73,7 +84,7 @@ class TestDockerComposeBuild:
 
     def test_docker_compose_has_nhid_api_service(self):
         """Verify nhid-api service is configured."""
-        compose_path = "/home/user/NHID-Clinical/docker-compose.yml"
+        compose_path = REPO_ROOT / "docker-compose.yml"
 
         with open(compose_path) as f:
             content = f.read()
@@ -83,7 +94,7 @@ class TestDockerComposeBuild:
 
     def test_docker_compose_has_localstack_service(self):
         """Verify LocalStack service is configured for local development."""
-        compose_path = "/home/user/NHID-Clinical/docker-compose.yml"
+        compose_path = REPO_ROOT / "docker-compose.yml"
 
         with open(compose_path) as f:
             content = f.read()
@@ -92,7 +103,7 @@ class TestDockerComposeBuild:
 
     def test_docker_compose_volume_audit_data(self):
         """Verify audit data volume is configured for persistence."""
-        compose_path = "/home/user/NHID-Clinical/docker-compose.yml"
+        compose_path = REPO_ROOT / "docker-compose.yml"
 
         with open(compose_path) as f:
             content = f.read()
@@ -101,7 +112,7 @@ class TestDockerComposeBuild:
 
     def test_docker_compose_environment_variables(self):
         """Verify required environment variables are set."""
-        compose_path = "/home/user/NHID-Clinical/docker-compose.yml"
+        compose_path = REPO_ROOT / "docker-compose.yml"
 
         with open(compose_path) as f:
             content = f.read()
@@ -121,13 +132,13 @@ class TestInitAwsScript:
 
     def test_init_aws_script_exists(self):
         """Verify init-aws.sh exists and is executable."""
-        script_path = "/home/user/NHID-Clinical/scripts/init-aws.sh"
-        assert os.path.exists(script_path), "init-aws.sh not found"
+        script_path = REPO_ROOT / "scripts" / "init-aws.sh"
+        assert script_path.exists(), "init-aws.sh not found"
         assert os.access(script_path, os.X_OK), "init-aws.sh is not executable"
 
     def test_init_aws_script_has_required_steps(self):
         """Verify init-aws.sh has required initialization steps."""
-        script_path = "/home/user/NHID-Clinical/scripts/init-aws.sh"
+        script_path = REPO_ROOT / "scripts" / "init-aws.sh"
 
         with open(script_path) as f:
             content = f.read()


### PR DESCRIPTION
<!--
Thanks for contributing to NHID-Clinical. Keep claims conservative: this is an
open, voluntary reference — not a standard, certification, or production infrastructure.
-->

## Summary

<!-- What does this change, and why? -->

## Type of change

- [ ] Reference implementation / conformance API
- [ ] Conformance tests
- [ ] Adapter (VAPI / Twilio / Vonage / Retell / Connect)
- [ ] NHID-Auth v2 (agent identity)
- [ ] Docs
- [ ] Website
- [ ] Specification / control text

## Checklist

- [ ] `python -m pytest tests/` passes locally
- [ ] Guards pass: `scripts/validate_ci.py`, `scripts/check_baseline.py`, `scripts/check_number_drift.py`
- [ ] No new claims of certification, accredited-standard, or regulatory status
- [ ] Control names and disclaimers are unchanged (or intentionally updated with rationale below)
- [ ] Public claims reviewed against `docs/claim-boundaries.md` and its Maintainer/Reviewer Claims Control (applies to any external-facing artifact: site copy, blog post, abstract, deck, announcement, demo page)

## Notes

<!-- Anything reviewers should know: trade-offs, follow-ups, screenshots. -->
