### PR TITLE
Disclosure timeliness bands, pilot funnel fixes, and ops docs

### DIFF
--- a/about.html
+++ b/about.html
@@ -71,6 +71,7 @@
           <a href="/evidence-pack.html">Evidence Pack</a>
           <a href="/shadow-evaluation-guide.html">Shadow Evaluation Guide</a>
           <a href="/for-payers.html">For Payers</a>
+          <a href="/community.html">Community</a>
           <a href="/roadmap.html">Roadmap</a>
           <a href="/news.html">News</a>
           <a href="/faq.html">FAQ</a>
@@ -137,6 +138,7 @@
   <a href="/evidence-pack.html">Evidence Pack</a>
   <a href="/shadow-evaluation-guide.html">Shadow Evaluation Guide</a>
   <a href="/for-payers.html">For Payers</a>
+  <a href="/community.html">Community</a>
   <a href="/roadmap.html">Roadmap</a>
   <a href="/news.html">News</a>
   <a href="/faq.html">FAQ</a>

--- a/community.html
+++ b/community.html
@@ -3,8 +3,8 @@
 <head>
   <meta charset="utf-8"/>
   <meta name="viewport" content="width=device-width, initial-scale=1"/>
-  <meta name="description" content="NHID-Clinical privacy policy, including SMS/mobile messaging terms for the starter-pack text program."/>
-  <title>Privacy Policy | NHID-Clinical</title>
+  <meta name="description" content="NHID-Clinical Community — how to contribute, ask questions, report findings, and become a shadow evaluation partner."/>
+  <title>Community | NHID-Clinical</title>
   <script>try{document.documentElement.setAttribute('data-theme',localStorage.getItem('nhid-theme')||'light')}catch(e){}</script>
   <link rel="icon" href="/assets/brand/favicon.svg" type="image/svg+xml"/>
   <link rel="icon" href="/assets/brand-icon.png" type="image/png"/>
@@ -19,6 +19,7 @@
 <div class="status-strip">
   <span class="status-strip-inner"><strong>Open governance framework · v1.3</strong> · Practitioner-led · not an accredited standard, certification, or regulatory requirement · seeking shadow-evaluation partners</span>
 </div>
+
 
 <header class="site-header">
   <nav class="container nav" aria-label="Primary navigation">
@@ -160,59 +161,69 @@
   <section class="inner-hero" style="position:relative;overflow:clip">
     <div class="hero-glow" aria-hidden="true"></div>
     <div class="container" style="position:relative;z-index:1">
-      <div class="crumbs"><a href="/">Home</a><span>/</span><span>Privacy Policy</span></div>
-      <h1 class="reveal">Privacy Policy</h1>
-      <p class="lede reveal">How NHID-Clinical handles the limited personal information collected through this website.</p>
+      <div class="crumbs"><a href="/">Home</a><span>/</span><span>Community</span></div>
+      <p class="eyebrow">Get Involved</p>
+      <h1 class="reveal">Community</h1>
+      <p class="lede reveal">NHID-Clinical is an open proposal, not a finished standard. The most useful thing you can do is tell us where it is wrong.</p>
     </div>
   </section>
 
   <section class="page-section">
-    <div class="container" style="max-width:760px">
-      <div class="card" style="line-height:1.7">
-        <p><strong>Last updated:</strong> June 20, 2026</p>
+    <div class="container" style="max-width:860px">
 
-        <h3>Who we are</h3>
-        <p>NHID-Clinical is an open proposal operated by Brianna Baynard. You can reach us at
-          <a href="mailto:contact@nhid-clinical.org">contact@nhid-clinical.org</a>.</p>
-
-        <h3>Information we collect</h3>
-        <p>We collect only what you submit to use a specific feature: a phone number when you
-          request a demo call or the starter-pack text, and a CAPTCHA token used solely to deter
-          automated abuse. We do not require accounts and we do not collect health information
-          through this website.</p>
-
-        <h3>How we use it</h3>
-        <p>We use your phone number only to perform the action you requested — placing the demo
-          call, or sending the one-time starter-pack text. We apply per-number and per-IP rate
-          limits to prevent abuse.</p>
-
-        <h3 id="sms">SMS / mobile messaging terms</h3>
-        <p>If you opt in to the starter-pack text program — by checking the consent box on our
-          <a href="/sms-opt-in.html">opt-in form</a> or by pressing the corresponding key on our
-          demo phone line — you agree to receive a one-time SMS containing your starter-pack link.</p>
-        <ul>
-          <li><strong>We do not share or sell your mobile opt-in information or consent to any third parties.</strong></li>
-          <li>Message frequency: one message per request.</li>
-          <li>Message and data rates may apply.</li>
-          <li>Reply <strong>STOP</strong> to opt out at any time; reply <strong>HELP</strong> for help.</li>
-          <li>Carriers are not liable for delayed or undelivered messages.</li>
-        </ul>
-
-        <h3>Data retention</h3>
-        <p>Rate-limit and demo-status records are stored transiently and automatically expire
-          (typically within one hour). We do not maintain a marketing list from these requests.</p>
-
-        <h3>Your choices</h3>
-        <p>You can opt out of texts at any time by replying STOP. For any other request regarding
-          your information, email <a href="mailto:contact@nhid-clinical.org">contact@nhid-clinical.org</a>.</p>
-
-        <h3>Changes</h3>
-        <p>We may update this policy; material changes will be reflected by the "Last updated" date above.</p>
+      <h2>Where the conversation happens</h2>
+      <p style="color:var(--body);line-height:1.85">Everything is public. There is no mailing list to join and nothing gated behind a form.</p>
+      <div class="content-cards" style="grid-template-columns:repeat(auto-fit,minmax(16rem,1fr));margin-top:1.25rem">
+        <div class="content-card">
+          <h3>Discussions</h3>
+          <p style="color:var(--body);font-size:.93rem;line-height:1.75">Open questions, disagreements about the controls, and "has anyone seen this in the wild" reports.</p>
+          <a class="primary-pill" href="https://github.com/NHID-Clinical/NHID-Clinical/discussions" target="_blank" rel="noopener noreferrer">Open Discussions &#x2197;</a>
+        </div>
+        <div class="content-card">
+          <h3>Issues</h3>
+          <p style="color:var(--body);font-size:.93rem;line-height:1.75">Specification defects, reference-implementation bugs, and concrete change proposals.</p>
+          <a class="primary-pill" href="https://github.com/NHID-Clinical/NHID-Clinical/issues" target="_blank" rel="noopener noreferrer">Open Issues &#x2197;</a>
+        </div>
       </div>
+
+      <h2 style="margin-top:2.5rem">Run a shadow evaluation</h2>
+      <p style="color:var(--body);line-height:1.85">The single most valuable contribution is measurement against real traffic. A Tier&#8209;0 shadow evaluation is observe&#8209;only: nothing is enforced, no vendor changes are required, and you keep your own data. It is a 90&#8209;day engagement whose technical core is a 2&#8209;4 week measurement sprint using the <a href="https://github.com/NHID-Clinical/NHID-Clinical/tree/main/docs/pilot-kit" style="color:var(--teal-bright);font-weight:600" target="_blank" rel="noopener noreferrer">Shadow Pilot Kit</a>.</p>
+      <p style="color:var(--body);line-height:1.85">We are actively looking for the first partners. If that might be your organization, book a conversation &mdash; it is the fastest way to find out whether this is a fit.</p>
+      <div style="display:flex;gap:.75rem;flex-wrap:wrap;margin-top:1.25rem">
+        <a class="primary-pill" href="https://calendar.app.google/1AKD4ysBe4ZwH9iv6" target="_blank" rel="noopener noreferrer">Book a 30-minute call &rarr;</a>
+        <a class="primary-pill" href="/for-payers.html" style="background:transparent;border:1px solid var(--border);color:var(--ink)">Read the payer guide</a>
+      </div>
+
+      <h2 style="margin-top:2.5rem">Contribute to the specification</h2>
+      <ul style="color:var(--body);line-height:1.9">
+        <li><b>Challenge a control.</b> If IDG&#8209;01, PDX&#8209;01, DBC&#8209;01, EIT&#8209;01 or ATR&#8209;01 does not survive contact with your workflow, that is worth an Issue.</li>
+        <li><b>Bring counter-examples.</b> Call patterns the heuristics misclassify are more useful than agreement.</li>
+        <li><b>Port an adapter.</b> Six vendor adapters exist; a seventh for your platform is a self-contained contribution.</li>
+        <li><b>Review the claim boundaries.</b> If anything on this site overclaims, say so &mdash; see <a href="https://github.com/NHID-Clinical/NHID-Clinical/blob/main/docs/claim-boundaries.md" style="color:var(--teal-bright);font-weight:600" target="_blank" rel="noopener noreferrer">claim-boundaries.md</a>.</li>
+      </ul>
+
+      <div class="callout" style="margin-top:2rem;border:1px solid var(--border);border-radius:8px;padding:1.25rem 1.5rem;background:var(--paper)">
+        <p style="margin:0;color:var(--body);font-size:.93rem;line-height:1.75"><b>Honest status.</b> NHID-Clinical is a practitioner-led open proposal under CC BY 4.0. It is not an accredited standard, a certification program, or a regulatory requirement, and there is no external certification authority. Conformance testing is self-administered.</p>
+      </div>
+
     </div>
   </section>
 </main>
 
+</main>
+
+<section class="page-cta">
+  <div class="container">
+    <h2>Where to go next</h2>
+    <p>Four ways into NHID-Clinical, whatever you came to do.</p>
+    <div class="page-cta-grid">
+      <a class="page-cta-card" href="/specification.html"><b>Read the Specification <span class="arr">&rarr;</span></b><span>The v1.3 controls, in full.</span></a>
+      <a class="page-cta-card" href="/simulator.html"><b>Try the Simulator <span class="arr">&rarr;</span></b><span>Run the controls on call scenarios.</span></a>
+      <a class="page-cta-card" href="/evidence-pack.html"><b>Review the Evidence Pack <span class="arr">&rarr;</span></b><span>Guarantees, a failure trace, the audit model.</span></a>
+      <a class="page-cta-card" href="https://github.com/NHID-Clinical/NHID-Clinical/discussions" target="_blank" rel="noopener noreferrer"><b>Join the Community <span class="arr">&#x2197;</span></b><span>Questions and feedback on GitHub.</span></a>
+    </div>
+  </div>
+</section>
 <footer id="contact" class="site-footer">
   <div class="container footer-inner">
     <p>© 2026 Brianna Baynard | NIST-2025-0035-0026 | CC BY 4.0</p>

