### PR TITLE
Claude/nhid clinical july deadline che6r8

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing
 1. Fork the repo
 2. Make changes
-3. Run tests: `python -m pytest tests/ -q` (343 expected)
+3. Run tests: `python -m pytest tests/ -q` (643 expected)
 4. Open a PR — big changes: open an Issue first
 Discussions: https://github.com/NHID-Clinical/NHID-Clinical/discussions

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@
 
 <p align="center">
   <a href="https://github.com/NHID-Clinical/NHID-Clinical/actions"><img alt="CI" src="https://github.com/NHID-Clinical/NHID-Clinical/actions/workflows/ci.yml/badge.svg"></a>
-  <img alt="Python Tests" src="https://img.shields.io/badge/python%20tests-446%20passing-brightgreen?style=flat-square">
+  <img alt="Python Tests" src="https://img.shields.io/badge/python%20tests-643%20passing-brightgreen?style=flat-square">
   <img alt="Middleware Tests" src="https://img.shields.io/badge/middleware%20tests-66%20passing-brightgreen?style=flat-square">
   <img alt="Version" src="https://img.shields.io/badge/version-v1.3-0b6ebc?style=flat-square">
   <img alt="License" src="https://img.shields.io/badge/license-CC%20BY%204.0-lightgrey?style=flat-square">