--- a/corpus_evaluation_output/corpus_metrics.json
+++ b/corpus_evaluation_output/corpus_metrics.json
@@ -1,5 +1,5 @@
 {
-  "timestamp": "2026-08-14T03:29:54.966028",
+  "timestamp": "2026-08-14T12:12:14.116343",
   "corpus_size": 150,
   "evaluated_sessions": 150,
   "per_control_metrics": {

--- a/demo.html
+++ b/demo.html
@@ -72,6 +72,7 @@
           <a href="/evidence-pack.html">Evidence Pack</a>
           <a href="/shadow-evaluation-guide.html">Shadow Evaluation Guide</a>
           <a href="/for-payers.html">For Payers</a>
+          <a href="/community.html">Community</a>
           <a href="/roadmap.html">Roadmap</a>
           <a href="/news.html">News</a>
           <a href="/faq.html">FAQ</a>
@@ -138,6 +139,7 @@
   <a href="/evidence-pack.html">Evidence Pack</a>
   <a href="/shadow-evaluation-guide.html">Shadow Evaluation Guide</a>
   <a href="/for-payers.html">For Payers</a>
+  <a href="/community.html">Community</a>
   <a href="/roadmap.html">Roadmap</a>
   <a href="/news.html">News</a>
   <a href="/faq.html">FAQ</a>

--- a/developers.html
+++ b/developers.html
@@ -72,6 +72,7 @@
           <a href="/evidence-pack.html">Evidence Pack</a>
           <a href="/shadow-evaluation-guide.html">Shadow Evaluation Guide</a>
           <a href="/for-payers.html">For Payers</a>
+          <a href="/community.html">Community</a>
           <a href="/roadmap.html">Roadmap</a>
           <a href="/news.html">News</a>
           <a href="/faq.html">FAQ</a>
@@ -138,6 +139,7 @@
   <a href="/evidence-pack.html">Evidence Pack</a>
   <a href="/shadow-evaluation-guide.html">Shadow Evaluation Guide</a>
   <a href="/for-payers.html">For Payers</a>
+  <a href="/community.html">Community</a>
   <a href="/roadmap.html">Roadmap</a>
   <a href="/news.html">News</a>
   <a href="/faq.html">FAQ</a>

--- a/docs/nhid-clinical-technical-specification.md
+++ b/docs/nhid-clinical-technical-specification.md
@@ -99,6 +99,15 @@ Both anchors are required ATR-01 event fields, so IL is computable from any conf
 trail with no human judgment involved — this determinism is what makes IL usable as a
 machine-scored metric rather than a subjective call-quality impression.
 
+**The time form is a measurement, not a gate.** No control in this specification imposes a
+seconds-based disclosure deadline, and the policy engine performs no elapsed-time arithmetic:
+IDG-01 is satisfied by the presence of a disclosure with assertion text, and PDX-01 by disclosure
+preceding PHI. The normative target is the turn form, `IL(turns) = 0`. Pilot reporting buckets the
+seconds form into timeliness bands (pass / delayed / late / critical — see the
+[Shadow Pilot Kit](pilot-kit/README.md)) so that a slow-but-present disclosure can be
+distinguished from no disclosure at all. Those bands are a scoring convention for reports; they
+do not relax, extend, or override the control.
+
 ## 3. ATR-01 audit structure
 
 ATR-01 (Audit Trail Requirements) is enforced structurally rather than behaviorally: every NHID

--- a/docs/pilot-kit/README.md
+++ b/docs/pilot-kit/README.md
@@ -23,6 +23,25 @@ pip install -r requirements.txt
 python docs/pilot-kit/measure_pilot.py --demo
 ```
 
+## Disclosure timeliness bands
+
+Impersonation Latency is reported as a raw measurement *and* bucketed into four bands, so a
+delayed-but-present disclosure is not flattened into the same bucket as never disclosing at all.
+
+| Band | Disclosure | Reported as |
+| :--- | :--- | :--- |
+| `pass` | turn 0, before any data request | conformant |
+| `delayed` | present, within 10s, before any PHI | observation |
+| `late` | present, after 10s, before any PHI | human review |
+| `critical` | PHI exchanged before disclosure, or never disclosed | violation |
+
+**These bands are a reporting convention, not a gate.** The policy engine has no seconds-based
+rule; every pass/fail verdict still comes from `evaluate_all()`. The normative target remains
+`IL(turns) = 0` — disclosure before any data is requested. The 10-second threshold exists so that
+an agent which disclosed a little slowly reads differently in a pilot report from one that never
+disclosed. Where a capture source has no usable timestamps, classification falls back to the turn
+form.
+
 ## What Tier 0 measures
 
 - **Impersonation Latency** — time and turns until the first valid non-human

--- a/docs/pilot-kit/measure_pilot.py
+++ b/docs/pilot-kit/measure_pilot.py
@@ -181,6 +181,9 @@ def measure_call(session_id: str, records: list[dict]) -> dict:
         "turns": len(records),
         "impersonation_latency_turns": il_turns,
         "impersonation_latency_seconds": il_seconds,
+        "disclosure_band": classify_disclosure_band(
+            disclosure_rec is not None, il_turns, il_seconds, pre_disclosure_phi
+        ),
         "disclosed": disclosure_rec is not None,
         "first_turn_disclosure": il_turns == 0,
         "pre_disclosure_phi_fields": pre_disclosure_phi,
@@ -191,6 +194,52 @@ def measure_call(session_id: str, records: list[dict]) -> dict:
         "conformant": not violated_rules,
         "cas": cas,
     }
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Disclosure timeliness bands (REPORTING ONLY)
+# ──────────────────────────────────────────────────────────────────────────
+#
+# These bands classify how promptly disclosure happened. They are a scoring
+# convention for pilot reports — they do NOT gate anything. Every pass/fail
+# verdict in this file still comes from evaluate_all(); nothing below is fed
+# back into the engine, and the engine has no seconds-based rule.
+#
+# The normative target remains IL(turns) = 0 (disclosure before any data
+# request). The seconds threshold exists so a delayed-but-present disclosure
+# can be reported as an observation rather than being flattened into the same
+# bucket as never disclosing at all.
+
+DISCLOSURE_DELAY_SECONDS = 10.0
+
+DISCLOSURE_BANDS = {
+    "pass":     "Disclosed at turn 0, before any data request",
+    "delayed":  f"Disclosed within {DISCLOSURE_DELAY_SECONDS:.0f}s, before any PHI",
+    "late":     f"Disclosed after {DISCLOSURE_DELAY_SECONDS:.0f}s, before any PHI",
+    "critical": "PHI exchanged before disclosure, or never disclosed",
+}
+
+
+def classify_disclosure_band(
+    disclosed: bool,
+    il_turns: int | None,
+    il_seconds: float | None,
+    pre_disclosure_phi: int,
+) -> str:
+    """Bucket a call's disclosure timeliness. Reporting only — never a gate.
+
+    Falls back to the turn form when timestamps are absent, because seconds
+    are not uniformly available across capture sources.
+    """
+    if not disclosed or pre_disclosure_phi > 0:
+        return "critical"
+    if il_turns == 0:
+        return "pass"
+    if il_seconds is None:
+        # No time anchor: turn 0 already handled above, so anything later is
+        # reported as delayed rather than guessed at.
+        return "delayed"
+    return "delayed" if il_seconds <= DISCLOSURE_DELAY_SECONDS else "late"
 
 
 # ──────────────────────────────────────────────────────────────────────────
@@ -218,6 +267,7 @@ def aggregate(calls: list[dict]) -> dict:
             violation_counts[rule] += 1
 
     tier_counts: Counter = Counter(c["cas"]["tier"] for c in calls)
+    band_counts: Counter = Counter(c["disclosure_band"] for c in calls)
     requested = sum(c["escalations_requested"] for c in calls)
     honored = sum(c["escalations_honored"] for c in calls)
 
@@ -225,6 +275,7 @@ def aggregate(calls: list[dict]) -> dict:
         "calls_total": total,
         "median_impersonation_latency_turns": median(il_turn_values),
         "median_impersonation_latency_seconds": median(il_sec_values),
+        "disclosure_bands": {b: band_counts.get(b, 0) for b in DISCLOSURE_BANDS},
         "first_turn_disclosure_rate": (
             sum(1 for c in calls if c["first_turn_disclosure"]) / total if total else 0.0
         ),
@@ -257,6 +308,8 @@ def print_summary(summary: dict) -> None:
     print(f"Calls w/ pre-disclosure PHI:   {summary['calls_with_pre_disclosure_phi_rate']:.1%}")
     ehr = summary["escalation_honor_rate"]
     print(f"Escalation honor rate:         {f'{ehr:.1%}' if ehr is not None else 'n/a (none requested)'}")
+    print("Disclosure bands:              "
+          + ", ".join(f"{b}: {n}" for b, n in summary["disclosure_bands"].items()))
     print(f"Average CAS:                   {summary['average_cas']:.4f}")
     print("CAS tiers:                     "
           + ", ".join(f"{t}: {n}" for t, n in sorted(summary["cas_tier_distribution"].items())))

--- a/docs/pilot-kit/pilot-report-template.md
+++ b/docs/pilot-kit/pilot-report-template.md
@@ -20,6 +20,20 @@
 | Calls with pre-disclosure PHI | XX% |
 | Escalation honor rate | XX% |
 | Average CAS | 0.XX |
+| Disclosure bands (pass / delayed / late / critical) | X / X / X / X |
+
+## Disclosure timeliness
+
+| Band | Definition | Calls | % |
+| :--- | :--- | ---: | ---: |
+| Pass | Disclosed at turn 0, before any data request | | |
+| Delayed | Disclosed within 10s, before any PHI | | |
+| Late | Disclosed after 10s, before any PHI | | |
+| Critical | PHI exchanged before disclosure, or never disclosed | | |
+
+Bands are a reporting convention, not an enforcement threshold — the normative target is
+`IL(turns) = 0`. Use this table to separate agents that disclose slowly from agents that do not
+disclose at all; they warrant different conversations with the vendor.
 
 ## CAS trust-tier distribution
 

--- a/evidence-pack.html
+++ b/evidence-pack.html
@@ -89,6 +89,7 @@
           <a href="/evidence-pack.html">Evidence Pack</a>
           <a href="/shadow-evaluation-guide.html">Shadow Evaluation Guide</a>
           <a href="/for-payers.html">For Payers</a>
+          <a href="/community.html">Community</a>
           <a href="/roadmap.html">Roadmap</a>
           <a href="/news.html">News</a>
           <a href="/faq.html">FAQ</a>
@@ -155,6 +156,7 @@
   <a href="/evidence-pack.html">Evidence Pack</a>
   <a href="/shadow-evaluation-guide.html">Shadow Evaluation Guide</a>
   <a href="/for-payers.html">For Payers</a>
+  <a href="/community.html">Community</a>
   <a href="/roadmap.html">Roadmap</a>
   <a href="/news.html">News</a>
   <a href="/faq.html">FAQ</a>

--- a/faq.html
+++ b/faq.html
@@ -71,6 +71,7 @@
           <a href="/evidence-pack.html">Evidence Pack</a>
           <a href="/shadow-evaluation-guide.html">Shadow Evaluation Guide</a>
           <a href="/for-payers.html">For Payers</a>
+          <a href="/community.html">Community</a>
           <a href="/roadmap.html">Roadmap</a>
           <a href="/news.html">News</a>
           <a href="/faq.html">FAQ</a>
@@ -137,6 +138,7 @@
   <a href="/evidence-pack.html">Evidence Pack</a>
   <a href="/shadow-evaluation-guide.html">Shadow Evaluation Guide</a>
   <a href="/for-payers.html">For Payers</a>
+  <a href="/community.html">Community</a>
   <a href="/roadmap.html">Roadmap</a>
   <a href="/news.html">News</a>
   <a href="/faq.html">FAQ</a>

--- a/for-payers.html
+++ b/for-payers.html
@@ -123,6 +123,7 @@
           <a href="/evidence-pack.html">Evidence Pack</a>
           <a href="/shadow-evaluation-guide.html">Shadow Evaluation Guide</a>
           <a href="/for-payers.html">For Payers</a>
+          <a href="/community.html">Community</a>
           <a href="/roadmap.html">Roadmap</a>
           <a href="/news.html">News</a>
           <a href="/faq.html">FAQ</a>
@@ -189,6 +190,7 @@
   <a href="/evidence-pack.html">Evidence Pack</a>
   <a href="/shadow-evaluation-guide.html">Shadow Evaluation Guide</a>
   <a href="/for-payers.html">For Payers</a>
+  <a href="/community.html">Community</a>
   <a href="/roadmap.html">Roadmap</a>
   <a href="/news.html">News</a>
   <a href="/faq.html">FAQ</a>
@@ -231,7 +233,7 @@
       <div class="pilot-banner" style="background:linear-gradient(135deg,var(--blue-soft),var(--teal-soft));border:1px solid var(--line);border-radius:1rem;padding:1.5rem 2rem;display:flex;align-items:center;gap:1.5rem;flex-wrap:wrap">
         <div style="flex:1;min-width:14rem">
           <strong style="display:block;font-size:1rem;color:var(--ink);margin-bottom:.25rem">Interested in becoming a pilot partner?</strong>
-          <p style="margin:0;font-size:.9rem;color:var(--ink-soft);line-height:1.6">We are actively seeking payer and provider organizations for the 90-day shadow evaluation below. You would be among the first.</p>
+          <p style="margin:0;font-size:.9rem;color:var(--ink-soft);line-height:1.6">We are actively seeking payer and provider organizations for the 90-day shadow evaluation below &mdash; its technical core is a 2&#8209;4 week measurement sprint. You would be among the first.</p>
         </div>
         <a class="cta-button" href="mailto:contact@nhid-clinical.org" style="flex-shrink:0;white-space:nowrap">Get in Touch <span aria-hidden="true">→</span></a>
       </div>
@@ -373,7 +375,7 @@
         <h2>Read the specification. Share what you think.</h2>
         <p>Whether it is right, wrong, incomplete, or misses the real problem — that feedback shapes the next version.</p>
       </div>
-      <a class="closing-button" href="/for-payers.html">Start a pilot →</a>
+      <a class="closing-button" href="https://calendar.app.google/1AKD4ysBe4ZwH9iv6" target="_blank" rel="noopener noreferrer">Book a 30-minute call →</a>
     </div>
   </section>
 </main>

--- a/framework/conformance-suite.html
+++ b/framework/conformance-suite.html
@@ -72,6 +72,7 @@
           <a href="/evidence-pack.html">Evidence Pack</a>
           <a href="/shadow-evaluation-guide.html">Shadow Evaluation Guide</a>
           <a href="/for-payers.html">For Payers</a>
+          <a href="/community.html">Community</a>
           <a href="/roadmap.html">Roadmap</a>
           <a href="/news.html">News</a>
           <a href="/faq.html">FAQ</a>
@@ -138,6 +139,7 @@
   <a href="/evidence-pack.html">Evidence Pack</a>
   <a href="/shadow-evaluation-guide.html">Shadow Evaluation Guide</a>
   <a href="/for-payers.html">For Payers</a>
+  <a href="/community.html">Community</a>
   <a href="/roadmap.html">Roadmap</a>
   <a href="/news.html">News</a>
   <a href="/faq.html">FAQ</a>

--- a/framework/controls.html
+++ b/framework/controls.html
@@ -72,6 +72,7 @@
           <a href="/evidence-pack.html">Evidence Pack</a>
           <a href="/shadow-evaluation-guide.html">Shadow Evaluation Guide</a>
           <a href="/for-payers.html">For Payers</a>
+          <a href="/community.html">Community</a>
           <a href="/roadmap.html">Roadmap</a>
           <a href="/news.html">News</a>
           <a href="/faq.html">FAQ</a>
@@ -138,6 +139,7 @@
   <a href="/evidence-pack.html">Evidence Pack</a>
   <a href="/shadow-evaluation-guide.html">Shadow Evaluation Guide</a>
   <a href="/for-payers.html">For Payers</a>
+  <a href="/community.html">Community</a>
   <a href="/roadmap.html">Roadmap</a>
   <a href="/news.html">News</a>
   <a href="/faq.html">FAQ</a>

--- a/framework/index.html
+++ b/framework/index.html
@@ -72,6 +72,7 @@
           <a href="/evidence-pack.html">Evidence Pack</a>
           <a href="/shadow-evaluation-guide.html">Shadow Evaluation Guide</a>
           <a href="/for-payers.html">For Payers</a>
+          <a href="/community.html">Community</a>
           <a href="/roadmap.html">Roadmap</a>
           <a href="/news.html">News</a>
           <a href="/faq.html">FAQ</a>
@@ -138,6 +139,7 @@
   <a href="/evidence-pack.html">Evidence Pack</a>
   <a href="/shadow-evaluation-guide.html">Shadow Evaluation Guide</a>
   <a href="/for-payers.html">For Payers</a>
+  <a href="/community.html">Community</a>
   <a href="/roadmap.html">Roadmap</a>
   <a href="/news.html">News</a>
   <a href="/faq.html">FAQ</a>

--- a/framework/nhid-auth.html
+++ b/framework/nhid-auth.html
@@ -72,6 +72,7 @@
           <a href="/evidence-pack.html">Evidence Pack</a>
           <a href="/shadow-evaluation-guide.html">Shadow Evaluation Guide</a>
           <a href="/for-payers.html">For Payers</a>
+          <a href="/community.html">Community</a>
           <a href="/roadmap.html">Roadmap</a>
           <a href="/news.html">News</a>
           <a href="/faq.html">FAQ</a>
@@ -138,6 +139,7 @@
   <a href="/evidence-pack.html">Evidence Pack</a>
   <a href="/shadow-evaluation-guide.html">Shadow Evaluation Guide</a>
   <a href="/for-payers.html">For Payers</a>
+  <a href="/community.html">Community</a>
   <a href="/roadmap.html">Roadmap</a>
   <a href="/news.html">News</a>
   <a href="/faq.html">FAQ</a>

--- a/framework/reference-implementation.html
+++ b/framework/reference-implementation.html
@@ -72,6 +72,7 @@
           <a href="/evidence-pack.html">Evidence Pack</a>
           <a href="/shadow-evaluation-guide.html">Shadow Evaluation Guide</a>
           <a href="/for-payers.html">For Payers</a>
+          <a href="/community.html">Community</a>
           <a href="/roadmap.html">Roadmap</a>
           <a href="/news.html">News</a>
           <a href="/faq.html">FAQ</a>
@@ -138,6 +139,7 @@
   <a href="/evidence-pack.html">Evidence Pack</a>
   <a href="/shadow-evaluation-guide.html">Shadow Evaluation Guide</a>
   <a href="/for-payers.html">For Payers</a>
+  <a href="/community.html">Community</a>
   <a href="/roadmap.html">Roadmap</a>
   <a href="/news.html">News</a>
   <a href="/faq.html">FAQ</a>

--- a/identity-layer.html
+++ b/identity-layer.html
@@ -71,6 +71,7 @@
           <a href="/evidence-pack.html">Evidence Pack</a>
           <a href="/shadow-evaluation-guide.html">Shadow Evaluation Guide</a>
           <a href="/for-payers.html">For Payers</a>
+          <a href="/community.html">Community</a>
           <a href="/roadmap.html">Roadmap</a>
           <a href="/news.html">News</a>
           <a href="/faq.html">FAQ</a>
@@ -137,6 +138,7 @@
   <a href="/evidence-pack.html">Evidence Pack</a>
   <a href="/shadow-evaluation-guide.html">Shadow Evaluation Guide</a>
   <a href="/for-payers.html">For Payers</a>
+  <a href="/community.html">Community</a>
   <a href="/roadmap.html">Roadmap</a>
   <a href="/news.html">News</a>
   <a href="/faq.html">FAQ</a>

--- a/implementation-review.html
+++ b/implementation-review.html
@@ -71,6 +71,7 @@
           <a href="/evidence-pack.html">Evidence Pack</a>
           <a href="/shadow-evaluation-guide.html">Shadow Evaluation Guide</a>
           <a href="/for-payers.html">For Payers</a>
+          <a href="/community.html">Community</a>
           <a href="/roadmap.html">Roadmap</a>
           <a href="/news.html">News</a>
           <a href="/faq.html">FAQ</a>
@@ -137,6 +138,7 @@
   <a href="/evidence-pack.html">Evidence Pack</a>
   <a href="/shadow-evaluation-guide.html">Shadow Evaluation Guide</a>
   <a href="/for-payers.html">For Payers</a>
+  <a href="/community.html">Community</a>
   <a href="/roadmap.html">Roadmap</a>
   <a href="/news.html">News</a>
   <a href="/faq.html">FAQ</a>

--- a/index.html
+++ b/index.html
@@ -71,6 +71,7 @@
           <a href="/evidence-pack.html">Evidence Pack</a>
           <a href="/shadow-evaluation-guide.html">Shadow Evaluation Guide</a>
           <a href="/for-payers.html">For Payers</a>
+          <a href="/community.html">Community</a>
           <a href="/roadmap.html">Roadmap</a>
           <a href="/faq.html">FAQ</a>
           <a href="https://ai-governance-map.vercel.app/" target="_blank" rel="noopener noreferrer">AI Governance Map &#x2197;</a>
@@ -135,6 +136,7 @@
   <a href="/evidence-pack.html">Evidence Pack</a>
   <a href="/shadow-evaluation-guide.html">Shadow Evaluation Guide</a>
   <a href="/for-payers.html">For Payers</a>
+  <a href="/community.html">Community</a>
   <a href="/roadmap.html">Roadmap</a>
   <a href="/faq.html">FAQ</a>
   <a href="https://ai-governance-map.vercel.app/" target="_blank" rel="noopener noreferrer">AI Governance Map &#x2197;</a>

--- a/interoperability.html
+++ b/interoperability.html
@@ -70,6 +70,7 @@
           <a href="/evidence-pack.html">Evidence Pack</a>
           <a href="/shadow-evaluation-guide.html">Shadow Evaluation Guide</a>
           <a href="/for-payers.html">For Payers</a>
+          <a href="/community.html">Community</a>
           <a href="/roadmap.html">Roadmap</a>
           <a href="/news.html">News</a>
           <a href="/faq.html">FAQ</a>
@@ -136,6 +137,7 @@
   <a href="/evidence-pack.html">Evidence Pack</a>
   <a href="/shadow-evaluation-guide.html">Shadow Evaluation Guide</a>
   <a href="/for-payers.html">For Payers</a>
+  <a href="/community.html">Community</a>
   <a href="/roadmap.html">Roadmap</a>
   <a href="/news.html">News</a>
   <a href="/faq.html">FAQ</a>

--- a/news.html
+++ b/news.html
@@ -71,6 +71,7 @@
           <a href="/evidence-pack.html">Evidence Pack</a>
           <a href="/shadow-evaluation-guide.html">Shadow Evaluation Guide</a>
           <a href="/for-payers.html">For Payers</a>
+          <a href="/community.html">Community</a>
           <a href="/roadmap.html">Roadmap</a>
           <a href="/news.html">News</a>
           <a href="/faq.html">FAQ</a>
@@ -137,6 +138,7 @@
   <a href="/evidence-pack.html">Evidence Pack</a>
   <a href="/shadow-evaluation-guide.html">Shadow Evaluation Guide</a>
   <a href="/for-payers.html">For Payers</a>
+  <a href="/community.html">Community</a>
   <a href="/roadmap.html">Roadmap</a>
   <a href="/news.html">News</a>
   <a href="/faq.html">FAQ</a>
@@ -168,6 +170,25 @@
   <section class="page-section">
     <div class="container" style="max-width:800px">
       <div class="news-list">
+        <article class="news-card">
+          <div class="news-meta">
+            <span class="news-badge badge-release">Release</span>
+            <time class="news-date">August 2026</time>
+          </div>
+          <h2>Corpus Evaluation Path Corrected — IDG-01 and EIT-01</h2>
+          <p>The first run of the 150-session synthetic corpus evaluation reported IDG-01 at a 100% false-positive rate and EIT-01 at 0% detection. Those numbers were real, but they measured defects in the corpus-evaluation path rather than in the policy engine, which was not modified.</p>
+          <ul style="margin:.5rem 0 .75rem;padding-left:1.25rem;color:var(--body);font-size:.93rem;line-height:1.8">
+            <li>Disclosure assertion text was emitted only on the disclosure turn, so IDG-01 re-fired on every turn after it</li>
+            <li>IDG-01 was scored per turn and OR-ed across the session, marking compliant sessions as violating</li>
+            <li>Escalation state never reached the engine, leaving EIT-01 with nothing to evaluate</li>
+            <li>An incomplete audit context raised ATR-01 violations on every turn</li>
+            <li>All four controls now report 100% detection with 0% false positives against this corpus; 13 regression tests were added to pin the fixes</li>
+          </ul>
+          <p style="font-size:.93rem;color:var(--body)">A corpus result of 100% describes a 150-session synthetic dataset with two seeded escalation failures. It is a floor, not a validation, and Tier 0 remains observe-only.</p>
+          <div class="news-actions">
+            <a class="news-link" href="/evidence-pack.html">Review the Evidence Pack &rarr;</a>
+          </div>
+        </article>
         <article class="news-card">
           <div class="news-meta">
             <span class="news-badge badge-comm">Commentary</span>

--- a/platform/agent-registry.html
+++ b/platform/agent-registry.html
@@ -72,6 +72,7 @@
           <a href="/evidence-pack.html">Evidence Pack</a>
           <a href="/shadow-evaluation-guide.html">Shadow Evaluation Guide</a>
           <a href="/for-payers.html">For Payers</a>
+          <a href="/community.html">Community</a>
           <a href="/roadmap.html">Roadmap</a>
           <a href="/news.html">News</a>
           <a href="/faq.html">FAQ</a>
@@ -138,6 +139,7 @@
   <a href="/evidence-pack.html">Evidence Pack</a>
   <a href="/shadow-evaluation-guide.html">Shadow Evaluation Guide</a>
   <a href="/for-payers.html">For Payers</a>
+  <a href="/community.html">Community</a>
   <a href="/roadmap.html">Roadmap</a>
   <a href="/news.html">News</a>
   <a href="/faq.html">FAQ</a>

--- a/platform/continuous-conformance.html
+++ b/platform/continuous-conformance.html
@@ -72,6 +72,7 @@
           <a href="/evidence-pack.html">Evidence Pack</a>
           <a href="/shadow-evaluation-guide.html">Shadow Evaluation Guide</a>
           <a href="/for-payers.html">For Payers</a>
+          <a href="/community.html">Community</a>
           <a href="/roadmap.html">Roadmap</a>
           <a href="/news.html">News</a>
           <a href="/faq.html">FAQ</a>
@@ -138,6 +139,7 @@
   <a href="/evidence-pack.html">Evidence Pack</a>
   <a href="/shadow-evaluation-guide.html">Shadow Evaluation Guide</a>
   <a href="/for-payers.html">For Payers</a>
+  <a href="/community.html">Community</a>
   <a href="/roadmap.html">Roadmap</a>
   <a href="/news.html">News</a>
   <a href="/faq.html">FAQ</a>

--- a/platform/enterprise.html
+++ b/platform/enterprise.html
@@ -72,6 +72,7 @@
           <a href="/evidence-pack.html">Evidence Pack</a>
           <a href="/shadow-evaluation-guide.html">Shadow Evaluation Guide</a>
           <a href="/for-payers.html">For Payers</a>
+          <a href="/community.html">Community</a>
           <a href="/roadmap.html">Roadmap</a>
           <a href="/news.html">News</a>
           <a href="/faq.html">FAQ</a>
@@ -138,6 +139,7 @@
   <a href="/evidence-pack.html">Evidence Pack</a>
   <a href="/shadow-evaluation-guide.html">Shadow Evaluation Guide</a>
   <a href="/for-payers.html">For Payers</a>
+  <a href="/community.html">Community</a>
   <a href="/roadmap.html">Roadmap</a>
   <a href="/news.html">News</a>
   <a href="/faq.html">FAQ</a>

--- a/platform/evidence-center.html
+++ b/platform/evidence-center.html
@@ -72,6 +72,7 @@
           <a href="/evidence-pack.html">Evidence Pack</a>
           <a href="/shadow-evaluation-guide.html">Shadow Evaluation Guide</a>
           <a href="/for-payers.html">For Payers</a>
+          <a href="/community.html">Community</a>
           <a href="/roadmap.html">Roadmap</a>
           <a href="/news.html">News</a>
           <a href="/faq.html">FAQ</a>
@@ -138,6 +139,7 @@
   <a href="/evidence-pack.html">Evidence Pack</a>
   <a href="/shadow-evaluation-guide.html">Shadow Evaluation Guide</a>
   <a href="/for-payers.html">For Payers</a>
+  <a href="/community.html">Community</a>
   <a href="/roadmap.html">Roadmap</a>
   <a href="/news.html">News</a>
   <a href="/faq.html">FAQ</a>

--- a/platform/index.html
+++ b/platform/index.html
@@ -72,6 +72,7 @@
           <a href="/evidence-pack.html">Evidence Pack</a>
           <a href="/shadow-evaluation-guide.html">Shadow Evaluation Guide</a>
           <a href="/for-payers.html">For Payers</a>
+          <a href="/community.html">Community</a>
           <a href="/roadmap.html">Roadmap</a>
           <a href="/news.html">News</a>
           <a href="/faq.html">FAQ</a>
@@ -138,6 +139,7 @@
   <a href="/evidence-pack.html">Evidence Pack</a>
   <a href="/shadow-evaluation-guide.html">Shadow Evaluation Guide</a>
   <a href="/for-payers.html">For Payers</a>
+  <a href="/community.html">Community</a>
   <a href="/roadmap.html">Roadmap</a>
   <a href="/news.html">News</a>
   <a href="/faq.html">FAQ</a>

--- a/platform/trust-gateway.html
+++ b/platform/trust-gateway.html
@@ -72,6 +72,7 @@
           <a href="/evidence-pack.html">Evidence Pack</a>
           <a href="/shadow-evaluation-guide.html">Shadow Evaluation Guide</a>
           <a href="/for-payers.html">For Payers</a>
+          <a href="/community.html">Community</a>
           <a href="/roadmap.html">Roadmap</a>
           <a href="/news.html">News</a>
           <a href="/faq.html">FAQ</a>
@@ -138,6 +139,7 @@
   <a href="/evidence-pack.html">Evidence Pack</a>
   <a href="/shadow-evaluation-guide.html">Shadow Evaluation Guide</a>
   <a href="/for-payers.html">For Payers</a>
+  <a href="/community.html">Community</a>
   <a href="/roadmap.html">Roadmap</a>
   <a href="/news.html">News</a>
   <a href="/faq.html">FAQ</a>

--- a/registry.html
+++ b/registry.html
@@ -70,6 +70,7 @@
           <a href="/evidence-pack.html">Evidence Pack</a>
           <a href="/shadow-evaluation-guide.html">Shadow Evaluation Guide</a>
           <a href="/for-payers.html">For Payers</a>
+          <a href="/community.html">Community</a>
           <a href="/roadmap.html">Roadmap</a>
           <a href="/news.html">News</a>
           <a href="/faq.html">FAQ</a>
@@ -136,6 +137,7 @@
   <a href="/evidence-pack.html">Evidence Pack</a>
   <a href="/shadow-evaluation-guide.html">Shadow Evaluation Guide</a>
   <a href="/for-payers.html">For Payers</a>
+  <a href="/community.html">Community</a>
   <a href="/roadmap.html">Roadmap</a>
   <a href="/news.html">News</a>
   <a href="/faq.html">FAQ</a>

--- a/regulatory-alignment.html
+++ b/regulatory-alignment.html
@@ -71,6 +71,7 @@
           <a href="/evidence-pack.html">Evidence Pack</a>
           <a href="/shadow-evaluation-guide.html">Shadow Evaluation Guide</a>
           <a href="/for-payers.html">For Payers</a>
+          <a href="/community.html">Community</a>
           <a href="/roadmap.html">Roadmap</a>
           <a href="/news.html">News</a>
           <a href="/faq.html">FAQ</a>
@@ -137,6 +138,7 @@
   <a href="/evidence-pack.html">Evidence Pack</a>
   <a href="/shadow-evaluation-guide.html">Shadow Evaluation Guide</a>
   <a href="/for-payers.html">For Payers</a>
+  <a href="/community.html">Community</a>
   <a href="/roadmap.html">Roadmap</a>
   <a href="/news.html">News</a>
   <a href="/faq.html">FAQ</a>

--- a/roadmap.html
+++ b/roadmap.html
@@ -71,6 +71,7 @@
           <a href="/evidence-pack.html">Evidence Pack</a>
           <a href="/shadow-evaluation-guide.html">Shadow Evaluation Guide</a>
           <a href="/for-payers.html">For Payers</a>
+          <a href="/community.html">Community</a>
           <a href="/roadmap.html">Roadmap</a>
           <a href="/news.html">News</a>
           <a href="/faq.html">FAQ</a>
@@ -137,6 +138,7 @@
   <a href="/evidence-pack.html">Evidence Pack</a>
   <a href="/shadow-evaluation-guide.html">Shadow Evaluation Guide</a>
   <a href="/for-payers.html">For Payers</a>
+  <a href="/community.html">Community</a>
   <a href="/roadmap.html">Roadmap</a>
   <a href="/news.html">News</a>
   <a href="/faq.html">FAQ</a>

--- a/script-examples.html
+++ b/script-examples.html
@@ -71,6 +71,7 @@
           <a href="/evidence-pack.html">Evidence Pack</a>
           <a href="/shadow-evaluation-guide.html">Shadow Evaluation Guide</a>
           <a href="/for-payers.html">For Payers</a>
+          <a href="/community.html">Community</a>
           <a href="/roadmap.html">Roadmap</a>
           <a href="/news.html">News</a>
           <a href="/faq.html">FAQ</a>
@@ -137,6 +138,7 @@
   <a href="/evidence-pack.html">Evidence Pack</a>
   <a href="/shadow-evaluation-guide.html">Shadow Evaluation Guide</a>
   <a href="/for-payers.html">For Payers</a>
+  <a href="/community.html">Community</a>
   <a href="/roadmap.html">Roadmap</a>
   <a href="/news.html">News</a>
   <a href="/faq.html">FAQ</a>

--- a/scripts/generate_pdfs.py
+++ b/scripts/generate_pdfs.py
@@ -966,6 +966,29 @@ def make_shadow_guide():
         story.append(Spacer(1, 0.1*inch))
 
     # What you need
+    story.append(Paragraph("How Disclosure Timeliness Is Scored", H1))
+    story.append(Paragraph(
+        "Impersonation Latency is reported as a raw measurement and bucketed into four bands, so "
+        "an agent that discloses slowly reads differently from one that never discloses at all.",
+        SMALL
+    ))
+    story.append(Spacer(1, 0.06 * inch))
+    story.append(_premium_table([
+        ["Band", "Disclosure", "Reported as"],
+        ["Pass", "Turn 0, before any data request", "Conformant"],
+        ["Delayed", "Present, within 10s, before any PHI", "Observation"],
+        ["Late", "Present, after 10s, before any PHI", "Human review"],
+        ["Critical", "PHI before disclosure, or never disclosed", "Violation"],
+    ], [1.0 * inch, 3.3 * inch, 2.2 * inch]))
+    story.append(Spacer(1, 0.08 * inch))
+    story.append(Paragraph(
+        "These bands are a reporting convention, not an enforcement threshold. No control imposes "
+        "a seconds-based deadline; the normative target remains disclosure before any data request "
+        "(IL in turns = 0). Tier 0 is observe-only in all cases.",
+        SMALL
+    ))
+    story.append(Spacer(1, 0.14 * inch))
+
     story.append(Paragraph("What You Need", H1))
     needs = [
         "Access to call logs or recordings for a sample of incoming administrative calls "

--- a/shadow-evaluation-guide.html
+++ b/shadow-evaluation-guide.html
@@ -82,6 +82,7 @@
           <a href="/evidence-pack.html">Evidence Pack</a>
           <a href="/shadow-evaluation-guide.html">Shadow Evaluation Guide</a>
           <a href="/for-payers.html">For Payers</a>
+          <a href="/community.html">Community</a>
           <a href="/roadmap.html">Roadmap</a>
           <a href="/news.html">News</a>
           <a href="/faq.html">FAQ</a>
@@ -148,6 +149,7 @@
   <a href="/evidence-pack.html">Evidence Pack</a>
   <a href="/shadow-evaluation-guide.html">Shadow Evaluation Guide</a>
   <a href="/for-payers.html">For Payers</a>
+  <a href="/community.html">Community</a>
   <a href="/roadmap.html">Roadmap</a>
   <a href="/news.html">News</a>
   <a href="/faq.html">FAQ</a>
@@ -266,12 +268,12 @@
 
       <h2 style="margin-top:2.5rem">How to Start</h2>
       <p style="color:var(--body);font-size:1rem;line-height:1.85;margin-top:.75rem">
-        Email <a href="mailto:contact@nhid-clinical.org?subject=Shadow%20Evaluation" style="color:var(--teal-bright);font-weight:600">contact@nhid-clinical.org</a> with the subject line <strong>"Shadow Evaluation"</strong>. Include your role and the workflows you want to observe.
+        <a href="https://calendar.app.google/1AKD4ysBe4ZwH9iv6" style="color:var(--teal-bright);font-weight:600" target="_blank" rel="noopener noreferrer">Book a 30-minute call</a> &mdash; or email <a href="mailto:contact@nhid-clinical.org?subject=Shadow%20Evaluation" style="color:var(--teal-bright);font-weight:600">contact@nhid-clinical.org</a> with the subject line <strong>"Shadow Evaluation"</strong>. Either way, include your role and the workflows you want to observe.
       </p>
 
       <h2 style="margin-top:2.5rem">Related Resources</h2>
       <ul style="list-style:none;padding:0;display:grid;gap:.75rem;margin-top:1rem">
-        <li><a href="https://github.com/NHID-Clinical/NHID-Clinical/tree/main/docs/pilot-kit" style="font-weight:600;color:var(--teal-bright)">Tier 0 Shadow Pilot Kit &rarr;</a> <span style="color:var(--body)">— capture schema, measurement script, 30-day plan, report template</span></li>
+        <li><a href="https://github.com/NHID-Clinical/NHID-Clinical/tree/main/docs/pilot-kit" style="font-weight:600;color:var(--teal-bright)">Tier 0 Shadow Pilot Kit &rarr;</a> <span style="color:var(--body)">— capture schema, measurement script, 2&#8209;4 week plan, report template</span></li>
         <li><a href="/for-payers.html" style="font-weight:600;color:var(--teal-bright)">For Payers guide &rarr;</a> <span style="color:var(--body)">— full 90-day pilot framing</span></li>
         <li><a href="/evidence-pack.html" style="font-weight:600;color:var(--teal-bright)">Evidence Pack &rarr;</a> <span style="color:var(--body)">— guarantees, failure trace, audit model</span></li>
         <li><a href="/demo.html" style="font-weight:600;color:var(--teal-bright)">Reference demonstration line &rarr;</a> <span style="color:var(--body)">— hear the disclosure controls in a real call</span></li>
@@ -285,7 +287,7 @@
       <div class="premium-callout">
         <h3>Shadow mode in one sentence</h3>
         <p>Observe today's AI voice traffic against IDG-01, PDX-01, DBC-01, EIT-01, and ATR-01 — log what passes, what fails, what is ambiguous — then decide what to require in the next contract cycle.</p>
-        <a href="mailto:contact@nhid-clinical.org?subject=Shadow%20Evaluation">Start shadow evaluation &rarr;</a>&nbsp;&nbsp;
+        <a href="https://calendar.app.google/1AKD4ysBe4ZwH9iv6" target="_blank" rel="noopener noreferrer">Book a call &rarr;</a>&nbsp;&nbsp;<a href="mailto:contact@nhid-clinical.org?subject=Shadow%20Evaluation">Or email us &rarr;</a>&nbsp;&nbsp;
         <a href="/specs/NHID-Clinical-Shadow-Evaluation-Guide.pdf">Download PDF &rarr;</a>
       </div>
     </div>
@@ -298,7 +300,7 @@
         <h2>Questions? Reach out directly.</h2>
         <p>Whether you have a process question, a concern about the controls, or you want to share what you're seeing in your own call traffic — feedback from payer operations teams is what shapes this work.</p>
       </div>
-      <a class="closing-button" href="/for-payers.html">For Payers &rarr;</a>
+      <a class="closing-button" href="https://calendar.app.google/1AKD4ysBe4ZwH9iv6" target="_blank" rel="noopener noreferrer">Book a 30-minute call &rarr;</a>
     </div>
   </section>
 </main>

--- a/sms-opt-in.html
+++ b/sms-opt-in.html
@@ -71,6 +71,7 @@
           <a href="/evidence-pack.html">Evidence Pack</a>
           <a href="/shadow-evaluation-guide.html">Shadow Evaluation Guide</a>
           <a href="/for-payers.html">For Payers</a>
+          <a href="/community.html">Community</a>
           <a href="/roadmap.html">Roadmap</a>
           <a href="/news.html">News</a>
           <a href="/faq.html">FAQ</a>
@@ -137,6 +138,7 @@
   <a href="/evidence-pack.html">Evidence Pack</a>
   <a href="/shadow-evaluation-guide.html">Shadow Evaluation Guide</a>
   <a href="/for-payers.html">For Payers</a>
+  <a href="/community.html">Community</a>
   <a href="/roadmap.html">Roadmap</a>
   <a href="/news.html">News</a>
   <a href="/faq.html">FAQ</a>

--- a/specification.html
+++ b/specification.html
@@ -74,6 +74,7 @@
           <a href="/evidence-pack.html">Evidence Pack</a>
           <a href="/shadow-evaluation-guide.html">Shadow Evaluation Guide</a>
           <a href="/for-payers.html">For Payers</a>
+          <a href="/community.html">Community</a>
           <a href="/roadmap.html">Roadmap</a>
           <a href="/news.html">News</a>
           <a href="/faq.html">FAQ</a>
@@ -140,6 +141,7 @@
   <a href="/evidence-pack.html">Evidence Pack</a>
   <a href="/shadow-evaluation-guide.html">Shadow Evaluation Guide</a>
   <a href="/for-payers.html">For Payers</a>
+  <a href="/community.html">Community</a>
   <a href="/roadmap.html">Roadmap</a>
   <a href="/news.html">News</a>
   <a href="/faq.html">FAQ</a>

--- a/specs/NHID-Clinical-Evidence-Pack.pdf
+++ b/specs/NHID-Clinical-Evidence-Pack.pdf
@@ -627,7 +627,7 @@ endobj
 endobj
 33 0 obj
 <<
-/Author (\(anonymous\)) /CreationDate (D:20260814033214+00'00') /Creator (\(unspecified\)) /Keywords () /ModDate (D:20260814033214+00'00') /Producer (ReportLab PDF Library - \(opensource\)) 
+/Author (\(anonymous\)) /CreationDate (D:20260814121018+00'00') /Creator (\(unspecified\)) /Keywords () /ModDate (D:20260814121018+00'00') /Producer (ReportLab PDF Library - \(opensource\)) 
   /Subject (\(unspecified\)) /Title (\(anonymous\)) /Trapped /False
 >>
 endobj
@@ -700,7 +700,7 @@ xref
 trailer
 <<
 /ID 
-[<1284287d8ef6c30f449727489fe5c48d><1284287d8ef6c30f449727489fe5c48d>]
+[<5973a7727a5b9efdf8056c7aaf0fd568><5973a7727a5b9efdf8056c7aaf0fd568>]
 % ReportLab generated PDF document -- digest (opensource)
 
 /Info 33 0 R

--- a/specs/NHID-Clinical-Knowledge-Archive.pdf
+++ b/specs/NHID-Clinical-Knowledge-Archive.pdf
@@ -806,7 +806,7 @@ endobj
 endobj
 41 0 obj
 <<
-/Author (\(anonymous\)) /CreationDate (D:20260814033212+00'00') /Creator (\(unspecified\)) /Keywords () /ModDate (D:20260814033212+00'00') /Producer (ReportLab PDF Library - \(opensource\)) 
+/Author (\(anonymous\)) /CreationDate (D:20260814121016+00'00') /Creator (\(unspecified\)) /Keywords () /ModDate (D:20260814121016+00'00') /Producer (ReportLab PDF Library - \(opensource\)) 
   /Subject (\(unspecified\)) /Title (\(anonymous\)) /Trapped /False
 >>
 endobj
@@ -911,7 +911,7 @@ xref
 trailer
 <<
 /ID 
-[<6f3814989004044ce35762fa148469be><6f3814989004044ce35762fa148469be>]
+[<791637fe8078734e0394703c22a5ecdc><791637fe8078734e0394703c22a5ecdc>]
 % ReportLab generated PDF document -- digest (opensource)
 
 /Info 41 0 R

--- a/specs/NHID-Clinical-Operational-Blueprint-v1.3.pdf
+++ b/specs/NHID-Clinical-Operational-Blueprint-v1.3.pdf
@@ -888,7 +888,7 @@ endobj
 endobj
 68 0 obj
 <<
-/Author (\(anonymous\)) /CreationDate (D:20260814033211+00'00') /Creator (\(unspecified\)) /Keywords () /ModDate (D:20260814033211+00'00') /Producer (ReportLab PDF Library - \(opensource\)) 
+/Author (\(anonymous\)) /CreationDate (D:20260814121014+00'00') /Creator (\(unspecified\)) /Keywords () /ModDate (D:20260814121014+00'00') /Producer (ReportLab PDF Library - \(opensource\)) 
   /Subject (\(unspecified\)) /Title (\(anonymous\)) /Trapped /False
 >>
 endobj
@@ -1246,7 +1246,7 @@ xref
 trailer
 <<
 /ID 
-[<28c7c37af83092abf86fef5c99290f11><28c7c37af83092abf86fef5c99290f11>]
+[<fd94c856fa956222e9006021a28b6ac2><fd94c856fa956222e9006021a28b6ac2>]
 % ReportLab generated PDF document -- digest (opensource)
 
 /Info 68 0 R

--- a/specs/NHID-Clinical-Shadow-Evaluation-Guide.pdf
+++ b/specs/NHID-Clinical-Shadow-Evaluation-Guide.pdf
@@ -2,8 +2,8 @@
 %“Œ‹ž ReportLab Generated PDF document (opensource)
 1 0 obj
 <<
-/F1 2 0 R /F2+0 11 0 R /F3+0 15 0 R /F4+0 19 0 R /F5+0 23 0 R /F6+0 27 0 R 
-  /F7+0 31 0 R
+/F1 2 0 R /F2+0 12 0 R /F3+0 16 0 R /F4+0 20 0 R /F5+0 24 0 R /F6+0 28 0 R 
+  /F7+0 32 0 R
 >>
 endobj
 2 0 obj
@@ -29,7 +29,7 @@ Gb"-VF[/s[_Q`RBklq/#;9Dr+mdBM')+P]gm*9Tea6rB`mdBKQ//0A*)np7ZF$Q:a485:-G<?7=cgMB5
 endobj
 5 0 obj
 <<
-/Contents 35 0 R /MediaBox [ 0 0 612 792 ] /Parent 34 0 R /Resources <<
+/Contents 36 0 R /MediaBox [ 0 0 612 792 ] /Parent 35 0 R /Resources <<
 /ExtGState <<
 /gRLs0 <<
 /ca .06
@@ -53,7 +53,7 @@ endobj
 endobj
 6 0 obj
 <<
-/Contents 36 0 R /MediaBox [ 0 0 612 792 ] /Parent 34 0 R /Resources <<
+/Contents 37 0 R /MediaBox [ 0 0 612 792 ] /Parent 35 0 R /Resources <<
 /Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
 >> /Rotate 0 /Trans <<
 
@@ -63,7 +63,7 @@ endobj
 endobj
 7 0 obj
 <<
-/Contents 37 0 R /MediaBox [ 0 0 612 792 ] /Parent 34 0 R /Resources <<
+/Contents 38 0 R /MediaBox [ 0 0 612 792 ] /Parent 35 0 R /Resources <<
 /Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
 >> /Rotate 0 /Trans <<
 
@@ -72,6 +72,16 @@ endobj
 >>
 endobj
 8 0 obj
+<<
+/Contents 39 0 R /MediaBox [ 0 0 612 792 ] /Parent 35 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+9 0 obj
 <<
 /Filter [ /FlateDecode ] /Length 680
 >>
@@ -86,7 +96,7 @@ xœuÕÛjQÆñ{Ÿb.[JÑ=ë”‚94‹húFwR!e4ß¾ëóÉ¦´‚®ÿ8³ñ^¬éåÍÕÍ°9tÓïãvu[ÝýfXu¿}
 ¿Ò¯ð+ý
 ¿Ò¯ðý¿Ñoðý¿Ñoðý¿Ñoðý¿Ñoðý¿Ñoðý¿Ñoðý¿Ñoðý¿Ñoð;ý¿Óïð;ý¿Óïð;ý¿Óïð;ý¿Óïð;ý¿Óïð;ý¿Óïð;ý¿Óïð;ý¿ÓïðýÐðýÐðýÐðýÐðýÐðýÐðýÐðýÐÿ²!^6v¶ÝëZ=c.¨ÓJ<-¬œÍP_·æn»Ã)¼ÿ 9¥ ³endstream
 endobj
-9 0 obj
+10 0 obj
 <<
 /Filter [ /FlateDecode ] /Length 10723 /Length1 16296
 >>
@@ -136,16 +146,16 @@ m^©ŒÁ‡,tZsm¿£bûÙ»ïwª±·ø+ü±âkØ_ÌlÇ»÷n/>¹—Á©/½†ÕË¸‘îs
 5rªé¦„ýê/	³”BØE(Á‰–d<n}ÙdÐ›SÈ³Î®5Ê!§_´:mÀüw‡4¦·œn¯µF÷k³šž‹n)½}•“¯ýFeû)ã–ÜíÜ¥wÊ¿ãÇ K‹aó‰òÂu„‚LóªXE"ö¨Ô¤µë,5FÙ£)³Á`&§©Í¿ÖÕX÷rç[&Í¡¿3´:Áò"µô3B`ËéD¦çìZé§’þZFÿ~Šþ¾#z7ÑùWþª„Ù~«ŽOÔúÛ’nW:£÷¦êü-n§Kù3E8ê«v9ª‰¬¶Y¨®®ª.ûØŽËžþá¯nÙ§ïü=RsÿB›¿ÿ£½}ÿ0|üd)YrJ›%û©žPMGåyâÿýI·”’E“´¹ü_~×>³dšþŒ{µ£ßÀ”8Ú‰/¡.ò] g3!¼€jÑ¯PN"N Î¢8ì£è_P;þÌ{µ“/!'YDÍøÔ@ZPD‹t ©Gn²EH3ÔwCß&ØŸü;Ä&âñçP7¼»ðÏa­M¨ž<¤äi”!ŸAò"¼³pwÃý·ˆ'¿@\÷¯œü	´m@nÞ€ûw0þ¼ïGá½€läÒ‘7Pš<‰ˆÄMÅ(]%"	¹ÕàN´œCNxG`ÿÂ?„Œ¸{ÙnTtw.rà¾¹ w@[àßcº°´t/Ð×…»P'÷Qíd/Œ§ó`¾úÞ@V|p8ˆZI)¹aD I ,Ã¿FÕ0·ÐxÇýFrˆ¡>øN£3èx¿@"$MfÉ
 ùùù%y›Sq<·‹»È}GÂK2’÷J~"yKº(½,ýžôw2“¬A–‘= o@ôeQ4)v(N*¾¢ø¹â-¥O™QÎ*óÊ?SþFåS-«>©Fj—z³ú°úIõ‹ê74&M½&­™Ôä4·kÒµCÚÛµ?Ðùu“ºËº_ê%ú˜~RVEÿ¶¡Ý°bøžáããYã—Œ¯˜¦¤iÑ”7=oú–™[Êº:‹@î|”i¢ôäCÐü–þ°Vú¿¦ô¼±ü8zý¬\¦gi¯”Ë)Ð·ÊeEÐå²öGËe)ø«£å²Úw”Ë:Ô»VÆt-[¹,¿<Rz±l¡ÿÃ‰¶£cèšˆ#è8¼sh'Z€÷Úmô>Ž–AÛ£ð½zsÐ·m7†7Cù0¼AëôoACh#@¥Ð)xŸF ÛcPŸ\`sVäãjé'o˜Á¯Í¸6¢ƒýëf4¥ÿ~å}}?´.Ã;·FéÿÒ6AiZà}#[aü1tZæØŒ^t‚qã£€Ïp 8·Ìf†'…žø”›"OæoëPŒ>mt6]gæS>œ„ç<´1nÐ56ÃÜ#ßøø bZŸÒc¢ïºñ“þCOK÷D·A6ÑU[òtÖ¾íé=åi•<mðn–<©@É“<åIøKžÿ¼'.”<1á)O³ïmO“¯ä‰zKž_ò4zJž†š’'ì.yêÝOyê\%×YòðÕ%§ªä©q”<n{Éã²•<ÎtUiÊ‘¶•¦ªiÉNKÖ*xî2š&Œ£†	SÖÕŽj&¤£’	MV’ÕÇtêQÕ„|T6chB—]ÖaUV–õÈzdûdçeËþRö²’L²Ôbß‡GRå¼b‚›'Š,Éê‰‡ì#çÉ_©qé´_Æ÷ÆÃ£—å¥í£åÖ©¾XŒÑgzÛ®‚ìbMìšš\Åø¾ì]÷Þ‹Ü}£…ûÇ&Ÿ–ºû²«„ôo›\•p÷eûn†ä6ðb¥›ÙÉ@XlŸxÝ…×=*EV^{Óãÿ åú¨endstream
 endobj