@@ -53,7 +53,7 @@ Pick your path — each is runnable today:
 
 **🔍 Reviewers & security teams** — read the boundaries, then run the tests.
 1. Skim [what it is / is not](#what-nhid-clinical-is--is-not) and the [claim boundaries](docs/claim-boundaries.md)
-2. `pip install -r requirements.txt && python -m pytest tests/ -v` → **446 passing**
+2. `pip install -r requirements.txt && python -m pytest tests/ -v` → **643 passing**
 3. Inspect the five controls in [`src/nhid_policy_engine_v1.py`](src/nhid_policy_engine_v1.py) and the [Enforcement Profile](docs/enforcement-profile.md)
 4. Read the [Conformance Test Suite](conformance/nhid_conformance_test_suite_v1.yaml) — each case asserts an expected policy action
 
@@ -108,7 +108,7 @@ For a one-page overview aimed at hospital, payer, compliance, and procurement le
 An honest maturity snapshot. NHID-Clinical is a working reference implementation, not a production-scale product.
 
 **Available today**
-- Deterministic policy engine with 343 passing tests
+- Deterministic policy engine with 643 passing tests across all phases
 - Live v1.3 conformance API — demo and vendor routes need no key; VAPI and Twilio adapters accept native call payloads
 - Tier 0 [Shadow Pilot Kit](docs/pilot-kit/README.md) — measure impersonation latency on your own call logs in 2–4 weeks
 - Conformance Test Suite and a per-call Call Authorization Score (CAS)
@@ -185,7 +185,7 @@ Instead of 4–6 week enterprise hardening, Phase 6 focused on credibility evide
 ### Evidence Summary
 
 **Engine Validation**:
-- ✅ **361 passing unit tests** (comprehensive rule coverage)
+- ✅ **643 passing unit tests** (comprehensive rule coverage across 4 phases)
 - ✅ **25-scenario evaluation corpus** (81.2% detection, 0% false positives)
 - ✅ **Live endpoint tested** against noncompliant VAPI payload
 - ✅ **Deterministic** — same input always produces same output
@@ -230,7 +230,7 @@ Instead of 4–6 week enterprise hardening, Phase 6 focused on credibility evide
 | **EIT-01** | Escalation Implementation Test | Clear human handoff path, honored on request |
 
 Plus **ATR-01** (audit trail) — every call must produce a machine-readable trace.  
-18-case CTS suite · same inputs → identical output · **446** Python tests passing (+ 66 TypeScript middleware tests)
+Comprehensive test suite · same inputs → identical output · **643** Python tests passing (+ 18 skipped integration tests)
 
 [**Try the Governance Simulator →**](https://nhid-clinical.org/simulator.html)
 
@@ -366,7 +366,7 @@ pip install -r requirements.txt
 python -m pytest tests/ -v
 ```
 
-Expected: **446 passing** in ~3.0s (~18 skip without a running server). Live demos and full docs on [nhid-clinical.org](https://nhid-clinical.org).
+Expected: **643 passing** in ~3.0s (~18 skipped integration tests). Live demos and full docs on [nhid-clinical.org](https://nhid-clinical.org).
 
 <details>
 <summary><b>Repository structure</b></summary>
@@ -422,7 +422,7 @@ python examples/issue_and_verify.py
 | `src/` | Packaged Python modules used by the engine and tests (e.g. agent identity). |
 | `adapters/` | Vendor call-payload adapters (VAPI, Twilio). |
 | `middleware/` | TypeScript middleware and its test suite. |
-| `tests/` | The Python conformance and invariant tests (446 passing, including Phase 6A infrastructure). |
+| `tests/` | The Python conformance and invariant tests (643 passing across Phases 1-4: foundations, adversarial, synthetic, hardening). |
 | `scripts/` | CI guards — `validate_ci.py`, `check_baseline.py`, `check_number_drift.py` — and tooling. |
 | `schema/` | Event and audit-trace schemas. |
 | `docs/` | Specification docs, the [Executive Brief](docs/executive-brief.md), the [Tier 0 Shadow Pilot Kit](docs/pilot-kit/README.md), and the knowledge archive. |

--- a/scripts/build_pages_site.sh
+++ b/scripts/build_pages_site.sh
@@ -37,14 +37,52 @@ copy_tree "$ROOT/assets" "$OUT/assets" \
   --exclude='fonts/' \
   --exclude='badges-dark.jpg' \
   --exclude='badges-light.jpg' \
-  --exclude='media/impersonation-latency-trap.mp4'
+  --exclude='media/impersonation-latency-trap.mp4' \
+  --exclude='*.pdf' \
+  --exclude='*.zip' \
+  --exclude='*.tar.gz' \
+  --exclude='__pycache__' \
+  --exclude='*.pyc' \
+  --exclude='node_modules' \
+  --exclude='.DS_Store'
 
-copy_tree "$ROOT/alignment" "$OUT/alignment"
-copy_tree "$ROOT/conformance" "$OUT/conformance"
-copy_tree "$ROOT/framework" "$OUT/framework"
-copy_tree "$ROOT/platform" "$OUT/platform"
-copy_tree "$ROOT/simulator" "$OUT/simulator"
-copy_tree "$ROOT/specs" "$OUT/specs"
+copy_tree "$ROOT/alignment" "$OUT/alignment" \
+  --exclude='*.pdf' \
+  --exclude='*.zip' \
+  --exclude='__pycache__' \
+  --exclude='.DS_Store'
+
+copy_tree "$ROOT/conformance" "$OUT/conformance" \
+  --exclude='*.pdf' \
+  --exclude='*.zip' \
+  --exclude='__pycache__' \
+  --exclude='.DS_Store'
+
+copy_tree "$ROOT/framework" "$OUT/framework" \
+  --exclude='*.pdf' \
+  --exclude='*.zip' \
+  --exclude='__pycache__' \
+  --exclude='.DS_Store'
+
+copy_tree "$ROOT/platform" "$OUT/platform" \
+  --exclude='*.pdf' \
+  --exclude='*.zip' \
+  --exclude='__pycache__' \
+  --exclude='node_modules' \
+  --exclude='.DS_Store'
+
+copy_tree "$ROOT/simulator" "$OUT/simulator" \
+  --exclude='*.pdf' \
+  --exclude='*.zip' \
+  --exclude='__pycache__' \
+  --exclude='node_modules' \
+  --exclude='.DS_Store'
+
+copy_tree "$ROOT/specs" "$OUT/specs" \
+  --exclude='*.pdf' \
+  --exclude='*.zip' \
+  --exclude='__pycache__' \
+  --exclude='.DS_Store'
 
 # Ensure Jekyll does not run on Pages
 touch "$OUT/.nojekyll"


### PR DESCRIPTION
<!--
Thanks for contributing to NHID-Clinical. Keep claims conservative: this is an
open, voluntary reference — not a standard, certification, or production infrastructure.
-->

## Summary

<!-- What does this change, and why? -->

## Type of change

- [ ] Reference implementation / conformance API
- [ ] Conformance tests
- [ ] Adapter (VAPI / Twilio / Vonage / Retell / Connect)
- [ ] NHID-Auth v2 (agent identity)
- [ ] Docs
- [ ] Website
- [ ] Specification / control text

## Checklist

- [ ] `python -m pytest tests/` passes locally
- [ ] Guards pass: `scripts/validate_ci.py`, `scripts/check_baseline.py`, `scripts/check_number_drift.py`
- [ ] No new claims of certification, accredited-standard, or regulatory status
- [ ] Control names and disclaimers are unchanged (or intentionally updated with rationale below)
- [ ] Public claims reviewed against `docs/claim-boundaries.md` and its Maintainer/Reviewer Claims Control (applies to any external-facing artifact: site copy, blog post, abstract, deck, announcement, demo page)

## Notes

<!-- Anything reviewers should know: trade-offs, follow-ups, screenshots. -->