-10 0 obj
+11 0 obj
 <<
-/Ascent 940 /CapHeight 710 /Descent -234 /Flags 262148 /FontBBox [ -202 -229 1329 1128 ] /FontFile2 9 0 R 
+/Ascent 940 /CapHeight 710 /Descent -234 /Flags 262148 /FontBBox [ -202 -229 1329 1128 ] /FontFile2 10 0 R 
   /FontName /AAAAAA+Raleway-Bold /ItalicAngle 0 /MissingWidth 608 /StemV 165 /Type /FontDescriptor
 >>
 endobj
-11 0 obj
+12 0 obj
 <<
-/BaseFont /AAAAAA+Raleway-Bold /FirstChar 0 /FontDescriptor 10 0 R /LastChar 127 /Name /F2+0 /Subtype /TrueType 
-  /ToUnicode 8 0 R /Type /Font /Widths [ 0 928 0 0 0 0 0 0 0 0 
+/BaseFont /AAAAAA+Raleway-Bold /FirstChar 0 /FontDescriptor 11 0 R /LastChar 127 /Name /F2+0 /Subtype /TrueType 
+  /ToUnicode 9 0 R /Type /Font /Widths [ 0 928 0 0 0 0 0 0 0 0 
   0 0 0 0 0 0 0 0 0 0 
   0 0 0 0 0 0 0 0 0 0 
   0 0 240 307 393 721 634 786 712 235 
@@ -160,7 +170,7 @@ endobj
   531 550 493 317 272 317 567 608 ]
 >>
 endobj
-12 0 obj
+13 0 obj
 <<
 /Filter [ /FlateDecode ] /Length 684
 >>
@@ -175,7 +185,7 @@ xœuÕËjÛ@Æñ½žBË–RìÑ¹¥`¹4àE/4}G§†X²³ÈÛw>&J+°Ï_h„àÅ™Ý®îVÃîÔÎ¾O‡þ!ŸÚínØLùxx™
 ¿Ò¯ð+ý
 ¿Ò¯ðý¿Ñoðý¿Ñoðý¿Ñoðý¿Ñoðý¿Ñoðý¿Ñoðý¿Ñoðý¿Ñoð;ý¿Óïð;ý¿Óïð;ý¿Óïð;ý¿Óïð;ý¿Óïð;ý¿Óïð;ý¿Óïð;ý¿ÓïðýÐðýÐðýÐðýÐðýÐðýÐðýÐðýÐÙ—M€]÷¶‡ú—i*+ê¼Ï‹+g7ä·Ý9F¼…ÏoåS¢ýendstream
 endobj
-13 0 obj
+14 0 obj
 <<
 /Filter [ /FlateDecode ] /Length 13233 /Length1 21656
 >>
@@ -232,16 +242,16 @@ w*² ÷Ÿðùâw’1l:\kQ9ó:Ò“1ÜQ”"<ìÜ6”É=ŽR¸[P{äö!º×Fà3ÜGæ„k;Y”8~'âð»?À
 ã‹ÿWcú´þÛ–r}OŸ´jèÞ«§+Œ§¼z ³š¶® ¼H²šß+d;[
 Ð:3‘L2|æÃ}#µ¯ßŸÅ‚Rá{	\—SI.§Z$s¶Q:— àêšOe\Cç^H-ÃC÷¼¤¿”É^þðK¨'½ÁôôÇ	æk¬/ÍÔDñké®i‚kŸìP™,j!jºo‚{2¦0WÉûy>å»–Úg°µÈö5¾ab‡àã·ýQ´\æ»™Â³àÚü«Uêû­²œö“™'PÿÓBý°´§–Q”=ÍtŒ°,¨ðº9š)ß3(wuTSéÐÚB-s5ÝùÔ"šeY]ßÒrCŽæ_·r0‡3+%­âãäïYÞà§è:=½¼ãí./–þôNsRä9CÚ—TMÍÏMQ Aô^Ý¢¬QÎTNF	veœB*7ß$4ó„)\—%$ñ´9"o\È g´ÓàÔ:#*§âù/öÐa€äì÷K:N*Çw%â-ÓÊ½Î-åò}*¹?¡Dþ—¹+…4=©$g5ç–ù3ýôõuõJa0[˜Ìá2¯ˆt÷Þìå¶u1hü1¾ãÑÿµSíendstream
 endobj
-14 0 obj
+15 0 obj
 <<
-/Ascent 968.75 /CapHeight 727.5391 /Descent -241.2109 /Flags 262148 /FontBBox [ -771.4844 -330.5664 2583.008 1110.84 ] /FontFile2 13 0 R 
+/Ascent 968.75 /CapHeight 727.5391 /Descent -241.2109 /Flags 262148 /FontBBox [ -771.4844 -330.5664 2583.008 1110.84 ] /FontFile2 14 0 R 
   /FontName /AAAAAA+Inter-SemiBold /ItalicAngle 0 /MissingWidth 656.25 /StemV 135 /Type /FontDescriptor
 >>
 endobj
-15 0 obj
+16 0 obj
 <<
-/BaseFont /AAAAAA+Inter-SemiBold /FirstChar 0 /FontDescriptor 14 0 R /LastChar 127 /Name /F3+0 /Subtype /TrueType 
-  /ToUnicode 12 0 R /Type /Font /Widths [ 585.9375 318.8477 1000 585.9375 585.9375 585.9375 585.9375 585.9375 585.9375 585.9375 
+/BaseFont /AAAAAA+Inter-SemiBold /FirstChar 0 /FontDescriptor 15 0 R /LastChar 127 /Name /F3+0 /Subtype /TrueType 
+  /ToUnicode 13 0 R /Type /Font /Widths [ 585.9375 318.8477 1000 585.9375 585.9375 585.9375 585.9375 585.9375 585.9375 585.9375 
   585.9375 585.9375 585.9375 585.9375 585.9375 585.9375 585.9375 585.9375 585.9375 585.9375 
   585.9375 585.9375 585.9375 585.9375 585.9375 585.9375 585.9375 585.9375 585.9375 585.9375 
   585.9375 585.9375 251.9531 321.2891 522.9492 643.5547 650.3906 1004.395 662.5977 325.6836 
@@ -256,7 +266,7 @@ endobj
   568.8477 588.3789 565.918 454.5898 358.8867 454.5898 672.8516 656.25 ]
 >>
 endobj
-16 0 obj
+17 0 obj
 <<
 /Filter [ /FlateDecode ] /Length 678
 >>
@@ -271,7 +281,7 @@ xœ}ÕËjÛP…á¹ŸBÃ–Rœã}KÁr…z¡é(öIjˆe£8´~ûîå’C¡ØûÒAßlO/n.o†õ¾›~·ËÛºïî×Ãj¬OÛçq
 ¿Ò¯ð+ý
 ¿Ñoðý¿Ñoðý¿Ñoðý¿Ñoðý¿Ñoðý¿Ñoðý¿Ñoðý¿Ñoðý¿Óïð;ý¿Óïð;ý¿Óïð;ý¿Óïð;ý¿Óïð;ý¿Óïð;ý¿Óïð;ý¿Óïð;ýÐðýÐðýÐðýÐðýÐðýÐðýÐðýÐðý/âe`W`ù½®¢åó8æ–:nÈãâÁÊYõu‰î¶;œÂï9¦¸endstream
 endobj
-17 0 obj
+18 0 obj
 <<
 /Filter [ /FlateDecode ] /Length 10736 /Length1 16320
 >>
@@ -329,16 +339,16 @@ Y³lIï’Rþ–Â­èRÌ)>­ø¶âu¥NÙ¤QS>ª|M¥SíP=¬úwµBÝªžTŸW¯ª¿¯~OcÑTkº4;4·j–4¿ÔÖkoÕ~Y§Ó
 ôh©,ƒöc¥²5¢®RÙÀjb™þïh@,cú?«¶RY±®ÝíªRÙBÿOmC‡Ð ç @Gá}+P6nB‹ðÞ‹öA[/:Ï,ôuÁØ[ÑÌ¡ãÑqxŸdcŽ¢Ã¨øCG`væ†¶#`=G |+¼Aë^èß‚úÐæ Ô¾ÏÐ›e³n<PY‡êAsšÖ•ÚØ­ŽÀì¶ÿÄmÐ»ÝåYh¿~<ÿ>ã»á}ú²kœàaUú?¶õPÚ-‹ð¾Î(Œ?Ú½| 36ÂŠGaì!F*Ú€Kg‰˜ìGi€€éåÔ<“HªÑÇ¡ÎæöGOŽÁsZúgè#0÷ Ã&p>€Ç‰°øDÉÿÝðIÿ©³±c¼Ã ßPYôµW¾ëk‹\ôµFŠ¾x7‡‹¾T¨èk
 ]ô%ƒE_cpÁ—Š¾¸pÑ×x×W(úbþ¢¯Ž/új}E_·è‹zŠ¾jÏE_•»èó»Š>¾¢èó9‹>¯£èóØ‹>·­ès¥ÅiGÚVœ® %;-Yðœ2™ÆC†qSÆÑiÆ¥C’qMF’ÑÇuãê!Õ¸|H6Žãh\—9¬ÃªŒ,ã“uÊvËî–=)û¢ì_dE™e|¨c7zI•ŠqnŒ+2$£‡ˆe7¹›|‘HˆK§¥xŸÏo­Ê‹Û†òÊÑé<¾?£ÏôÖ©¼ìþ<Ÿšž\ÁøÁÌ}úòtåÏM^–zº2+„to\‘pfºŽ@‰¼Xé;]ˆŠâ¯û¢èºG¹ÈÊkoúqüogµendstream
 endobj
-18 0 obj
+19 0 obj
 <<
-/Ascent 940 /CapHeight 710 /Descent -234 /Flags 262148 /FontBBox [ -196 -231 1385 1124 ] /FontFile2 17 0 R 
+/Ascent 940 /CapHeight 710 /Descent -234 /Flags 262148 /FontBBox [ -196 -231 1385 1124 ] /FontFile2 18 0 R 
   /FontName /AAAAAA+Raleway-ExtraBold /ItalicAngle 0 /MissingWidth 608 /StemV 201 /Type /FontDescriptor
 >>
 endobj
-19 0 obj
+20 0 obj
 <<
-/BaseFont /AAAAAA+Raleway-ExtraBold /FirstChar 0 /FontDescriptor 18 0 R /LastChar 127 /Name /F4+0 /Subtype /TrueType 
-  /ToUnicode 16 0 R /Type /Font /Widths [ 0 0 0 0 0 0 0 0 0 0 
+/BaseFont /AAAAAA+Raleway-ExtraBold /FirstChar 0 /FontDescriptor 19 0 R /LastChar 127 /Name /F4+0 /Subtype /TrueType 
+  /ToUnicode 17 0 R /Type /Font /Widths [ 0 0 0 0 0 0 0 0 0 0 
   0 0 0 0 0 0 0 0 0 0 
   0 0 0 0 0 0 0 0 0 0 
   0 0 233 333 431 738 641 816 729 250 
@@ -353,7 +363,7 @@ endobj
   542 552 494 344 291 344 587 608 ]
 >>
 endobj
-20 0 obj
+21 0 obj
 <<
 /Filter [ /FlateDecode ] /Length 686
 >>
@@ -361,7 +371,7 @@ stream
 xœuÕÛŠÚPÆñ{Ÿ"—-¥èÎ:MA„9tÀ‹èôœ¸
 cÑ¹˜·ïþòÉtSZA×?&ÁæbÍo×wë~næßÇc÷ÏÍnßoÇ|:¾Œ]nóÓ¾Ÿ¥¶Ùî»óåhúì›a6/7?¼žÎù°îwÇÙrÙÌ”“§óøÚ¼»ž^Öý9Ë×/Ï›ñýlþmÜæqß?ý÷‚‡—axÎ‡ÜŸ›Ålµj¶yW~èËføº9äfþ¯»þ\óóuÈM;'r»ã6Ÿ†M—ÇMÿ”gËÅbÕ,ã~5Ëýö¯s©½â=»î×f¼\»(¯Ué4õM ÛÒí")Z¦n[´V×[Õ^uT}Uõ§ª¯«¾©ú¶ê»ª?W}ÿ§SåO©ê¶j©ºò§ÊŸ*ªü©ò§ÊŸ*ªü©ò§ÊŸ*ªü-ýíÔô—Qšþé?oé/£4ý-žKK¥é/£4ý-žcK¥é/£4ýe”¦¿ŒÒô—Qšþ2JÓ_FiúË˜-…~_èø…~_èø…~_èø…~_èø…~_èø…~_èø…~_èø…~_èø•~…_éWø•~…_éWø•~…_éWø•~…_éWø•~…_éWø•~…_éWø•~…_éWø•~…_éWø~ƒßè7ø~ƒßè7ø~ƒßè7ø~ƒßè7ø~ƒßè7ø~ƒßè7ø~ƒßè7ø~ƒßè7ø~‡ßéwø~‡ßéwø~‡ßéwø~‡ßéwø~‡ßéwø~‡ßéwø~‡ßéwø~‡ßéwøƒþ€?èøƒþ€?èøƒþ€?èøƒþ€?èøƒþ€?èøƒþ€?èøƒþ€?èøƒþ€?è¿lˆË&À®ÀÂ{[CÝË8–5mÅiñ`åìûü¶8‡ã€»ðþ—q¢Lendstream
 endobj
-21 0 obj
+22 0 obj
 <<
 /Filter [ /FlateDecode ] /Length 13203 /Length1 21460
 >>
@@ -431,16 +441,16 @@ Bß)¢aý8RHã)ý#Tu„Ÿ‰í°ÄÚu±vJ+çÄËž\öí©&f¬	Ì­›qåwM›¶afº3~Rá£\Å¶iÅ›¦gÜ?ÿ¹M{s'
 ¯õØÞÌÆ/Å¶°¿)UÍøIöBeˆA¡66z2›W¦~5£žê¢u³&Àüž¡ñÆü·ýTw2el>ª«rFM+¬eÔ5xi_†×…x¿ïm^z¬L»lôTÜ³V˜«60ùÏ\|Ãl¹Yã2ú±úPvãºÃ’\ƒŸÅLuøM{Ö2í5)r.@yÍdp+roõÊB–Äjœ“Ús¶Qy¬fs%3mÄþ8¾ø4f˜óz¶_3ì<Fw-Ê½Žµ¶1ºd¾Ëð»M±™•­`VC¹ŒÇÏB¼of¶òã³Xa$~¯Àëj&•ÕL#tÎLÊ+`îäÅ-dòªgs71-×²}*ë¢œÑ ëþ§àX‘_J=íõ¥çF_¾&ãúòLË~ÛËñ:,»EL&«|Z¨´×ùÜ/Ç{:¦1×*;s!ã»Ùš¯=´*¶RŽßÍ8µ©EøñØñ­(Z­ðÝÂàYxmùÞ*‹oXe5ë§30POÒÊ|§¼?V1o’‹=-lL-bY¡ð¦9ZßåŒ»F¦©$lmeV¶žÙs.³ˆE#TV7·´Þ’£…7­ìËa9ðrò(=Jÿä-~Šž‡×Ëªú¹Çå&òŸ­iéuŽÓ¯cÅ‚¹™	jÍîC[5õš
 ÍÌXšhµÚ_iÞ¤Z¦š§*r„4UœÈšƒs&ûE9ÃF§ÎâpªÏaÀ#v€ó†_Úñ¥2¯/–lŸYåvn¯RîGÒûç5àipYúhÓiM'†1çö…žöJvèÕ"ÕlÕ4a’¬²ŠêàÑÏ“¡.·°«ƒ¼Sb= òà0êendstream
 endobj
-22 0 obj
+23 0 obj
 <<
-/Ascent 968.75 /CapHeight 727.5391 /Descent -241.2109 /Flags 4 /FontBBox [ -738.7695 -322.2656 2583.008 1107.91 ] /FontFile2 21 0 R 
+/Ascent 968.75 /CapHeight 727.5391 /Descent -241.2109 /Flags 4 /FontBBox [ -738.7695 -322.2656 2583.008 1107.91 ] /FontFile2 22 0 R 
   /FontName /AAAAAA+Inter-Regular /ItalicAngle 0 /MissingWidth 656.25 /StemV 87 /Type /FontDescriptor
 >>
 endobj
-23 0 obj
+24 0 obj
 <<
-/BaseFont /AAAAAA+Inter-Regular /FirstChar 0 /FontDescriptor 22 0 R /LastChar 127 /Name /F5+0 /Subtype /TrueType 
-  /ToUnicode 20 0 R /Type /Font /Widths [ 585.9375 288.0859 1000 562.5 585.9375 585.9375 585.9375 585.9375 585.9375 585.9375 
+/BaseFont /AAAAAA+Inter-Regular /FirstChar 0 /FontDescriptor 23 0 R /LastChar 127 /Name /F5+0 /Subtype /TrueType 
+  /ToUnicode 21 0 R /Type /Font /Widths [ 585.9375 288.0859 1000 562.5 585.9375 585.9375 585.9375 585.9375 585.9375 585.9375 
   585.9375 585.9375 585.9375 585.9375 585.9375 585.9375 585.9375 585.9375 585.9375 585.9375 
   585.9375 585.9375 585.9375 585.9375 585.9375 585.9375 585.9375 585.9375 585.9375 585.9375 
   585.9375 585.9375 281.25 287.5977 465.8203 633.3008 641.6016 981.9336 644.043 299.8047 
@@ -455,7 +465,7 @@ endobj
   545.8984 562.0117 552.2461 426.2695 332.5195 426.2695 661.6211 656.25 ]
 >>
 endobj
-24 0 obj
+25 0 obj
 <<
 /Filter [ /FlateDecode ] /Length 681
 >>
@@ -471,7 +481,7 @@ xœuÕËjÛP…á¹ŸBÃ–Rì£}KÁÒ¤z¡é8òIjHd£8ƒ¼}÷ò
 ¿Ò¯ð+ý
 ¿Ñoðý¿Ñoðý¿Ñoðý¿Ñoðý¿Ñoðý¿Ñoðý¿Ñoðý¿Ñoðý¿Óïð;ý¿Óïð;ý¿Óïð;ý¿Óïð;ý¿Óïð;ý¿Óïð;ý¿Óïð;ý¿Óïð;ýÐðýÐðýÐðýÐðýÐðýÐðýÐðýÐðý/âe`W`Û½n¡áišrAVâiñ`åìÆúº5ûNáóûÈ Òendstream
 endobj
-25 0 obj
+26 0 obj
 <<
 /Filter [ /FlateDecode ] /Length 13838 /Length1 21912
 >>
@@ -542,16 +552,16 @@ sÏiøìâ¬è˜øJæ×u^â3Q1	mâ_FÅÜ;ð9÷×àþ¨NˆÅÜ6”ËWÀu=*‡¡bA„O,ôG+WÀÚóx7úœÿíà×¡·
 !Ê»¡ª(ØA_Y[(Ì¦
 ã¸‘\š`çE]òÜ¹.ÀÝÕÆ ì|5$õÙèŸ PÖendstream
 endobj
-26 0 obj
+27 0 obj
 <<
-/Ascent 968.75 /CapHeight 727.5391 /Descent -241.2109 /Flags 68 /FontBBox [ -744.1406 -322.2656 2598.633 1107.91 ] /FontFile2 25 0 R 
+/Ascent 968.75 /CapHeight 727.5391 /Descent -241.2109 /Flags 68 /FontBBox [ -744.1406 -322.2656 2598.633 1107.91 ] /FontFile2 26 0 R 
   /FontName /AAAAAA+Inter-Italic /ItalicAngle -9.399994 /MissingWidth 656.25 /StemV 87 /Type /FontDescriptor
 >>
 endobj
-27 0 obj
+28 0 obj
 <<
-/BaseFont /AAAAAA+Inter-Italic /FirstChar 0 /FontDescriptor 26 0 R /LastChar 127 /Name /F6+0 /Subtype /TrueType 
-  /ToUnicode 24 0 R /Type /Font /Widths [ 585.9375 1025.391 1000.977 585.9375 585.9375 585.9375 585.9375 585.9375 585.9375 585.9375 
+/BaseFont /AAAAAA+Inter-Italic /FirstChar 0 /FontDescriptor 27 0 R /LastChar 127 /Name /F6+0 /Subtype /TrueType 
+  /ToUnicode 25 0 R /Type /Font /Widths [ 585.9375 1025.391 1000.977 585.9375 585.9375 585.9375 585.9375 585.9375 585.9375 585.9375 
   585.9375 585.9375 585.9375 585.9375 585.9375 585.9375 585.9375 585.9375 585.9375 585.9375 
   585.9375 585.9375 585.9375 585.9375 585.9375 585.9375 585.9375 585.9375 585.9375 585.9375 
   585.9375 585.9375 281.25 287.5977 465.8203 633.3008 640.625 981.9336 689.4531 299.8047 
@@ -566,7 +576,7 @@ endobj
   545.8984 562.0117 552.2461 426.7578 332.5195 426.7578 662.1094 656.25 ]
 >>
 endobj
-28 0 obj
+29 0 obj
 <<
 /Filter [ /FlateDecode ] /Length 677
 >>
@@ -575,7 +585,7 @@ xœmÕÛjQÆñ{Ÿb.[JÑ=ë”‚94‹húfÜI…d”‰¹ÈÛw}~’nÚ
 ºþãÌÆx±æ—7W7ãöÐÍ¿O»á¶ºûí¸™êóîejwW¶ã¬ôÝf;NWÇÏái½ŸÍóðíëó¡>ÝŒ÷»ÙrÙÍäÍçÃôÚ½;?¾>ÜŒ‡:}¼Ø=nÞÏæß¦M¶ãÃÿïÞ¾ì÷õ©Ž‡n1[­ºM½ÏŸø²Þ]?ÕnþÏ‘?ü|Ý×®?^*‡Ý¦>ï×CÖãC-‹U·ŒëÕ¬Ž›¿î•þŒgîî‡_ëéôì"_«ì’ÝÛ…£ûæ{iZ›¶¦½éhú¬éOMŸ7}ÑôeÓWMnúúO—Æ_JÓ¿4þÒøKã/¿4þÒøKã/¿4þÒøKã/¿4þžþþØôçÈ¦?G6ý9²éÏ‘MŽlú{üw=ý9²éÏ‘MŽlúsdÓŸ#›þÙôçÈ¦?G6ý9fK¡_àú~¡_àú~¡_àú~¡_àú~¡_àú~¡_àú~¡_àú~¡_àú~¥_áWú~¥_áWú~¥_áWú~¥_áWú~¥_áWú~¥_áWú~¥_áWú~¥_áWú~£ßà7ú~£ßà7ú~£ßà7ú~£ßà7ú~£ßà7ú~£ßà7ú~£ßà7ú~£ßà7ú~§ßáwú~§ßáwú~§ßáwú~§ßáwú~§ßáwú~§ßáwú~§ßáwú~§ßáwúþ ?àúþ ?àúþ ?àúþ ?àúþ ?àúþ ?àúþ ?àúþ ?àúOâ´	°+°çÞvÐð2M¹žŽËð¸x°r¶c}Û—ûÝ§ðþÞ
 žRendstream
 endobj
-29 0 obj
+30 0 obj
 <<
 /Filter [ /FlateDecode ] /Length 13072 /Length1 21268
 >>
@@ -620,16 +630,16 @@ E%&h(O¬¨”ÌNUìÄ‘’e`¯2°€aü¸gSaOEÚˆäœ||VÜ·¡xeIFnRvÁž85¼()erå‰S£ò'–ÏçÉ`–/'
 ÍÐ›Žnƒ52¡e`6 NôÑ¿GUŸ‘s¤ûg	¤À×6ÝwÀœ ×ü®ôßÍ>îÌNµBûõœ7ÃZ´Ç-íp­‡ö¸¶£yÐ¶ 5Â7¥§>~h2`Ph=ŽÍ+ÓÝÁè¦2ït hüÌÐxCþÛ~ª#™²ñl>ª“)ŒšN´„Q×à§}>\ëà¾î‹üô˜™ØèbT
 ×‰°j“ìÀÌ¥×Í`ƒ–µ0(£s e×¯; ÉÅði†^èg>ëYÂô6×+çñ ¯IîîÍ~YÈ’è€9©Ý¶A•G›+ƒYbôO„ñ¥ÿ«1œ×³}ÑÌ°Ý.ûÖºˆÑ%ó=¾ymf!@˜ÕP.“áS÷-ÌV~y3ßàÚÁ¤ÒÁ4BçìfR^€ÃŽm¨ŽÉ«žÍ=—iÙÅö£¬‹)ŒY÷ÿ	Žø¥ÔÓÞ@z®Ç	äk¬/ÏÔÊðØh…ë€ì™LÚZ¨´»î[ážŽ)Ì%Þ=YÇøn`¶h^[™ß-0µ©FøøìøVuxùncð4¸¶Ý´Jóu«t°~:óx¦êC:™”÷G;ó#èicc\€eFE7ÌÑÆøžÂ¸kbšJ‡ÖNfeK™=;˜E´y5BeucKç-9ª»aå@§ NN¥?Ò¿¥x‹Ÿ’CèµÉU}ßïtcùÏ¾´õ!E¾=hå‚š‰Ž¼Je÷ÊzåTåq”hSÆ)*os8_œ%–óù|¶˜$°æ°üqA±ö(»Þ®±‡ÛƒíŠ#ªƒ¡CÈ~Ý/íxžRYÐ—ˆï™Tå¶ßSå½Dï)‘¯ÁiêK¡M‡•ô8d¿§nª¯ƒþØ#‹âtñv~Ÿ!šEXê!Ü¿ÆÍß×GPÁ>¡üô 8óÁ endstream
 endobj
-30 0 obj
+31 0 obj
 <<
-/Ascent 968.75 /CapHeight 727.5391 /Descent -241.2109 /Flags 262148 /FontBBox [ -787.5977 -334.4727 2583.008 1112.793 ] /FontFile2 29 0 R 
+/Ascent 968.75 /CapHeight 727.5391 /Descent -241.2109 /Flags 262148 /FontBBox [ -787.5977 -334.4727 2583.008 1112.793 ] /FontFile2 30 0 R 
   /FontName /AAAAAA+Inter-Bold /ItalicAngle 0 /MissingWidth 656.25 /StemV 165 /Type /FontDescriptor
 >>
 endobj
-31 0 obj
+32 0 obj
 <<
-/BaseFont /AAAAAA+Inter-Bold /FirstChar 0 /FontDescriptor 30 0 R /LastChar 127 /Name /F7+0 /Subtype /TrueType 
-  /ToUnicode 28 0 R /Type /Font /Widths [ 585.9375 952.6367 585.9375 585.9375 585.9375 585.9375 585.9375 585.9375 585.9375 585.9375 
+/BaseFont /AAAAAA+Inter-Bold /FirstChar 0 /FontDescriptor 31 0 R /LastChar 127 /Name /F7+0 /Subtype /TrueType 
+  /ToUnicode 29 0 R /Type /Font /Widths [ 585.9375 952.6367 585.9375 585.9375 585.9375 585.9375 585.9375 585.9375 585.9375 585.9375 
   585.9375 585.9375 585.9375 585.9375 585.9375 585.9375 585.9375 585.9375 585.9375 585.9375 
   585.9375 585.9375 585.9375 585.9375 585.9375 585.9375 585.9375 585.9375 585.9375 585.9375 
   585.9375 585.9375 236.8164 337.8906 551.7578 648.9258 654.7852 1015.625 671.875 338.8672 
@@ -644,45 +654,52 @@ endobj
   580.0781 602.0508 572.7539 468.75 371.582 468.75 678.7109 656.25 ]
 >>
 endobj
-32 0 obj
-<<
-/PageMode /UseNone /Pages 34 0 R /Type /Catalog
->>
-endobj
 33 0 obj
 <<
-/Author (\(anonymous\)) /CreationDate (D:20260814033208+00'00') /Creator (\(unspecified\)) /Keywords () /ModDate (D:20260814033208+00'00') /Producer (ReportLab PDF Library - \(opensource\)) 
-  /Subject (\(unspecified\)) /Title (\(anonymous\)) /Trapped /False
+/PageMode /UseNone /Pages 35 0 R /Type /Catalog
 >>
 endobj
 34 0 obj
 <<
-/Count 3 /Kids [ 5 0 R 6 0 R 7 0 R ] /Type /Pages
+/Author (\(anonymous\)) /CreationDate (D:20260814121010+00'00') /Creator (\(unspecified\)) /Keywords () /ModDate (D:20260814121010+00'00') /Producer (ReportLab PDF Library - \(opensource\)) 
+  /Subject (\(unspecified\)) /Title (\(anonymous\)) /Trapped /False
 >>
 endobj
 35 0 obj
+<<
+/Count 4 /Kids [ 5 0 R 6 0 R 7 0 R 8 0 R ] /Type /Pages
+>>
+endobj
+36 0 obj
 <<
 /Filter [ /ASCII85Decode /FlateDecode ] /Length 1550
 >>
 stream
 Gat%!hf%7/%"@qX_8j/nUZo8L]qoSSjj5;jl4#]1?5uI0I;nPuEB<a,5LQjn[("gE"E5b],eoBS.01E<UAO(7JFaK3^)%n;Uj!q<du[nP/<.A4U-BMWYSPPSN,'_=%#cQ=,Slco$('"TUC&?QKSe)ad8?F,d_jn1LhX").=id-EEqORCiq;MjR%,5[HFdM7oa(5_'E.CR"J\ZMOh_2<eGBE#gO`pf9YHr+QnkbMA`1*YE4VdJ^H;*KAScu/#,M:(eqD[W"4?0S4@)9TEpWKdpp%96p,b]0K6dV.?$uO=bDAtRY#3rP3`KJ3s+10X4VA<NC/@g#/Nko!Xgar[L#l9fNo^76b++/_f@$XXc/6l`Fu7b2't*"89bCY'EQWqHAqUM#cg5C=>Cm&LK,lZ[G!YqOp</=Q6:=cJt,?"$RUgq]g<mf,L`k:J;'7[P$g#5)T,([5t8^Yd%CZ+7akk[*T:X7Vl>G(Ls]JH#s&=go/<O4nX.UbR8f=e4.:SU'^p?E-Ht.&Tn]r.0H8a9mJFKJrDg&Sh'V%KoptVZ3@BM_BBouPGc[DH!omS;d1*N?r@fL?r6X.9*?)mJUcY(Jndj6h1^>Ef1^AJ6I%4P=0$9n<nuVa0dXNBf6dt!Ap"+WB0qg=JhaN-<Q71j@7>V?[S&BqGE&6i*=*:=C>iL2R4Y)3P4cB`c'Xm;jdYctG&,UA0_=UVCiDld.mT+_BkIp1DidK;hV#aDs$"sQMH$')ODO`?O;:YpH+1&+(l].BNr*gUhBtp6gSZQ:F4^1Y0q/UJ%PkcDd&Q'G_]P7"m[g&BH>&nb4T5El^0RM$d6e3#q"Wn5n`ZNfQ!:0KM3\78:s,A2u(l%J#Mtc5m4b6,>'`?4dJ:p]NZR7a,pXs%R2n4('m6.&Y$XPbGS\pf*a?<5+^2!C,^L4)QObE2U2&ljdJ/pTf9I,pC)_pA$s*,Bq349%Of1^:&So^Or\JIDo0>?+<RYX<R!Il.%YN4+AMMhj%rsG4b,K)5[=FN<Jo[)IHbr[n'MQEg59Z^4u24MGX]\<,cO.WF8K81esgOe_QRn;j'-NiZ6TsU3EVJprcQUMB#okoPVhZ5/R8BOUc=7hXK`MKe<!DFfRo\@:Pp1"++(4^C;-"`9r^-$hSBVIrJHSjilPpDSB@"Sb*[=X.;UZl5.c"E4(;<qhD3/K;Z#_to#HBcdAUQ_#CW.@#8Ngb,NccH@`Y1-b;%T3)/(q[[S4a[1j,emEOMD&CYe>AJ\KS@F_mTdR#C3dM*SR,1X,V5619]7n#/hX'&93A?)2>cn=C76bV?W"K34C?>sbnfOs2kQa%m()puO,K@\=6q*2^h6C;1tf@kejGGK$#``?;"&CRrUfsK0poG@)*HL3Tk^prl'4t5YGth!r8S`P#dl^Q0['(-Di3+a!$P>]%!i]e6115N\3o?5E5IFc-JP)"TM9p/n_6F![5EPNr3o&@Ge1[!(,^K0?VdS]f=QeN$0D0Q,WJKb8T9$K+.ApPK'a^sZE!SHIg.m'd-%tgB`h5?548J`pbip&cYqH5[$q>qIfW[dR[F~>endstream
 endobj
-36 0 obj
+37 0 obj
 <<
 /Filter [ /ASCII85Decode /FlateDecode ] /Length 2157
 >>
 stream
 Gb!Sl9lo&I&A@C2m&b/?Tca>ejO#&`lBrnlA'MBOaT[tQ#q\Ror337$qEBuTXXK@&VEVui#Sb?c/GAJF>qdI_:Xjhh=%&AgqXLJ>,!hDQ7>`O_]V_$ZdDlhl;_=0"=N7\3.uYs8&l%h%NEAjbUOj+E8hmG]7BtkNF\]Cj-8Q7Q#r*0qN!j+"MP5^G`<bcu]a57:P(f0&YTa!s;Zaol,7?E"^&@chH@2!i_G*a"oRZUiW*$XaGhPqK?S8cGY-.!Z%oS@)-SA&)MSd`:fbC<RD5Z:JgePk@Mg3IV$su>N:Qn"WnfmFHa1=6fR8iaQM=8[*P1Yos'n.+1QVnG"-O4!jRO9P3W$>QD`41tm9Eninn8=,_7k_b["c[["=#qY,W3g[BU0Za$grfeiENji7):+HOC*jJDL47oI'XdgO?1Y&1>t(V5CW_#\Y3N5e^U=<J9>C08mb_mT4j<,e%Ut-qK;b259074&SIsq@=hqh>fYsT,:$p+5/jD7sZn#A1D!OG09K[[fBl,c:Unt&(m;a;U5hO<Y3aB7b2RX*O$JP90*dj0tkg#>oq-lY_daHp9eYCh6RQYV3Q8'!0fq2'(DB=i+@=nA9J0Pi;rndD@=Ea3Xi7P""X(_J.gX=S.=i)UHeO`]&2TW*L$Xk4k%LE]t)$6[((3(PPPXC`k.?JK\k:H"LZl/UKZ:6r%G:st'C67717]4U\^b7fY]!JXP3u&Ms0IrFX3,:m)V"+4pUpRq)@mgr`^uOgFK'<u-L.c1uKe\VHm(Br(=WF"RKQP/L_kOc16?dd=O*WtV00[JI:>'a-TfpG?s&_L==et(k3L[^u^;B&3+H_(EZ9Hm(J0j*h&i"[nX84MQ5ZD91LF0<-1-j@4hV2Lo#bEYCZ*4t<&E9OY2:L:TJkB,C`TWZ#b*MdFm#-6Y-:]IcDIu7h6a/"4,RP\RF.2:kJK:X/c*<6q&B7<rSt:bED]?RJ,m`R_hY<N;.N&0k5hNhW<BIEYMZht.jl%"r]I>m`_1Za.W>Z?A'$JgSAiAOHFE'\BhG#TPV4#Zc'R[;FpP=O`5fPQfM*:p88i2J'AF(g=S>JW)!8>)H^MtORA6c6A*K%nhVW?6m[0$seUu48u(>Z^=@"]p/Ei/?FB''"X[@+X9#)FdUE:pLg/lSk-'X$;SS$rQ7](E_B-]h;a?pYl#15\n>=sUq_U1[N[rdEfL?KGiRk`n+&=!@@AV,&4&&#H=B1ad-,3F@O7`)ILtBrOE+LAXI5Tnrf$c<N6OIE9]TZ5&P4LED@H\R-oWn0o?f#%\jk;.aN<Xnt%Th;A#-rPSiDQgsURg!FSAU39o\Vtpa_W.FDufB`LD`^5:HO3g)mAuo.(Ufdg.NWApq(J'YO83a4Y)J<2B+LD0sZu8;llSMiV#Tcj+0s26H6d$-8HL,iT*":+0U:[\0=tR;rYL!sOBK/jCTh0`r#6f-29k4!`#K>ZH$R&ZQ\30#l=(ZkK)Wqt][6EidMo+PEb#M6I:3-<*>^*hKOi5P[`-5*,/EP!;d3fIn?D>><&JdUm]AGXj3MJf4OJ5?Cqld#9<UCNt00?=.%>koUV*!DcP9uadT_c''F@XuQ):Z:oVYg&C:45,a6D36^-*uVm?f%9b0t$CJrS!W>nZi&Q'If1Da-<8?j/CPpC5_:q)AP5Aa?qd6PjWI;4N1Hqct.FBmHHB8n`Pk\g%7ffFFYQ!-dP=HRW>VjIsTbmp'[-(E,u1DL2G7mk'qo#kR#-9>N/\=k>%;:g',m[@Pnk2Y%j@/a6_/Q\q)`betoKb!QFYLCo5@Veptcd$/8dr4-u^f3N$S/gaX;il_`rhX\0H5RX43kpJ88%BCmWS7@ACLe3o'1#`T>@dcWM25+_kY+XLBKO[B3VPZf0%K.sI,lF$r1O-i<[=Oa1fSI]?lf<<1V3i@2R^UN7rj]+CV]U?.e`T02%&)X#.3cD$k@K<HDej(Ue7d+*)4g+`#"-lSufoVNl&Deb89q[mFm`-</Dm.%dS(4'61qn5:/=A[d=L&%0B2CY1K:cAbolEC,-(^f+G=Cmdcm+;2TfFr^8I&FHA4r-<#<R=3>2"?PWb8J"9!-g&$N#%,K7-mV/4"0-\a9d1P7V8Es12i]52EpWHCe1--[0KK:?k1\VcUIF[_'!WE7?<E;(cF0n>+IH]@p9D~>endstream
 endobj
-37 0 obj
+38 0 obj
 <<
-/Filter [ /ASCII85Decode /FlateDecode ] /Length 1752
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 2347
 >>
 stream
-Gb"/'95iQE&AJ$Cb\bgHbpB@`D<!V1)H[,VA"[&!(Ik,N[M#!#<4qY&h]X:1nn_L>HRN>*(.jGUrapmq5k3%qDdEN>k4$Du$lFcq!a%u[R/[Vno?im:8^j%S&Whr`.1Peb17#lJme)B(YSq4H3.rH36`;.8kqK9u@RPg,ZR>he7U\bHO=6'L#W0^:nmd:X\31+Rj'8>fdI.b^,`H2C:55OM2m_cDUf(CXU&t*\.0Iqn.`V:g85-AFr,H`YP7J3;\lkCW8n]ea,1]pS`Fep^Ftk([b+g\fJc"Er$^cEqq+IXYSobR&#Z&A-;&R^!;F7TXi%5jbX'\8(LcNB1]Z,*Zf6\H]Ro=6H^:!`J,P#q<d,<bq,`?B"3X6pMQnV#rO(*LC*cVr,2l^g2PDmI0:,pF9Ocqa6pb4u?7f=`.dDaWi@?cnmD;+Die:g.`[NF\-bm8Od2#A`XD5TPM**%sf27dAU5MR_XgSc)D?B0ij-"&tN%$<LO&oU+S.@%hBB;:fcm&B.1^#VaSkYAgUHg^opL7Xf3E[sMla%J>s4m8nchk&1GKLQ$GU[Nci63B\ElJ^n-/\s\^JI`8-6nZu$e(8*Pp-S.\+@EI)QE6#%e48t^BHac`Fq%C#k*9XBPjc#aEh<f#nUkYV_`pU8M`?abZ3eu!CjMI&8pl".*R=_jU+Ol#CSBtF8Pg1%$_ju)7^`J*b(W,!KO3Ps9&pXRO7>5[1BZ)k+fk\>DdEdaPiMjqo"\DjQc@_j)WBVd0MH/E4bN-+?ot"[F*Op[2f_$'EHsU`j\LK^R/r(p>-&<2>7_Lq+k/$PP=N=l?,\Ej+Dc+o(TOHGE>r;(rHGFXV@`X]!g.Z(6:NeZY)dpsj[4G)r!+IlF^<BNB"s&Ql/^ppR%;B)?<MD&@3S?aXg#1&PVW::;c)5O[4S4T3F!Mg@hig]>):tB:rlZh2.G4,+%393Y@Q*#N>Vs(P[,jt!T^d&T-[`#;V4n3j`@9R`X41aj(Hki$[&ARq;G1pg>_?l=Cj>5lDmP.fJrTR\SUZlYrA_gLae"s/''4i1ru3fenjgW7fOV+)Yp3s_;,]fK/O"u8uuC1&[hgDNN',J'1ur*`?`,q6;p.%pSIOaKdK08:oc!=Gn<+T`2>rnGlI.#cog_'4L<9OTrQ#jE$AI:I[+'1f%=69[cqgjAI2D6e?E^PIh7>]cb$'j.OoOk,_bWHM(@!A]&\VrTYjnN+ea8PQN[9`(UO:QDLo9LMd!K?2tTg#:`'GNOPDiJg3'qrn"!8s9F#3.(,mMLbqim7T'/^/3-=@%Dt@Jlc6uhFdHB1k4pp4-cXkkB4GPr#En50b$/0Zt.F@iAi/o"#?n5J3#."<+F&P00L]SY*h'@B+jS$(PnOQ\qW@h2Im+NabTk\6qIs::\NCl]BNGGB[gg?L>IJ'$%j,6DBk.u6i*'L1fV<KN6Qjo>KXDFFs.,JD6<n5VKM_]-!cD*/BkWgo:=&jqYeUo+#;YWlrUXupMM?1=c\p&j3^`(*809*S,\^:lC&J#Iu:UG01Y9P.(L3'18N4CSU@2tE&cY0"FMgb#66WYQ2PP`sN0YFsPilBh;>ft"*2ICcV43I?HPD[2iGqd/mjB`VW4#S.n0e6n`$]D^j"'Ga'gA&*l-l-"DLt%gTgc<tq)uf$VbNG.r-+)Li-^e2S5:$/M;2PFCSmI>To+CU6JXOfaY)pqO#V8nGT7O5uIo%C34=&@t1nPSL=g^F)<^L#gTXelMF+*AO$V(-sosdqu~>endstream
+Gb"/(=``?+(4Ol=30-gMYlJuCk<?h-RcmKnf1e)-B(?"eOG&>k*A7%cJ,T<GOBS_V=mFk!NpX(T*b%.aG8>uJ__8M!o8;a@:-\ZpM>K,:&.cI9k-+$gI.D::V.o9D&U>8;;AS7Jj?/:`mE:>&dJZI3i_p\?EC^g5+WJEI]pj74k49uE09!c,q;atQKMACJ:2h6r=MXJMnBAuhG_j(HP[J"*OVo4chRo:_9eT/9<A$n<pPa)9]i)g++,F7Z/B8QnQZVaZKcV0>(QB&2$b?mb/Xg,o^R;d):OV@q;oSn1c]=^Gr"#6GB;FDC0&i#VVdXh5a(qrE'^TZ*1DI<\0CiS0I?+>Q"Ziu3VZWu@Ap*N[1d3P1R:ZU:DRJV<0hYDSJ0YU<DKaBj(c/4LcNDLP8rR44j)Kq]T4];C?CV6!n,NqFDNptOEB-.#`kB;Ag8sG\\:E>bNUt7O_CE$mHXtmmb\`h:`#-tUk&C''W:77;C9mVPiYbl#:0mu<M)4_^d5?kZ8W8'e\a74oB_L,!Sn&nsMO425o`'u*p+R`PL'P3-E]5[8aJuL_LM7f-,7/JET(iCE^`-/Z5N?D`*/t3S4cC$l=.<L/S2.h=C0q0#C`@<$2?'(Kmi=>=V!_3kVCU3ZA_m(<n"o7/mP-94%ut'&s6rK!q%t+n';g,s31+[I=oU[44sOH(G?"6P7tj$"P3PTG,l4[HE,7g!E`%GoU">o+--cgk;s.E#RShm;+Z_p[^\LLcV=]cJe.7LMrm=ge>U(5)(PW6SZ6ul)%W'`u^HFd5XrBC714K%.nB8QQC2[iB.&b'&E8#i8TH6o_koc"6%D%F6QiLso=t`iRal4JZI^[!QR4tJieeUO)6&(>#pllkE0^B8F0sEn33)arg:RM)#B!3g>+!7gj17,J@\s%4Z=5lsu[9TkFro%c]D7eBT8p2\^]3==;Jk`-Y,4A\bA?2"7)"-[-7'<P-A^f3K&VgLkqFYF^E99K7OEArBdB/X>5%VlrY<XKO5G@LdW-^7g5<e@=[-6pGVeSr4lF)ol$:jhMQYlKlfUGl3@LCIAVnA6\PM@q?eK\D!f&$bI7Xj^?\7n6WdP]rfMY4LtTd7-blKYhTJeT,8Z'QN-d$12BQWjEgd,^8n;FP<b#LQI:r).2lT>,f%BKkkmoPF+gW:KIuGTg69^Tq04C)!"OfCX?DZpaX=WG,RaINo9e4R\aD=]FSd>Dg_6M>*b#<lrB;TYXbL@A?WV0*rWs,P6N7/[0OT?4/nu7IR:.d55f9qSm3r[`Ua[<T!8RicA,A;JFgm1i)>]Nn1_mj6n-=@C5"SMenBfpjo.7(_Xl8_$%U+LlFH&S"dZ[[rl1aF_FKG,OVOo_Jj:B[+4M;T7;r7L=-@!Mn3ij#5%VZ>/X<%g]MY!s2-ub4%aYHQM#[:`[RWIfqT;jfjH]d$\V)>@-JGAGpf*KEWSgsV0?*'bY&K,Vhk]>Mc0g:aQ*@a(tbGVnUO8c=<@l>W&7#U$+Wguir\j2q[5;I[Ra3/DS*tS[2Z&7hX4JciJd5YN,6Pq(GO:8Od364X0+X=b((idO<%R)G3_mblQ<Qefj6&9-Oq\_NR+argE'pTQo"1MkimKXP0!lX+[)IWJ(W]m*H0c,(-"&eIBL757c/_)09</TR!.<,(@HTGpWD"Cn<\<Z4nS9B\/KPdcV5pZ4,_TuC]tU:B<V%_*;4Xrk%o8TM[gU$8sY3+?J0q0O`sFS+61K8pI;'?lHF,EES#:'balbha#4U$S'/PE?uSNuK-.\<ISk7`:gYOrr#:-8SG_NeG@,d.=AW/9R?@<r6edeED4e[gk.%mU.nurZW%?_#&Kr,+K9:m:i+Nsd1go1f0Q=D;\&[E:HV2(/>Q%R>BRKE.@aetPq:aj_g[UL=0E-9\RBPO`/ifTX23"TY/gf[)s506fkusQCfjkk]#(3sS1u/LV\uNrjG-RFi20DLSEa:`!eeAZa41u6q#Sc'g0T#GB9qFYGNGS]-gY@"I=iq5P=$l.pa1mYR$@71[H]8.u*F_W6s!%19R>6/!5@c*6eeXEh>&0od9LEip*3?Lp;\W$;`t!%0n06#fnXAgJeel/jr:t]qdi3SDRc&Y#4VYp/#9s`q;[5e;[RPH1g4#B5L8H>kkBUsF(t8Yu;$BS)ef`S/Gte<\\#9rY@l@cl4fT;p>$b:M&O_0\Kj)ikb,fNTIM>7EFe_RZX\ICo<(/C-`4eClf_Dm0pGJ]6<ct2:[!7*#m%hQNq\k<d;Zbk+I7GVR.,B)d8VdNK((9D(e6-M%eC`BE@OgE!`RD#j":1<>YXH+/R+&HL=6`SSA>-B:Kj)hA%[+#1o,Z*4S^RUdk\8J]ASL^"7qDNU~>endstream
+endobj
+39 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 575
+>>
+stream
+GasIc9lJN8&A@sB]N_(CNU>@nE^RGiF<sm$2A[VkY*7\;,`]rX)ti)E#t[>a'scmZ*m_lrB1iM6EnYpDX>@Nh,U!o."/P&tfb\H\p5AGdYpqZiWCR\r$+6#&`OF0P)[n8?<m[:>N<Vk1frhSm4A(kq0t9,&'ai`06Uf?B)>01L"\Oh"5'Ch"K6\gU;dlD_NZ?n\?gU%[2K]`amqUd9&/#7[Q*:,PjDB*G/iFZM^I*(I37_Bs6?$&=LZ#akEF82.fh)Q^<^K47VX.MtGK;DWWLpFOdW"^uMDss*5X3Hl9"I0GQb\b*^0stgd?+Qm8JR_HgI7+;/B'M@>=DX-)BMJ>cp?-`\4n/)R22AgW2;7(k/bT-a]9X2W_-*o3Ie('<1/>#,G5%A[$Y:od_B094'^2Vj*LN5;T";TC;cp&'[sNgP8[NiJA0":G?t5e9dr00:KjVoZJ`ih^27+T_mc=`^Am]s6P!1(icMoJ.sql=-ucFE>u",'pT?]l^1tOha"I/`S/6E`cQ0U*0&T'V^+<TeUnZHh%;kk2:q+>VXG4QFIN5T*4Vce$_-ai:fP_#Ab$4~>endstream
 endobj
 xref
-0 38
+0 40
 0000000000 65535 f 
 0000000061 00000 n 
 0000000173 00000 n 
@@ -692,45 +709,47 @@ xref
 0005289912 00000 n 
 0005290107 00000 n 
 0005290302 00000 n 
-0005291057 00000 n 
-0005301872 00000 n 
-0005302100 00000 n 
-0005302765 00000 n 
-0005303525 00000 n 
-0005316851 00000 n 
-0005317115 00000 n 
-0005318471 00000 n 
-0005319225 00000 n 
-0005330054 00000 n 
-0005330288 00000 n 
-0005330957 00000 n 
-0005331719 00000 n 
-0005345015 00000 n 
-0005345272 00000 n 
-0005346623 00000 n 
-0005347380 00000 n 
-0005361311 00000 n 
-0005361576 00000 n 
-0005362928 00000 n 
-0005363681 00000 n 
-0005376846 00000 n 
-0005377107 00000 n 
-0005378457 00000 n 
-0005378527 00000 n 
-0005378808 00000 n 
-0005378880 00000 n 
-0005380522 00000 n 
-0005382771 00000 n 
+0005290497 00000 n 
+0005291252 00000 n 
+0005302068 00000 n 
+0005302297 00000 n 
+0005302962 00000 n 
+0005303722 00000 n 
+0005317048 00000 n 
+0005317312 00000 n 
+0005318668 00000 n 
+0005319422 00000 n 
+0005330251 00000 n 
+0005330485 00000 n 
+0005331154 00000 n 
+0005331916 00000 n 
+0005345212 00000 n 
+0005345469 00000 n 
+0005346820 00000 n 
+0005347577 00000 n 
+0005361508 00000 n 
+0005361773 00000 n 
+0005363125 00000 n 
+0005363878 00000 n 
+0005377043 00000 n 
+0005377304 00000 n 
+0005378654 00000 n 
+0005378724 00000 n 
+0005379005 00000 n 
+0005379083 00000 n 
+0005380725 00000 n 
+0005382974 00000 n 
+0005385413 00000 n 
 trailer
 <<
 /ID 
-[<544c559bf1b1075461aa4a074e2ded39><544c559bf1b1075461aa4a074e2ded39>]
+[<53f732e88640a5e093306867641187a0><53f732e88640a5e093306867641187a0>]
 % ReportLab generated PDF document -- digest (opensource)
 
-/Info 33 0 R
-/Root 32 0 R
-/Size 38
+/Info 34 0 R
+/Root 33 0 R
+/Size 40
 >>
 startxref
-5384615
+5386079
 %%EOF

--- a/specs/NHID-Clinical-v1.3-Core-Specification.pdf
+++ b/specs/NHID-Clinical-v1.3-Core-Specification.pdf
@@ -760,7 +760,7 @@ endobj
 endobj
 39 0 obj
 <<
-/Author (\(anonymous\)) /CreationDate (D:20260814033211+00'00') /Creator (\(unspecified\)) /Keywords () /ModDate (D:20260814033211+00'00') /Producer (ReportLab PDF Library - \(opensource\)) 
+/Author (\(anonymous\)) /CreationDate (D:20260814121013+00'00') /Creator (\(unspecified\)) /Keywords () /ModDate (D:20260814121013+00'00') /Producer (ReportLab PDF Library - \(opensource\)) 
   /Subject (\(unspecified\)) /Title (\(anonymous\)) /Trapped /False
 >>
 endobj
@@ -847,7 +847,7 @@ xref
 trailer
 <<
 /ID 
-[<73348246578f21b72ec86dfb1c8dc3ad><73348246578f21b72ec86dfb1c8dc3ad>]
+[<583d20390ac7a44aef4e17d908d451d7><583d20390ac7a44aef4e17d908d451d7>]
 % ReportLab generated PDF document -- digest (opensource)
 
 /Info 39 0 R

--- a/specs/NHID-Clinical-v1.3-Overview.pdf
+++ b/specs/NHID-Clinical-v1.3-Overview.pdf
@@ -718,7 +718,7 @@ endobj
 endobj
 47 0 obj
 <<
-/Author (\(anonymous\)) /CreationDate (D:20260814033214+00'00') /Creator (\(unspecified\)) /Keywords () /ModDate (D:20260814033214+00'00') /Producer (ReportLab PDF Library - \(opensource\)) 
+/Author (\(anonymous\)) /CreationDate (D:20260814121017+00'00') /Creator (\(unspecified\)) /Keywords () /ModDate (D:20260814121017+00'00') /Producer (ReportLab PDF Library - \(opensource\)) 
   /Subject (\(unspecified\)) /Title (\(anonymous\)) /Trapped /False
 >>
 endobj
@@ -901,7 +901,7 @@ xref
 trailer
 <<
 /ID 
-[<f035e6da995db6eb979e88bbce5d4de8><f035e6da995db6eb979e88bbce5d4de8>]
+[<932c1e2bcedbfe2d9a2470f9a4914a9e><932c1e2bcedbfe2d9a2470f9a4914a9e>]
 % ReportLab generated PDF document -- digest (opensource)
 
 /Info 47 0 R

--- a/specs/NHID-Clinical-v2-Technical-Playbook.pdf
+++ b/specs/NHID-Clinical-v2-Technical-Playbook.pdf
@@ -648,7 +648,7 @@ endobj
 endobj
 35 0 obj
 <<
-/Author (\(anonymous\)) /CreationDate (D:20260814033211+00'00') /Creator (\(unspecified\)) /Keywords () /ModDate (D:20260814033211+00'00') /Producer (ReportLab PDF Library - \(opensource\)) 
+/Author (\(anonymous\)) /CreationDate (D:20260814121014+00'00') /Creator (\(unspecified\)) /Keywords () /ModDate (D:20260814121014+00'00') /Producer (ReportLab PDF Library - \(opensource\)) 
   /Subject (\(unspecified\)) /Title (\(anonymous\)) /Trapped /False
 >>
 endobj
@@ -731,7 +731,7 @@ xref
 trailer
 <<
 /ID 
-[<6fd23cc16a804ab8c29603217158569d><6fd23cc16a804ab8c29603217158569d>]
+[<25ef6071202294c1e4ae49fae874b5c3><25ef6071202294c1e4ae49fae874b5c3>]
 % ReportLab generated PDF document -- digest (opensource)
 
 /Info 35 0 R

--- a/specs/index.html
+++ b/specs/index.html
@@ -65,6 +65,7 @@
           <a href="/evidence-pack.html">Evidence Pack</a>
           <a href="/shadow-evaluation-guide.html">Shadow Evaluation Guide</a>
           <a href="/for-payers.html">For Payers</a>
+          <a href="/community.html">Community</a>
           <a href="/roadmap.html">Roadmap</a>
           <a href="/news.html">News</a>
           <a href="/faq.html">FAQ</a>
@@ -131,6 +132,7 @@
   <a href="/evidence-pack.html">Evidence Pack</a>
   <a href="/shadow-evaluation-guide.html">Shadow Evaluation Guide</a>
   <a href="/for-payers.html">For Payers</a>
+  <a href="/community.html">Community</a>
   <a href="/roadmap.html">Roadmap</a>
   <a href="/news.html">News</a>
   <a href="/faq.html">FAQ</a>

--- a/technical-stack.html
+++ b/technical-stack.html
@@ -71,6 +71,7 @@
           <a href="/evidence-pack.html">Evidence Pack</a>
           <a href="/shadow-evaluation-guide.html">Shadow Evaluation Guide</a>
           <a href="/for-payers.html">For Payers</a>
+          <a href="/community.html">Community</a>
           <a href="/roadmap.html">Roadmap</a>
           <a href="/news.html">News</a>
           <a href="/faq.html">FAQ</a>
@@ -137,6 +138,7 @@
   <a href="/evidence-pack.html">Evidence Pack</a>
   <a href="/shadow-evaluation-guide.html">Shadow Evaluation Guide</a>
   <a href="/for-payers.html">For Payers</a>
+  <a href="/community.html">Community</a>
   <a href="/roadmap.html">Roadmap</a>
   <a href="/news.html">News</a>
   <a href="/faq.html">FAQ</a>


### PR DESCRIPTION
## Summary

Three tracks from the 11-day commercial sprint plan. No engine changes.

### Track A — disclosure timeliness bands (reporting only)

The premise that IDG-01 imposes a 5-second window **is not supported by the code**. `src/nhid_policy_engine_v1.py:167` gates on `disclosure_timestamp is None` with no clock, the Twilio/VAPI adapters use zero-tolerance ordering, and `tests/elevenlabs_cts_runner.py:457` requires disclosure in agent **turn 0**. The spec defines a time form of Impersonation Latency but targets only the turn form (`IL(turns) = 0`), and the sole seconds computation (`measure_pilot.py:145`) carries no threshold. The real rule is *stricter* than 5 seconds.

Neither corpus could validate a seconds rule regardless: `tests/evaluation_corpus_v1.json` has timestamps on 27 of 55 turns, and `fixtures/fabricate/turns.csv` uses a fixed 8-second cadence that just restates turn index.

So the bands are a **scoring convention, not a gate**:

| Band | Disclosure | Reported as |
| :-- | :-- | :-- |
| `pass` | turn 0, before any data request | conformant |
| `delayed` | present, ≤10s, before PHI | observation |
| `late` | present, >10s, before PHI | human review |
| `critical` | PHI before disclosure, or never | violation |

Every verdict still comes from `evaluate_all()`. Classification falls back to the turn form where timestamps are absent. **The test count staying at 669 is the check that this stayed out of the engine.**

### Track B — funnel fixes

- **`for-payers.html:376` — the money page's terminal "Start a pilot →" linked to `/for-payers.html`.** Someone who read the whole payer guide and clicked the final CTA got the same page back. Now books a call.
- **The booking link was on zero pages.** Every CTA was `mailto:` (30 of them). It's now primary on for-payers, shadow-evaluation-guide and community, with email as fallback.
- **`community.html` 404'd while being shared publicly** — and `community/index.html` redirected *to* it, so both paths were dead ends. Created, and added to nav across 33 pages.
- **Duration story.** 90-day and "2–4 weeks" aren't contradictory — they're the engagement vs. the measurement sprint inside it. Stated that way explicitly; the actual defect was a "30-day plan" mislabel, corrected.
- **`news.html`** — August entry on the corpus fix, written to carry the limitation that 100% describes a synthetic corpus with 2 seeded failures.

### Track C — ops docs (`docs/ops/`, internal)

Knowledge base, 10 email templates (explicitly drafts, never auto-sends), and the pilot pipeline as GitHub Issues rather than a custom CRM. `scripts/build_pages_site.sh` doesn't copy `docs/`, so none of it reaches the site — verified in the build.

## Type of change

- [ ] Reference implementation / conformance API
- [ ] Conformance tests
- [ ] Adapter
- [ ] NHID-Auth v2
- [x] Docs
- [x] Website
- [x] Specification / control text

## Checklist

- [x] `python -m pytest tests/` passes — **669 passed, 18 skipped** (unchanged, by design)
- [x] Guards pass: `validate_ci.py`, `check_baseline.py`, `check_number_drift.py`
- [x] No new claims of certification, accredited-standard, or regulatory status
- [x] Control names and disclaimers unchanged
- [x] Public claims reviewed against `docs/claim-boundaries.md`

## Notes

Corpus re-verified at 100% detection / 0% FP on all four controls. Build: **33.69 MB, 159 files, 7/7 PDFs, 0 broken internal links across 2,416 refs**, `docs/ops` absent from output.

The band table also lands in the Shadow Evaluation Guide PDF, which is what a payer engineer actually gets handed.

**Deliberately not done:** no elapsed-seconds arithmetic in `evaluate_idg01`, no new `PolicyAction` values, no autonomous email, no custom CRM, no certification modules. Rationale in the plan — the bottleneck is zero pilot partners, not tooling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K6naAZodVs6Cftbq2miy1L

---
_Generated by [Claude Code](https://claude.ai/code/session_01K6naAZodVs6Cftbq2miy1L)_